### PR TITLE
replace ibmcom with eclipse

### DIFF
--- a/actions/install.go
+++ b/actions/install.go
@@ -23,9 +23,9 @@ func InstallCommand(c *cli.Context) {
 	tag := c.String("tag")
 	jsonOutput := c.Bool("json")
 
-	imageArr := [3]string{"docker.io/ibmcom/codewind-pfe-amd64:",
-		"docker.io/ibmcom/codewind-performance-amd64:",
-		"docker.io/ibmcom/codewind-initialize-amd64:"}
+	imageArr := [3]string{"docker.io/eclipse/codewind-pfe-amd64:",
+		"docker.io/eclipse/codewind-performance-amd64:",
+		"docker.io/eclipse/codewind-initialize-amd64:"}
 
 	targetArr := [3]string{"codewind-pfe-amd64:",
 		"codewind-performance-amd64:",

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -21,9 +21,9 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand() {
 	imageArr := [4]string{}
-	imageArr[0] = "ibmcom/codewind-pfe"
-	imageArr[1] = "ibmcom/codewind-performance"
-	imageArr[2] = "ibmcom/codewind-initialize"
+	imageArr[0] = "eclipse/codewind-pfe"
+	imageArr[1] = "eclipse/codewind-performance"
+	imageArr[2] = "eclipse/codewind-initialize"
 	imageArr[3] = "cw-"
 	networkName := "codewind"
 

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -188,9 +188,9 @@ func CheckContainerStatus() bool {
 func CheckImageStatus() bool {
 	var imageStatus = false
 	imageArr := [3]string{}
-	imageArr[0] = "ibmcom/codewind-pfe"
-	imageArr[1] = "ibmcom/codewind-performance"
-	imageArr[2] = "ibmcom/codewind-initialize"
+	imageArr[0] = "eclipse/codewind-pfe"
+	imageArr[1] = "eclipse/codewind-performance"
+	imageArr[2] = "eclipse/codewind-initialize"
 
 	images := GetImageList()
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -33,7 +33,7 @@ func TestToggleDebug(t *testing.T) {
 }
 
 func TestRemoveImage(t *testing.T) {
-	performanceImage := "docker.io/ibmcom/codewind-performance-amd64"
+	performanceImage := "docker.io/eclipse/codewind-performance-amd64"
 	PullImage(performanceImage, false)
 	RemoveImage(performanceImage)
 }
@@ -52,7 +52,7 @@ func TestCheckContainerStatusFalse(t *testing.T) {
 }
 
 func TestPullDockerImage(t *testing.T) {
-	performanceImage := "docker.io/ibmcom/codewind-performance-amd64"
+	performanceImage := "docker.io/eclipse/codewind-performance-amd64"
 	performanceImageTarget := "codewind-performance-amd64:latest"
 	PullImage(performanceImage, false)
 	TagImage(performanceImage, performanceImageTarget)
@@ -68,7 +68,7 @@ func TestPullDockerImage(t *testing.T) {
 			assert.Equal(t, imageStatus, true, "should return true: imageStatus should be true")
 		}
 	}
-	cmd := exec.Command("docker", "image", "rm", "ibmcom/codewind-performance-amd64", performanceImageTarget, "-f")
+	cmd := exec.Command("docker", "image", "rm", "eclipse/codewind-performance-amd64", performanceImageTarget, "-f")
 	cmd.Stdin = strings.NewReader("Deleting pulled image")
 	var out bytes.Buffer
 	cmd.Stdout = &out


### PR DESCRIPTION
**Problem #60**
Dockerhub image reference pointed to `ibmcom` whereas the images are now `eclipse`

**Solution**
Replace `ibmcom` with `eclipse` throughout the installer code

**Tested**
Bats output:
```
➜  codewind-installer git:(replace-ibmcom) ✗ bats integration.bats                         
 ✓ invoke install command - default to latest tag
 ✓ invoke start command - Start dockerhub images'
 ✓ invoke stop-all command - Stop dockerhub images'
 ✓ invoke remove command - remove dockerhub images

4 tests, 0 failures
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>