### PR TITLE
Add debug flag

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/eclipse/codewind-installer/errors"
@@ -27,7 +26,6 @@ import (
 )
 
 var tempFilePath = "installer-docker-compose.yaml"
-var debug, _ = strconv.ParseBool(os.Getenv("DEBUG"))
 
 const versionNum = "0.2.0"
 const healthEndpoint = "http://localhost:9090/api/v1/environment"
@@ -124,6 +122,10 @@ func commands() {
 					Value: "latest",
 					Usage: "dockerhub image tag",
 				},
+				cli.BoolFlag{
+					Name:  "debug, d",
+					Usage: "add debug output",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				status := utils.CheckContainerStatus()
@@ -132,8 +134,10 @@ func commands() {
 					fmt.Println("Codewind is already running!")
 				} else {
 					tag := c.String("tag")
+					debug := c.Bool("debug")
+					fmt.Println("Debug:", debug)
 					utils.CreateTempFile(tempFilePath)
-					utils.WriteToComposeFile(tempFilePath)
+					utils.WriteToComposeFile(tempFilePath, debug)
 					utils.DockerCompose(tag)
 					utils.DeleteTempFile(tempFilePath) // Remove installer-docker-compose.yaml
 					utils.PingHealth(healthEndpoint)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -32,8 +31,6 @@ import (
 	"github.com/moby/moby/client"
 	"gopkg.in/yaml.v3"
 )
-
-var debug, _ = strconv.ParseBool(os.Getenv("DEBUG"))
 
 // docker-compose yaml data
 var data = `
@@ -103,7 +100,7 @@ func CreateTempFile(tempFilePath string) bool {
 }
 
 // WriteToComposeFile the contents of the docker compose yaml
-func WriteToComposeFile(tempFilePath string) bool {
+func WriteToComposeFile(tempFilePath string, debug bool) bool {
 	if tempFilePath == "" {
 		return false
 	}


### PR DESCRIPTION
**Problem:**
Currently the only way to get debug is to set an environment variable and retrieve it from within the installer - (`var debug, _ = strconv.ParseBool(os.Getenv("DEBUG"))`). This isnt appropriate as this could be used for more than one application and cause conflicts/unwanted output.

**Solution:**
- Introduce a debug flag that can be used on specific commands
- Only introduced on the start command as this is where it is only currently used/needed
- example command: `./installer start -t 0.2.0 -d`

**Tested:**
- Manually tested to get expected outputs
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>