### PR TITLE
Add the home and maven_opts env variable

### DIFF
--- a/utils/docker.go
+++ b/utils/docker.go
@@ -101,12 +101,7 @@ func DockerCompose(tag string) {
 		os.Setenv("WORKSPACE_DIRECTORY", "C:\\codewind-workspace")
 		// In Windows, calling the env variable "HOME" does not return
 		// the user directory correctly
-		userHome, err := os.UserHomeDir()
-		if (err == nil){
-		  os.Setenv("HOME", userHome)
-		} else {
-		  os.Setenv("HOME", home)
-		}
+		os.Setenv("HOME", os.Getenv("USERPROFILE"))
 
 	} else {
 		os.Setenv("WORKSPACE_DIRECTORY", home+"/codewind-workspace")

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -36,7 +36,7 @@ services:
   image: ${REPOSITORY}codewind-pfe${PLATFORM}:${TAG}
   container_name: codewind-pfe
   user: root
-  environment: ["HOST_WORKSPACE_DIRECTORY=${WORKSPACE_DIRECTORY}","CONTAINER_WORKSPACE_DIRECTORY=/codewind-workspace","HOST_OS=${HOST_OS}","CODEWIND_VERSION=${TAG}","PERFORMANCE_CONTAINER=codewind-performance${PLATFORM}:${TAG}","HOME=${HOME}","MAVEN_OPTS=${MAVEN_OPTS}"]
+  environment: ["HOST_WORKSPACE_DIRECTORY=${WORKSPACE_DIRECTORY}","CONTAINER_WORKSPACE_DIRECTORY=/codewind-workspace","HOST_OS=${HOST_OS}","CODEWIND_VERSION=${TAG}","PERFORMANCE_CONTAINER=codewind-performance${PLATFORM}:${TAG}","HOST_HOME=${HOST_HOME}","HOST_MAVEN_OPTS=${HOST_MAVEN_OPTS}"]
   depends_on: [codewind-performance]
   ports: ["127.0.0.1:9090:9090"]
   volumes: ["/var/run/docker.sock:/var/run/docker.sock","${WORKSPACE_DIRECTORY}:/codewind-workspace"]
@@ -101,15 +101,15 @@ func DockerCompose(tag string) {
 		os.Setenv("WORKSPACE_DIRECTORY", "C:\\codewind-workspace")
 		// In Windows, calling the env variable "HOME" does not return
 		// the user directory correctly
-		os.Setenv("HOME", os.Getenv("USERPROFILE"))
+		os.Setenv("HOST_HOME", os.Getenv("USERPROFILE"))
 
 	} else {
 		os.Setenv("WORKSPACE_DIRECTORY", home+"/codewind-workspace")
-		os.Setenv("HOME", home)
+		os.Setenv("HOST_HOME", home)
 	}
 	os.Setenv("HOST_OS", GOOS)
 	os.Setenv("COMPOSE_PROJECT_NAME", "codewind")
-	os.Setenv("MAVEN_OPTS", os.Getenv("MAVEN_OPTS"))         
+	os.Setenv("HOST_MAVEN_OPTS", os.Getenv("MAVEN_OPTS"))         
 
 	cmd := exec.Command("docker-compose", "-f", "installer-docker-compose.yaml", "up", "-d")
 	output := new(bytes.Buffer)


### PR DESCRIPTION
For appsody support, we need to determine the maven cache directory in the local scenario. By default (confirmed with other open source plug-ins), the maven directory is in the user's home directory. However, the user can override this setting via the environment variable MAVEN_OPTS. This change adds both variables and takes care of processing these environment variables in the appsody extension. The home directory is also generic enough that it could be used by others as needed.

From testing and looking on stackoverflow, Windows does not handle the home environment correctly. It was returning "/root" for me. The workaround is to use os.UserHomeDir.