### PR TITLE
Replace artifactory link with eclipse download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codewind Installer
 Install Codewind on MacOS or Windows.
-Prebuilt binaries are available for download [on Artifactory](https://sys-mcs-docker-local.artifactory.swg-devops.com/artifactory/sys-mcs-docker-local/codewind-installer/).
+Prebuilt binaries are available for download [on Artifactory](https://download.eclipse.org/codewind/codewind-installer/).
 
 [![Build Status](https://travis.ibm.com/dev-ex/codewind-installer.svg?token=jLZpzPrJozeLHsb1tpsR&branch=master)](https://travis.ibm.com/dev-ex/codewind-installer)
 [![Eclipse License](https://img.shields.io/badge/license-Eclipse-brightgreen.svg)](https://github.ibm.com/dev-ex/tempest/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codewind Installer
 Install Codewind on MacOS or Windows.
-Prebuilt binaries are available for download [on Artifactory](https://download.eclipse.org/codewind/codewind-installer/).
+Prebuilt binaries are available for download [on Eclipse](https://download.eclipse.org/codewind/codewind-installer/).
 
 [![Build Status](https://travis.ibm.com/dev-ex/codewind-installer.svg?token=jLZpzPrJozeLHsb1tpsR&branch=master)](https://travis.ibm.com/dev-ex/codewind-installer)
 [![Eclipse License](https://img.shields.io/badge/license-Eclipse-brightgreen.svg)](https://github.ibm.com/dev-ex/tempest/blob/master/LICENSE)


### PR DESCRIPTION
Problem:
Binary download link in the readme pointed towards artifactory

Solution:
Remove the artifactory link and replace it with the eclipse download link

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>