### PR TITLE
Clone repository using archive link

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,12 +13,15 @@
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
-  digest = "1:f9ae348e1f793dcf9ed930ed47136a67343dbd6809c5c91391322267f4476892"
+  digest = "1:d5e752c67b445baa5b6cb6f8aa706775c2aa8e41aca95a0c651520ff2c80361a"
   name = "github.com/Microsoft/go-winio"
-  packages = ["."]
+  packages = [
+    ".",
+    "pkg/guid",
+  ]
   pruneopts = "UT"
-  revision = "1a8911d1ed007260465c3bfbbc785ac6915a0bb8"
-  version = "v0.4.12"
+  revision = "a969fb018bd3439cc50861ce06796c40430e3a65"
+  version = "v0.4.13"
 
 [[projects]]
   digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
@@ -160,12 +163,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
+  digest = "1:ca4df663ad76879ad38dbd736493679cbb1aa596c6d479fd9fc5e959e5ceb4fb"
   name = "github.com/urfave/cli"
   packages = ["."]
   pruneopts = "UT"
-  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
-  version = "v1.20.0"
+  revision = "e6cf83ec39f6e1158ced1927d4ed14578fda8edb"
+  version = "v1.21.0"
 
 [[projects]]
   branch = "master"
@@ -185,7 +188,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:63c7bce98d2534e119bf2830e5152b3d5d58d9d1278d5184f0d05641996e9c8f"
+  digest = "1:2954b3699dc7d134a2ad3710f170b912bd979c5513cc13d869a57a1d2e753d8b"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -194,26 +197,26 @@
     "proxy",
   ]
   pruneopts = "UT"
-  revision = "4829fb13d2c62012c17688fa7f629f371014946d"
+  revision = "ca1201d0de80cfde86cb01aea620983605dfe99b"
 
 [[projects]]
   branch = "master"
-  digest = "1:38fc62caae4ecfec54e6047306fdf39210358fefce36fd9ed8e4d008fe150238"
+  digest = "1:00d73f8175ba939718fdfc3d3ecab52270c6d801a1930fbca62100f9a4d8f4c1"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "d89cdac9e8725f2aefce25fcbfef41134c9ad412"
+  revision = "51ab0e2deafac1f46c46ad59cf0921be2f180c3d"
 
 [[projects]]
   branch = "v3"
-  digest = "1:e11e6a71536a7120d56ea0c0cbfb4cf2b24b328f3982e8d03ce6939f7fe8b14c"
+  digest = "1:46754188622566b86271d7526cb643b88c2b9589ee224c2d55e282f0f35a0df8"
   name = "gopkg.in/yaml.v3"
   packages = ["."]
   pruneopts = "UT"
-  revision = "55513cacd4ae8b250e3a9084ab9d8c407b1ed618"
+  revision = "674ba3eaed223079f9377fbb0c98c0951bf6ec10"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -96,6 +96,22 @@
   version = "v0.4.0"
 
 [[projects]]
+  digest = "1:525ebc5da920b1f2c76ae763c13f4decdc3c3bc541ff0fa18f2399d4e742177f"
+  name = "github.com/google/go-github"
+  packages = ["github"]
+  pruneopts = "UT"
+  revision = "4c1ec01570ac97daecec8c2b62b07176700f093d"
+  version = "v27.0.4"
+
+[[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  pruneopts = "UT"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -153,6 +169,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:50804d40964a0c59170e827824e79bbf810cc10ae57603d8facce8a1f48f9a83"
+  name = "golang.org/x/crypto"
+  packages = [
+    "cast5",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+  ]
+  pruneopts = "UT"
+  revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
+
+[[projects]]
+  branch = "master"
   digest = "1:63c7bce98d2534e119bf2830e5152b3d5d58d9d1278d5184f0d05641996e9c8f"
   name = "golang.org/x/net"
   packages = [
@@ -190,6 +222,7 @@
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/term",
+    "github.com/google/go-github/github",
     "github.com/moby/moby/client",
     "github.com/stretchr/testify/assert",
     "github.com/urfave/cli",

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -142,13 +142,10 @@ func UnZip(zipFileName, destination string) {
 
 //MoveFiles to directory specified in command
 func MoveFiles(source, destination string) {
-	src := source
-	dest := destination
+	fmt.Println("==> moving files from ", source)
+	fmt.Println("==> moving files too ", destination)
 
-	fmt.Println("==> moving files from ", src)
-	fmt.Println("==> moving files too ", dest)
-
-	err := os.Rename(src, dest)
+	err := os.Rename(source, destination)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -12,28 +12,142 @@
 package actions
 
 import (
-	"bytes"
+	"archive/zip"
+	"context"
 	"fmt"
+	"io"
 	"log"
-	"os/exec"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/eclipse/codewind-installer/errors"
+	"github.com/eclipse/codewind-installer/utils"
+	"github.com/google/go-github/github"
 	"github.com/urfave/cli"
 )
 
-//CloneTemplate from github
+// CloneTemplate from github
 func CloneTemplate(c *cli.Context) {
 	//TODO Use go-git to do this in future
-	url := c.String("template")
-	if url == "" {
-		log.Fatal("No repository URL provided")
-	}
-	cmd := exec.Command("git", "clone", url)
-	output := new(bytes.Buffer)
-	cmd.Stdout = output
-	cmd.Stderr = output
-	if err := cmd.Start(); err != nil {
+	destination := c.String("destination")
+
+	zipURL := GetZipURL(c)
+	tempName := "/tmp/test_" + time.Now().String()
+	zipFileName := tempName + ".zip"
+
+	// download files in zip format
+	if err := DownloadFile(zipFileName, zipURL); err != nil {
 		log.Fatal(err)
 	}
-	cmd.Wait()
-	fmt.Printf(output.String())
+
+	// unzip into /tmp dir
+	extracedFilePath := UnZip(zipFileName, "/tmp")
+
+	// get top level dir from unzipped file and move files to new destination
+	if strings.HasPrefix(extracedFilePath, "/tmp/") {
+		extracedFilePath = strings.TrimPrefix(extracedFilePath, "/tmp/")
+	}
+	filePath := strings.Split(extracedFilePath, "/")
+	source := "/tmp/" + filePath[0]
+	MoveFiles(source, destination)
+
+	//delete zip file
+	utils.DeleteTempFile(zipFileName)
+
+}
+
+//GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
+func GetZipURL(c *cli.Context) string {
+	branch := c.String("branch")
+	owner := c.String("owner")
+	repo := c.String("repo")
+
+	client := github.NewClient(nil)
+
+	opt := &github.RepositoryContentGetOptions{Ref: branch}
+
+	URL, _, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+	url := URL.String()
+	fmt.Println(URL)
+	return url
+}
+
+//DownloadFile - the git zip of master into current dir
+func DownloadFile(zipFileName, url string) error {
+
+	// Get the data
+	resp, err := http.Get(url)
+	errors.CheckErr(err, 400, "")
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(zipFileName)
+	errors.CheckErr(err, 401, "")
+	defer out.Close()
+
+	// Write body to file
+	_, err = io.Copy(out, resp.Body)
+	fmt.Println(zipFileName)
+
+	return err
+}
+
+//UnZip downloaded file
+func UnZip(zipFileName, tempDestination string) string {
+	zipReader, _ := zip.OpenReader(zipFileName)
+
+	var extractedFilePath = ""
+	for _, file := range zipReader.Reader.File {
+
+		zippedFile, err := file.Open()
+		errors.CheckErr(err, 402, "")
+		defer zippedFile.Close()
+
+		targetDir := tempDestination
+		extractedFilePath = filepath.Join(
+			targetDir,
+			file.Name,
+		)
+
+		if file.FileInfo().IsDir() {
+			log.Println("Directory Created:", extractedFilePath)
+			os.MkdirAll(extractedFilePath, file.Mode())
+		} else {
+			log.Println("File extracted:", file.Name)
+
+			outputFile, err := os.OpenFile(
+				extractedFilePath,
+				os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+				file.Mode(),
+			)
+			errors.CheckErr(err, 403, "")
+			defer outputFile.Close()
+
+			_, err = io.Copy(outputFile, zippedFile)
+			errors.CheckErr(err, 404, "")
+		}
+	}
+	log.Println("File extracted:", zipFileName)
+	fmt.Println("Extraced file path", extractedFilePath)
+	return extractedFilePath
+}
+
+//MoveFiles to directory specified in command
+func MoveFiles(source, destination string) {
+	src := source
+	dest := destination
+
+	fmt.Println("old dir: ", src)
+	fmt.Println("new dir: ", dest)
+
+	err := os.Rename(src, dest)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -24,8 +24,10 @@ import (
 
 // CloneTemplate from github
 func CloneTemplate(c *cli.Context) {
-	var tempPath = ""
+	destination := c.String("destination")
+	branch := c.String("branch")
 
+	var tempPath = ""
 	const GOOS string = runtime.GOOS
 	if GOOS == "windows" {
 		tempPath = os.Getenv("TEMP") + "\\"
@@ -33,9 +35,8 @@ func CloneTemplate(c *cli.Context) {
 		tempPath = "/tmp/"
 	}
 
-	destination := c.String("destination")
-	branch := c.String("branch")
 	zipURL := utils.GetZipURL(c)
+
 	time := time.Now().Format(time.RFC3339)
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
 	tempName := tempPath + branch + "_" + time

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/urfave/cli"
+)
+
+//CloneTemplate from github
+func CloneTemplate(c *cli.Context) {
+	//TODO Use go-git to do this in future
+	url := c.String("template")
+	if url == "" {
+		log.Fatal("No repository URL provided")
+	}
+	cmd := exec.Command("git", "clone", url)
+	output := new(bytes.Buffer)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	cmd.Wait()
+	fmt.Printf(output.String())
+}

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -33,9 +33,6 @@ import (
 func CloneTemplate(c *cli.Context) {
 	//TODO Use go-git to do this in future
 	destination := c.String("destination")
-	if destination == "" {
-		log.Fatal("Error: No destination path provided")
-	}
 
 	zipURL := GetZipURL(c)
 	tempName := "/tmp/test_" + time.Now().Format(time.RFC3339)

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -143,8 +143,8 @@ func MoveFiles(source, destination string) {
 	src := source
 	dest := destination
 
-	fmt.Println("old dir: ", src)
-	fmt.Println("new dir: ", dest)
+	fmt.Println("==> moving files from ", src)
+	fmt.Println("==> moving files too ", dest)
 
 	err := os.Rename(src, dest)
 	if err != nil {

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -35,7 +35,7 @@ func CloneTemplate(c *cli.Context) {
 	destination := c.String("destination")
 
 	zipURL := GetZipURL(c)
-	tempName := "/tmp/test_" + time.Now().String()
+	tempName := "/tmp/test_" + time.Now().Format(time.RFC3339)
 	zipFileName := tempName + ".zip"
 
 	// download files in zip format

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -12,141 +12,43 @@
 package actions
 
 import (
-	"archive/zip"
-	"context"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
-	"github.com/eclipse/codewind-installer/errors"
 	"github.com/eclipse/codewind-installer/utils"
-	"github.com/google/go-github/github"
 	"github.com/urfave/cli"
 )
 
 // CloneTemplate from github
 func CloneTemplate(c *cli.Context) {
 	var tempPath = ""
+
 	const GOOS string = runtime.GOOS
 	if GOOS == "windows" {
 		tempPath = os.Getenv("TEMP") + "\\"
 	} else {
 		tempPath = "/tmp/"
 	}
+
 	destination := c.String("destination")
 	branch := c.String("branch")
-
-	zipURL := GetZipURL(c)
+	zipURL := utils.GetZipURL(c)
 	time := time.Now().Format(time.RFC3339)
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
-
 	tempName := tempPath + branch + "_" + time
 	zipFileName := tempName + ".zip"
 
 	// download files in zip format
-	if err := DownloadFile(zipFileName, zipURL); err != nil {
+	if err := utils.DownloadFile(zipFileName, zipURL); err != nil {
 		log.Fatal(err)
 	}
 
 	// unzip into /tmp dir
-	UnZip(zipFileName, destination)
+	utils.UnZip(zipFileName, destination)
 
 	//delete zip file
 	utils.DeleteTempFile(zipFileName)
-
-}
-
-//GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
-func GetZipURL(c *cli.Context) string {
-	branch := c.String("branch")
-	owner := c.String("owner")
-	repo := c.String("repo")
-
-	client := github.NewClient(nil)
-
-	opt := &github.RepositoryContentGetOptions{Ref: branch}
-
-	URL, _, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt)
-	if err != nil {
-		log.Fatal(err)
-	}
-	url := URL.String()
-	fmt.Println(URL)
-	return url
-}
-
-//DownloadFile - the git zip of master into current dir
-func DownloadFile(zipFileName, url string) error {
-
-	// Get the data
-	resp, err := http.Get(url)
-	errors.CheckErr(err, 400, "")
-	defer resp.Body.Close()
-
-	// Create the file
-	out, err := os.Create(zipFileName)
-	errors.CheckErr(err, 401, "")
-	defer out.Close()
-
-	// Write body to file
-	_, err = io.Copy(out, resp.Body)
-	fmt.Println(zipFileName)
-
-	return err
-}
-
-//UnZip downloaded file
-func UnZip(zipFileName, destination string) {
-	zipReader, _ := zip.OpenReader(zipFileName)
-
-	var extractedFilePath = ""
-	for _, file := range zipReader.Reader.File {
-
-		zippedFile, err := file.Open()
-		errors.CheckErr(err, 402, "")
-		defer zippedFile.Close()
-
-		fileNameArr := strings.Split(file.Name, "/")
-		extractedFilePath = destination
-
-		for i := 1; i < len(fileNameArr); i++ {
-			extractedFilePath = filepath.Join(extractedFilePath, fileNameArr[i])
-		}
-
-		if file.FileInfo().IsDir() {
-			log.Println("Directory Created:", extractedFilePath)
-			os.MkdirAll(extractedFilePath, file.Mode())
-		} else {
-			log.Println("File extracted:", file.Name)
-
-			outputFile, err := os.OpenFile(
-				extractedFilePath,
-				os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
-				file.Mode(),
-			)
-			errors.CheckErr(err, 403, "")
-			defer outputFile.Close()
-
-			_, err = io.Copy(outputFile, zippedFile)
-			errors.CheckErr(err, 404, "")
-		}
-	}
-	log.Println("File extracted:", zipFileName)
-}
-
-//MoveFiles to directory specified in command
-func MoveFiles(source, destination string) {
-	fmt.Println("==> moving files from ", source)
-	fmt.Println("==> moving files too ", destination)
-
-	err := os.Rename(source, destination)
-	if err != nil {
-		log.Fatal(err)
-	}
 }

--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -33,6 +33,9 @@ import (
 func CloneTemplate(c *cli.Context) {
 	//TODO Use go-git to do this in future
 	destination := c.String("destination")
+	if destination == "" {
+		log.Fatal("Error: No destination path provided")
+	}
 
 	zipURL := GetZipURL(c)
 	tempName := "/tmp/test_" + time.Now().Format(time.RFC3339)

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -35,6 +35,33 @@ func Commands() {
 	app.Commands = []cli.Command{
 
 		{
+			Name:    "clone",
+			Aliases: []string{"c"},
+			Usage:   "Clone a template from github",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "template, t",
+					Value: "",
+					Usage: "project template URL",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				CloneTemplate(c)
+				return nil
+			},
+		},
+
+		{
+			Name:    "install-dev",
+			Aliases: []string{"in-dev"},
+			Usage:   "Pull pfe, performance & intialize images from artifactory",
+			Action: func(c *cli.Context) error {
+				InstallDevCommand()
+				return nil
+			},
+		},
+
+		{
 			Name:    "install",
 			Aliases: []string{"in"},
 			Usage:   "Pull pfe, performance & intialize images from dockerhub",

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -67,16 +67,6 @@ func Commands() {
 		},
 
 		{
-			Name:    "install-dev",
-			Aliases: []string{"in-dev"},
-			Usage:   "Pull pfe, performance & intialize images from artifactory",
-			Action: func(c *cli.Context) error {
-				InstallDevCommand()
-				return nil
-			},
-		},
-
-		{
 			Name:    "install",
 			Aliases: []string{"in"},
 			Usage:   "Pull pfe, performance & intialize images from dockerhub",

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -45,16 +45,19 @@ func Commands() {
 					Usage: "repository branch",
 				},
 				cli.StringFlag{
-					Name:  "destination, d",
-					Usage: "absolute destination file path",
+					Name:     "destination, d",
+					Required: true,
+					Usage:    "absolute destination file path",
 				},
 				cli.StringFlag{
-					Name:  "owner",
-					Usage: "repository owner",
+					Name:     "owner",
+					Required: true,
+					Usage:    "repository owner",
 				},
 				cli.StringFlag{
-					Name:  "repo",
-					Usage: "repository to download",
+					Name:     "repo",
+					Required: true,
+					Usage:    "repository to download",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -40,9 +40,21 @@ func Commands() {
 			Usage:   "Clone a template from github",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "template, t",
-					Value: "",
-					Usage: "project template URL",
+					Name:  "branch, b",
+					Value: "master",
+					Usage: "repository branch",
+				},
+				cli.StringFlag{
+					Name:  "destination, d",
+					Usage: "absolute destination file path",
+				},
+				cli.StringFlag{
+					Name:  "owner",
+					Usage: "repository owner",
+				},
+				cli.StringFlag{
+					Name:  "repo",
+					Usage: "repository to download",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/errors/error.go
+++ b/errors/error.go
@@ -55,13 +55,13 @@ func CheckErr(err error, code int, optMsg string) {
 		case 300:
 			log.Fatal("APPLICATION_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 400:
-			log.Fatal("REPOSITORY_CLONE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+			log.Fatal("REPOSITORY_DOWNLOAD_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 401:
-			log.Fatal("ZIP_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+			log.Fatal("CREATE_ZIP_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 402:
-			log.Fatal("READ_ZIP_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+			log.Fatal("ZIP_FILE_READ_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 403:
-			log.Fatal("ZIP_OUTPUT_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+			log.Fatal("OUTPUT_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 404:
 			log.Fatal("WRITE_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		default:

--- a/errors/error.go
+++ b/errors/error.go
@@ -54,6 +54,16 @@ func CheckErr(err error, code int, optMsg string) {
 			log.Print("DELETE_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 300:
 			log.Fatal("APPLICATION_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 400:
+			log.Fatal("REPOSITORY_CLONE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 401:
+			log.Fatal("ZIP_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 402:
+			log.Fatal("READ_ZIP_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 403:
+			log.Fatal("ZIP_OUTPUT_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 404:
+			log.Fatal("WRITE_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		default:
 			log.Fatal("UNKNOWN_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		}

--- a/errors/error.go
+++ b/errors/error.go
@@ -59,7 +59,7 @@ func CheckErr(err error, code int, optMsg string) {
 		case 401:
 			log.Fatal("CREATE_ZIP_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 402:
-			log.Fatal("ZIP_FILE_READ_ERROR", "[", code, "]: ", err, ". ", optMsg)
+			log.Fatal("READ_ZIP_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 403:
 			log.Fatal("OUTPUT_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 404:

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -189,14 +189,3 @@ func UnZip(zipFileName, destination string) {
 	}
 	log.Println("File extracted:", zipFileName)
 }
-
-//MoveFiles to directory specified in command
-func MoveFiles(source, destination string) {
-	fmt.Println("==> moving files from ", source)
-	fmt.Println("==> moving files too ", destination)
-
-	err := os.Rename(source, destination)
-	if err != nil {
-		log.Fatal(err)
-	}
-}

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -12,14 +12,21 @@
 package utils
 
 import (
+	"archive/zip"
+	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/eclipse/codewind-installer/errors"
+	"github.com/google/go-github/github"
+	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
 )
 
@@ -103,4 +110,93 @@ func PingHealth(healthEndpoint string) bool {
 		log.Fatal("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
 	}
 	return started
+}
+
+//GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
+func GetZipURL(c *cli.Context) string {
+	branch := c.String("branch")
+	owner := c.String("owner")
+	repo := c.String("repo")
+
+	client := github.NewClient(nil)
+
+	opt := &github.RepositoryContentGetOptions{Ref: branch}
+
+	URL, _, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+	url := URL.String()
+	fmt.Println(URL)
+	return url
+}
+
+//DownloadFile - the git zip of master into current dir
+func DownloadFile(zipFileName, url string) error {
+
+	// Get the data
+	resp, err := http.Get(url)
+	errors.CheckErr(err, 400, "")
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(zipFileName)
+	errors.CheckErr(err, 401, "")
+	defer out.Close()
+
+	// Write body to file
+	_, err = io.Copy(out, resp.Body)
+	fmt.Println(zipFileName)
+
+	return err
+}
+
+//UnZip downloaded file
+func UnZip(zipFileName, destination string) {
+	zipReader, _ := zip.OpenReader(zipFileName)
+
+	var extractedFilePath = ""
+	for _, file := range zipReader.Reader.File {
+
+		zippedFile, err := file.Open()
+		errors.CheckErr(err, 402, "")
+		defer zippedFile.Close()
+
+		fileNameArr := strings.Split(file.Name, "/")
+		extractedFilePath = destination
+
+		for i := 1; i < len(fileNameArr); i++ {
+			extractedFilePath = filepath.Join(extractedFilePath, fileNameArr[i])
+		}
+
+		if file.FileInfo().IsDir() {
+			log.Println("Directory Created:", extractedFilePath)
+			os.MkdirAll(extractedFilePath, file.Mode())
+		} else {
+			log.Println("File extracted:", file.Name)
+
+			outputFile, err := os.OpenFile(
+				extractedFilePath,
+				os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+				file.Mode(),
+			)
+			errors.CheckErr(err, 403, "")
+			defer outputFile.Close()
+
+			_, err = io.Copy(outputFile, zippedFile)
+			errors.CheckErr(err, 404, "")
+		}
+	}
+	log.Println("File extracted:", zipFileName)
+}
+
+//MoveFiles to directory specified in command
+func MoveFiles(source, destination string) {
+	fmt.Println("==> moving files from ", source)
+	fmt.Println("==> moving files too ", destination)
+
+	err := os.Rename(source, destination)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -127,11 +127,11 @@ func GetZipURL(c *cli.Context) string {
 		log.Fatal(err)
 	}
 	url := URL.String()
-	fmt.Println(URL)
+	fmt.Println("Repository archive link - ", URL)
 	return url
 }
 
-//DownloadFile - the git zip of master into current dir
+//DownloadFile into /temp dir using the git archive link
 func DownloadFile(zipFileName, url string) error {
 
 	// Get the data
@@ -140,19 +140,19 @@ func DownloadFile(zipFileName, url string) error {
 	defer resp.Body.Close()
 
 	// Create the file
-	out, err := os.Create(zipFileName)
+	file, err := os.Create(zipFileName)
 	errors.CheckErr(err, 401, "")
-	defer out.Close()
+	defer file.Close()
 
 	// Write body to file
-	_, err = io.Copy(out, resp.Body)
+	_, err = io.Copy(file, resp.Body)
 	fmt.Println(zipFileName)
 
 	return err
 }
 
 //UnZip downloaded file
-func UnZip(zipFileName, destination string) {
+func UnZip(zipFileName, fileDestination string) {
 	zipReader, _ := zip.OpenReader(zipFileName)
 
 	var extractedFilePath = ""
@@ -163,7 +163,7 @@ func UnZip(zipFileName, destination string) {
 		defer zippedFile.Close()
 
 		fileNameArr := strings.Split(file.Name, "/")
-		extractedFilePath = destination
+		extractedFilePath = fileDestination
 
 		for i := 1; i < len(fileNameArr); i++ {
 			extractedFilePath = filepath.Join(extractedFilePath, fileNameArr[i])


### PR DESCRIPTION
**Enhancement needed**
Be able to clone a repository from github into a directory without using git

**Solution**
1. Get the archive link by querying the GitHub api
2. Download the files into `.zip` format into the tmp/temp dir of host machine by using the archive link
3. Unzip files into specified directory
4. Delete the `.zip` file stored in the tmp/temp dir

UPDATE
5. Updated packages to latest versions

**Commands**
1. `--branch/-b` **optional**
2. `--destination/-d` **required**
3. `--owner` **required**
4. `--repo` **required**

**Tested**
1. bats automated test. Output:
```
✓ invoke install command - using -t
 ✓ invoke start command - Start dockerhub images'
 ✓ invoke stop-all command - Stop dockerhub images'
 ✓ invoke remove command - remove dockerhub images
 ✓ invoke clone command - clone  microclimate-dev2ops/microclimateGoTemplate into ./clonetest

5 tests, 0 failures
```
2. Manually tested Mac/Windows environments