### PR TITLE
add --json flag to the install command

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -53,6 +53,10 @@ func Commands() {
 					Value: "latest",
 					Usage: "dockerhub image tag",
 				},
+				cli.StringFlag{
+					Name:  "output, o",
+					Usage: "specify json terminal output",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				InstallCommand(c)

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -53,8 +53,8 @@ func Commands() {
 					Value: "latest",
 					Usage: "dockerhub image tag",
 				},
-				cli.StringFlag{
-					Name:  "output, o",
+				cli.BoolFlag{
+					Name:  "json, j",
 					Usage: "specify terminal output",
 				},
 			},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -55,7 +55,7 @@ func Commands() {
 				},
 				cli.StringFlag{
 					Name:  "output, o",
-					Usage: "specify json terminal output",
+					Usage: "specify terminal output",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/actions/install.go
+++ b/actions/install.go
@@ -25,7 +25,7 @@ import (
 //InstallCommand to pull images from dockerhub
 func InstallCommand(c *cli.Context) {
 	tag := c.String("tag")
-	output := c.String("output")
+	jsonOutput := c.Bool("json")
 
 	imageArr := [3]string{"docker.io/ibmcom/codewind-pfe-amd64:",
 		"docker.io/ibmcom/codewind-performance-amd64:",
@@ -36,7 +36,7 @@ func InstallCommand(c *cli.Context) {
 		"codewind-initialize-amd64:"}
 
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i]+tag, "", output)
+		utils.PullImage(imageArr[i]+tag, "", jsonOutput)
 		utils.TagImage(imageArr[i]+tag, targetArr[i]+tag)
 	}
 
@@ -63,7 +63,7 @@ func InstallDevCommand() {
 		"codewind-initialize-amd64:latest"}
 
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i], authStr, "")
+		utils.PullImage(imageArr[i], authStr, false)
 		utils.TagImage(imageArr[i], targetArr[i])
 	}
 

--- a/actions/install.go
+++ b/actions/install.go
@@ -25,6 +25,7 @@ import (
 //InstallCommand to pull images from dockerhub
 func InstallCommand(c *cli.Context) {
 	tag := c.String("tag")
+	output := c.String("output")
 
 	imageArr := [3]string{"docker.io/ibmcom/codewind-pfe-amd64:",
 		"docker.io/ibmcom/codewind-performance-amd64:",
@@ -35,7 +36,7 @@ func InstallCommand(c *cli.Context) {
 		"codewind-initialize-amd64:"}
 
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i]+tag, "")
+		utils.PullImage(imageArr[i]+tag, "", output)
 		utils.TagImage(imageArr[i]+tag, targetArr[i]+tag)
 	}
 
@@ -62,7 +63,7 @@ func InstallDevCommand() {
 		"codewind-initialize-amd64:latest"}
 
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i], authStr)
+		utils.PullImage(imageArr[i], authStr, "")
 		utils.TagImage(imageArr[i], targetArr[i])
 	}
 

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -129,7 +129,7 @@ func DockerCompose(tag string) {
 }
 
 // PullImage - pull pfe/performance/initialize images from artifactory
-func PullImage(image string, auth string, output string) {
+func PullImage(image string, auth string, jsonOutput bool) {
 	ctx := context.Background()
 	cli, err := client.NewEnvClient()
 	errors.CheckErr(err, 200, "")
@@ -144,7 +144,7 @@ func PullImage(image string, auth string, output string) {
 
 	errors.CheckErr(err, 100, "")
 
-	if output == "json" {
+	if jsonOutput == true {
 		defer codewindOut.Close()
 		io.Copy(os.Stdout, codewindOut)
 	} else {


### PR DESCRIPTION
**Problem: #54**
The installer needs a flag option to return unformatted json. This will allow the editor plugins to have more flexibility when displaying progress during codewind installation.

**Solution:**
Added `--json/-j` flag on the install command e.g `./codewind-installer install --json` to get the raw json output

**Tested**
1. Manually tested all commands
2. Bats test output:
```
 ✓ invoke install command - using -t & -j flag
 ✓ invoke start command - Start dockerhub images'
 ✓ invoke stop-all command - Stop dockerhub images'
 ✓ invoke remove command - remove dockerhub images

4 tests, 0 failures
```

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>