### PR TITLE
improve terminal output

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -224,19 +224,19 @@ func TagImage(source, tag string) {
 // PingHealth - pings environment api over a 15 second to check if containers started
 func PingHealth(healthEndpoint string) bool {
 	var started = false
-	for i := 0; i < 20; i++ {
+	fmt.Println("Waiting for Codewind to start")
+	for i := 0; i < 120; i++ {
 		resp, err := http.Get(healthEndpoint)
 		if err != nil {
-			fmt.Println("Waiting for Codewind to start...")
+			fmt.Printf(".")
 		} else {
 			if resp.StatusCode == 200 {
-				fmt.Println("HTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
+				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
 				fmt.Println("Codewind successfully started")
 				started = true
 				break
 			}
 		}
-
 		time.Sleep(1 * time.Second)
 	}
 


### PR DESCRIPTION
Problem: 
Previously the terminal output was very noisy, always printing a message for each iteration of the health ping:
```
==> finished deleting file installer-docker-compose.yaml
Waiting for Codewind to start...
Waiting for Codewind to start...
Waiting for Codewind to start...
Waiting for Codewind to start...
HTTP Response Status: 200 OK
Codewind successfully started
```
This output is too noisy.

Solution:
- Increase loop timeout to 2mins for slow machines
- Instead of printing the message on every iteration through the loop, it will not print a progress dot. New output as follows:
```
==> finished deleting file installer-docker-compose.yaml
Waiting for Codewind to start
..
HTTP Response Status: 200 OK
Codewind successfully started
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>