### PR TITLE
change status return codes

### DIFF
--- a/actions/status.go
+++ b/actions/status.go
@@ -21,15 +21,15 @@ import (
 func StatusCommand() {
 	if utils.CheckContainerStatus() {
 		fmt.Println("Codewind is installed and running")
-		os.Exit(2)
+		os.Exit(202)
 	}
 
 	if utils.CheckImageStatus() {
 		fmt.Println("Codewind is installed but not running")
-		os.Exit(1)
+		os.Exit(201)
 	} else {
 		fmt.Println("Codewind is not installed")
-		os.Exit(0)
+		os.Exit(200)
 	}
 	return
 }


### PR DESCRIPTION
**Problem**
Currently the installer returned codes 0/1/2 when the status command is invoked. These can be miss-interpreted as success/error return codes.

**Solution**
Change the codes 0/1/2 => 200/201/202

**Tested**
Manually tested each scenario. Output:
```
Codewind is not installed
exit status 200

Codewind is installed but not running
exit status 201

Codewind is installed and running
exit status 202
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>