### PR TITLE
Add image tag flag and command alias'

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -127,7 +127,7 @@ func WriteToComposeFile(tempFilePath string) bool {
 }
 
 // DockerCompose to set up the Codewind environment
-func DockerCompose() {
+func DockerCompose(tag string) {
 
 	// Set env variables for the docker compose file
 	home := os.Getenv("HOME")
@@ -144,7 +144,7 @@ func DockerCompose() {
 	}
 
 	os.Setenv("REPOSITORY", "")
-	os.Setenv("TAG", "latest")
+	os.Setenv("TAG", tag)
 	if GOOS == "windows" {
 		os.Setenv("WORKSPACE_DIRECTORY", "C:\\codewind-workspace")
 	} else {
@@ -165,7 +165,12 @@ func DockerCompose() {
 	cmd.Wait()
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
-	if strings.Contains(output.String(), "ERROR") {
+	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
+		DeleteTempFile("installer-docker-compose.yaml")
+		os.Exit(1)
+	}
+
+	if strings.Contains(output.String(), "The image for the service you're trying to recreate has been removed") {
 		DeleteTempFile("installer-docker-compose.yaml")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Problem: 
Previously, the installer would only pull and re-tag`:latest` images. Since these will be versioned the install should allow the client to specify a different image tag.

Solution:
- Add `-t`/`--tag` flag to the `install` & `start` commands to specify image tag. If not supplied, it will default to `latest`
- Add alias' to commands: `install-dev` = `in-dev`, `install` = `in`, `remove` = `rm`
- Better search on the output of `docker-compose` to catch errors

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>