### PR TITLE
Exit health endpoint ping

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -223,7 +223,7 @@ func TagImage(source, tag string) {
 // PingHealth - pings environment api over a 15 second to check if containers started
 func PingHealth(healthEndpoint string) bool {
 	var started = false
-	for i := 0; i < 15; i++ {
+	for i := 0; i < 20; i++ {
 		resp, err := http.Get(healthEndpoint)
 		if err != nil {
 			fmt.Println("Waiting for Codewind to start...")
@@ -241,6 +241,7 @@ func PingHealth(healthEndpoint string) bool {
 
 	if started != true {
 		fmt.Println("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
+		os.Exit(1)
 	}
 	return started
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -240,8 +241,7 @@ func PingHealth(healthEndpoint string) bool {
 	}
 
 	if started != true {
-		fmt.Println("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
-		os.Exit(1)
+		log.Fatal("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
 	}
 	return started
 }


### PR DESCRIPTION
Problem: issue #35 
If docker-compose takes too long or fails to start up pfe, the pinging of the environment endpoint will exit without an error code at the end of the loop causing the plugin to take in a false positive.

Solution: (short term)
- At the end of the loop it will exit with a status code 1 to indicate an error for the plugins
- Increased loop timeout to help prevent hitting this
- A better solution of a ready/health endpoint API from codewind is needed

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>