### PR TITLE
fix linter warnings

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package actions
 
 import (

--- a/actions/install.go
+++ b/actions/install.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package actions
 
 import (

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package actions
 
 import (

--- a/actions/start.go
+++ b/actions/start.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package actions
 
 import (

--- a/actions/status.go
+++ b/actions/status.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package actions
 
 import (

--- a/actions/stop-all.go
+++ b/actions/stop-all.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package actions
 
 import (

--- a/actions/stop.go
+++ b/actions/stop.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package actions
 
 import (

--- a/errors/error.go
+++ b/errors/error.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package errors
 
 import (

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package main
 
 import "github.com/eclipse/codewind-installer/actions"


### PR DESCRIPTION
**Problem**
Linter wanrning - expects a new line between the comment and package definition

**Solution**
Put a new line in. Looks neater and removed the linter error
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>