### PR TITLE
Reduce binary size

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,9 +61,9 @@ spec:
 						export HOME=$JENKINS_HOME
 						export GOCACHE="off"
 						export GOARCH=amd64
-						GOOS=darwin go build -o codewind-installer-macos
-  						GOOS=windows go build -o codewind-installer-win.exe
-  						GOOS=linux go build -o codewind-installer-linux
+						GOOS=darwin go build -ldflags="-s -w" -o codewind-installer-macos
+  						GOOS=windows go build -ldflags="-s -w" -o codewind-installer-win.exe
+  						GOOS=linux go build -ldflags="-s -w" -o codewind-installer-linux
   						chmod -v +x codewind-installer-*
 
 					'''


### PR DESCRIPTION
Problem:
Current builds are ~11MB. 
Issue #24 

Solution:
Adding `-ldflags="-s -w"` to the build commands will reduce the binary file size by ~2/3MB as it will remove the debug info.

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>