### PR TITLE
Remove artifactory

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -34,16 +34,6 @@ func Commands() {
 	app.Commands = []cli.Command{
 
 		{
-			Name:    "install-dev",
-			Aliases: []string{"in-dev"},
-			Usage:   "Pull pfe, performance & intialize images from artifactory",
-			Action: func(c *cli.Context) error {
-				InstallDevCommand()
-				return nil
-			},
-		},
-
-		{
 			Name:    "install",
 			Aliases: []string{"in"},
 			Usage:   "Pull pfe, performance & intialize images from dockerhub",

--- a/actions/install.go
+++ b/actions/install.go
@@ -11,13 +11,8 @@
 package actions
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"os"
 
-	"github.com/docker/docker/api/types"
-	"github.com/eclipse/codewind-installer/errors"
 	"github.com/eclipse/codewind-installer/utils"
 	"github.com/urfave/cli"
 )
@@ -38,33 +33,6 @@ func InstallCommand(c *cli.Context) {
 	for i := 0; i < len(imageArr); i++ {
 		utils.PullImage(imageArr[i]+tag, "", jsonOutput)
 		utils.TagImage(imageArr[i]+tag, targetArr[i]+tag)
-	}
-
-	fmt.Println("Image Tagging Successful")
-}
-
-//InstallDevCommand to pull images from artifactory
-func InstallDevCommand() {
-	authConfig := types.AuthConfig{
-		Username: os.Getenv("USER"),
-		Password: os.Getenv("PASS"),
-	}
-	encodedJSON, err := json.Marshal(authConfig)
-	errors.CheckErr(err, 106, "")
-
-	authStr := base64.URLEncoding.EncodeToString(encodedJSON)
-
-	imageArr := [3]string{"sys-mcs-docker-local.artifactory.swg-devops.com/codewind-pfe-amd64",
-		"sys-mcs-docker-local.artifactory.swg-devops.com/codewind-performance-amd64",
-		"sys-mcs-docker-local.artifactory.swg-devops.com/codewind-initialize-amd64"}
-
-	targetArr := [3]string{"codewind-pfe-amd64:latest",
-		"codewind-performance-amd64:latest",
-		"codewind-initialize-amd64:latest"}
-
-	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i], authStr, false)
-		utils.TagImage(imageArr[i], targetArr[i])
 	}
 
 	fmt.Println("Image Tagging Successful")

--- a/actions/install.go
+++ b/actions/install.go
@@ -31,7 +31,7 @@ func InstallCommand(c *cli.Context) {
 		"codewind-initialize-amd64:"}
 
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i]+tag, "", jsonOutput)
+		utils.PullImage(imageArr[i]+tag, jsonOutput)
 		utils.TagImage(imageArr[i]+tag, targetArr[i]+tag)
 	}
 

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -19,14 +19,11 @@ import (
 
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand() {
-	imageArr := [7]string{}
-	imageArr[0] = "sys-mcs-docker-local.artifactory.swg-devops.com/codewind-pfe"
-	imageArr[1] = "sys-mcs-docker-local.artifactory.swg-devops.com/codewind-performance"
-	imageArr[2] = "sys-mcs-docker-local.artifactory.swg-devops.com/codewind-initialize"
-	imageArr[3] = "ibmcom/codewind-pfe"
-	imageArr[4] = "ibmcom/codewind-performance"
-	imageArr[5] = "ibmcom/codewind-initialize"
-	imageArr[6] = "cw-"
+	imageArr := [4]string{}
+	imageArr[0] = "ibmcom/codewind-pfe"
+	imageArr[1] = "ibmcom/codewind-performance"
+	imageArr[2] = "ibmcom/codewind-initialize"
+	imageArr[3] = "cw-"
 	networkName := "codewind"
 
 	images := utils.GetImageList()

--- a/errors/error.go
+++ b/errors/error.go
@@ -30,8 +30,6 @@ func CheckErr(err error, code int, optMsg string) {
 			log.Fatal("IMAGE_STATUS_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 105:
 			log.Fatal("REMOVE_IMAGE_ERROR", "[", code, "]: ", err, ". ", optMsg)
-		case 106:
-			log.Fatal("AUTH_ENCODING_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 107:
 			log.Fatal("CONTAINER_LIST_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 108:

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -128,8 +128,8 @@ func DockerCompose(tag string) {
 	}
 }
 
-// PullImage - pull pfe/performance/initialize images from artifactory
-func PullImage(image string, auth string, jsonOutput bool) {
+// PullImage - pull pfe/performance/initialize images from dockerhub
+func PullImage(image string, jsonOutput bool) {
 	ctx := context.Background()
 	cli, err := client.NewEnvClient()
 	errors.CheckErr(err, 200, "")

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -136,11 +136,7 @@ func PullImage(image string, auth string, jsonOutput bool) {
 
 	var codewindOut io.ReadCloser
 
-	if auth == "" {
-		codewindOut, err = cli.ImagePull(ctx, image, types.ImagePullOptions{})
-	} else {
-		codewindOut, err = cli.ImagePull(ctx, image, types.ImagePullOptions{RegistryAuth: auth})
-	}
+	codewindOut, err = cli.ImagePull(ctx, image, types.ImagePullOptions{})
 
 	errors.CheckErr(err, 100, "")
 
@@ -191,13 +187,10 @@ func CheckContainerStatus() bool {
 // CheckImageStatus of Codewind installed/uninstalled
 func CheckImageStatus() bool {
 	var imageStatus = false
-	imageArr := [6]string{}
-	imageArr[0] = "sys-mcs-docker-local.artifactory.swg-devops.com/codewind-pfe"
-	imageArr[1] = "sys-mcs-docker-local.artifactory.swg-devops.com/codewind-performance"
-	imageArr[2] = "sys-mcs-docker-local.artifactory.swg-devops.com/codewind-initialize"
-	imageArr[3] = "ibmcom/codewind-pfe"
-	imageArr[4] = "ibmcom/codewind-performance"
-	imageArr[5] = "ibmcom/codewind-initialize"
+	imageArr := [3]string{}
+	imageArr[0] = "ibmcom/codewind-pfe"
+	imageArr[1] = "ibmcom/codewind-performance"
+	imageArr[2] = "ibmcom/codewind-initialize"
 
 	images := GetImageList()
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -34,7 +34,7 @@ func TestToggleDebug(t *testing.T) {
 
 func TestRemoveImage(t *testing.T) {
 	performanceImage := "docker.io/ibmcom/codewind-performance-amd64"
-	PullImage(performanceImage, "")
+	PullImage(performanceImage, false)
 	RemoveImage(performanceImage)
 }
 func TestCheckImageStatusFalse(t *testing.T) {
@@ -54,7 +54,7 @@ func TestCheckContainerStatusFalse(t *testing.T) {
 func TestPullDockerImage(t *testing.T) {
 	performanceImage := "docker.io/ibmcom/codewind-performance-amd64"
 	performanceImageTarget := "codewind-performance-amd64:latest"
-	PullImage(performanceImage, "")
+	PullImage(performanceImage, false)
 	TagImage(performanceImage, performanceImageTarget)
 
 	ctx := context.Background()


### PR DESCRIPTION
**Problem #29**
The installer still had to support artifactory images until recently. Now codewind is opensource this support can be dropped.

**Solution**
Removing artifactory references and logic

**Tested**
1. each command manually
2. bats tests output:
```
✓ invoke install command - using -t & -j flag
 ✓ invoke start command - Start dockerhub images'
 ✓ invoke stop-all command - Stop dockerhub images'
 ✓ invoke remove command - remove dockerhub images

4 tests, 0 failures
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>