### PR TITLE
Separate util functions

### DIFF
--- a/utils/docker.go
+++ b/utils/docker.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package utils
 
 import (
@@ -15,21 +16,16 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
 	"github.com/eclipse/codewind-installer/errors"
 	"github.com/moby/moby/client"
-	"gopkg.in/yaml.v3"
 )
 
 // docker-compose yaml data
@@ -82,48 +78,6 @@ type Compose struct {
 	} `yaml:"networks"`
 }
 
-// CreateTempFile in the same directory as the binary for docker compose
-func CreateTempFile(tempFilePath string) bool {
-
-	var _, err = os.Stat(tempFilePath)
-
-	// create file if not exists
-	if os.IsNotExist(err) {
-		var file, err = os.Create(tempFilePath)
-		errors.CheckErr(err, 201, "")
-		defer file.Close()
-
-		fmt.Println("==> created file", tempFilePath)
-		return true
-	}
-	return false
-}
-
-// WriteToComposeFile the contents of the docker compose yaml
-func WriteToComposeFile(tempFilePath string, debug bool) bool {
-	if tempFilePath == "" {
-		return false
-	}
-
-	dataStruct := Compose{}
-
-	unmarshDataErr := yaml.Unmarshal([]byte(data), &dataStruct)
-	errors.CheckErr(unmarshDataErr, 202, "")
-
-	marshalledData, err := yaml.Marshal(&dataStruct)
-	errors.CheckErr(err, 203, "")
-
-	if debug == true {
-		fmt.Printf("==> "+tempFilePath+" structure is: \n%s\n\n", string(marshalledData))
-	} else {
-		fmt.Println("==> environment structure written to " + tempFilePath)
-	}
-
-	err = ioutil.WriteFile(tempFilePath, marshalledData, 0644)
-	errors.CheckErr(err, 204, "")
-	return true
-}
-
 // DockerCompose to set up the Codewind environment
 func DockerCompose(tag string) {
 
@@ -174,21 +128,6 @@ func DockerCompose(tag string) {
 	}
 }
 
-// DeleteTempFile once the the Codewind environment has been created
-func DeleteTempFile(tempFilePath string) (boolean bool, err error) {
-
-	var _, file = os.Stat(tempFilePath)
-
-	if os.IsNotExist(file) {
-		errors.CheckErr(file, 206, "No files to delete")
-		return false, file
-	}
-
-	os.Remove(tempFilePath)
-	fmt.Println("==> finished deleting file " + tempFilePath)
-	return true, nil
-}
-
 // PullImage - pull pfe/performance/initialize images from artifactory
 func PullImage(image string, auth string) {
 	ctx := context.Background()
@@ -216,31 +155,6 @@ func TagImage(source, tag string) {
 
 	output := string(out[:])
 	fmt.Println(output)
-}
-
-// PingHealth - pings environment api over a 15 second to check if containers started
-func PingHealth(healthEndpoint string) bool {
-	var started = false
-	fmt.Println("Waiting for Codewind to start")
-	for i := 0; i < 120; i++ {
-		resp, err := http.Get(healthEndpoint)
-		if err != nil {
-			fmt.Printf(".")
-		} else {
-			if resp.StatusCode == 200 {
-				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
-				fmt.Println("Codewind successfully started")
-				started = true
-				break
-			}
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	if started != true {
-		log.Fatal("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
-	}
-	return started
 }
 
 // CheckContainerStatus of Codewind running/stopped

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/eclipse/codewind-installer/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// CreateTempFile in the same directory as the binary for docker compose
+func CreateTempFile(tempFilePath string) bool {
+
+	var _, err = os.Stat(tempFilePath)
+
+	// create file if not exists
+	if os.IsNotExist(err) {
+		var file, err = os.Create(tempFilePath)
+		errors.CheckErr(err, 201, "")
+		defer file.Close()
+
+		fmt.Println("==> created file", tempFilePath)
+		return true
+	}
+	return false
+}
+
+// WriteToComposeFile the contents of the docker compose yaml
+func WriteToComposeFile(tempFilePath string, debug bool) bool {
+	if tempFilePath == "" {
+		return false
+	}
+
+	dataStruct := Compose{}
+
+	unmarshDataErr := yaml.Unmarshal([]byte(data), &dataStruct)
+	errors.CheckErr(unmarshDataErr, 202, "")
+
+	marshalledData, err := yaml.Marshal(&dataStruct)
+	errors.CheckErr(err, 203, "")
+
+	if debug == true {
+		fmt.Printf("==> "+tempFilePath+" structure is: \n%s\n\n", string(marshalledData))
+	} else {
+		fmt.Println("==> environment structure written to " + tempFilePath)
+	}
+
+	err = ioutil.WriteFile(tempFilePath, marshalledData, 0644)
+	errors.CheckErr(err, 204, "")
+	return true
+}
+
+// DeleteTempFile once the the Codewind environment has been created
+func DeleteTempFile(tempFilePath string) (boolean bool, err error) {
+
+	var _, file = os.Stat(tempFilePath)
+
+	if os.IsNotExist(file) {
+		errors.CheckErr(file, 206, "No files to delete")
+		return false, file
+	}
+
+	os.Remove(tempFilePath)
+	fmt.Println("==> finished deleting file " + tempFilePath)
+	return true, nil
+}
+
+// PingHealth - pings environment api over a 15 second to check if containers started
+func PingHealth(healthEndpoint string) bool {
+	var started = false
+	fmt.Println("Waiting for Codewind to start")
+	for i := 0; i < 120; i++ {
+		resp, err := http.Get(healthEndpoint)
+		if err != nil {
+			fmt.Printf(".")
+		} else {
+			if resp.StatusCode == 200 {
+				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
+				fmt.Println("Codewind successfully started")
+				started = true
+				break
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if started != true {
+		log.Fatal("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
+	}
+	return started
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package utils
 
 import (
@@ -85,13 +86,13 @@ func TestCreateTempFile(t *testing.T) {
 
 func TestWriteToComposeFile(t *testing.T) {
 	os.Create("TestFile.yaml")
-	got := WriteToComposeFile("TestFile.yaml")
+	got := WriteToComposeFile("TestFile.yaml", false)
 	assert.Equal(t, got, true, "should return true: should write data to a temp file")
 	os.Remove("TestFile.yaml")
 }
 
 func TestWriteToComposeFileFail(t *testing.T) {
-	writeToFile := WriteToComposeFile("")
+	writeToFile := WriteToComposeFile("", false)
 	assert.Equal(t, writeToFile, false, "should return false: should fail to write data")
 }
 


### PR DESCRIPTION
**Problem:**
The installer `utils.go` code is difficult to read and maintain in its current state. It currently houses both docker functions and file system functions . This will become an issue in the future as it matures.

**Solution:**
This PR splits the `utils.go` file functions into docker functions and file system functions.

**Tested:**
- Manually tested and checked each command works.
- Used bats integration test file for automated testing.
Output:
```
 ✓ invoke install command
 ✓ invoke start command - Start dockerhub images'
 ✓ invoke stop-all command - Stop dockerhub images'
 ✓ invoke remove command - remove dockerhub images

4 tests, 0 failures
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>