### PR TITLE
Add project command

### DIFF
--- a/actions/clone-template.go
+++ b/actions/clone-template.go
@@ -24,8 +24,20 @@ import (
 
 // CloneTemplate from github
 func CloneTemplate(c *cli.Context) {
-	destination := c.String("destination")
-	branch := c.String("branch")
+	destination := c.Args().Get(0)
+	if destination == "" {
+		log.Fatal("destination not set")
+	}
+	repoURL := c.String("r")
+
+	if strings.HasPrefix(repoURL, "https://") {
+		repoURL = strings.TrimPrefix(repoURL, "https://")
+	}
+
+	repoArray := strings.Split(repoURL, "/")
+	owner := repoArray[1]
+	repo := repoArray[2]
+	branch := "master"
 
 	var tempPath = ""
 	const GOOS string = runtime.GOOS
@@ -35,7 +47,7 @@ func CloneTemplate(c *cli.Context) {
 		tempPath = "/tmp/"
 	}
 
-	zipURL := utils.GetZipURL(c)
+	zipURL := utils.GetZipURL(owner, repo, branch)
 
 	time := time.Now().Format(time.RFC3339)
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -42,10 +42,6 @@ func Commands() {
 					Name:  "r",
 					Usage: "repository url",
 				},
-				cli.StringFlag{
-					Name:  "a",
-					Usage: "archive url",
-				},
 			},
 			Action: func(c *cli.Context) error {
 				if c.NumFlags() == 0 {

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -49,7 +49,7 @@ func Commands() {
 			},
 			Action: func(c *cli.Context) error {
 				if c.NumFlags() == 0 {
-					// run validation
+					// ValidateProject()
 				} else {
 					DownloadTemplate(c)
 				}

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -48,7 +48,11 @@ func Commands() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				DownloadTemplate(c)
+				if c.NumFlags() == 0 {
+					// run validation
+				} else {
+					DownloadTemplate(c)
+				}
 				return nil
 			},
 		},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -36,7 +36,7 @@ func Commands() {
 
 		{
 			Name:  "project",
-			Usage: "Project management",
+			Usage: "Manage Codewind projects",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "r",
@@ -45,7 +45,7 @@ func Commands() {
 			},
 			Action: func(c *cli.Context) error {
 				if c.NumFlags() == 0 {
-					// ValidateProject()
+					// TODO: add ValidateProject() func
 				} else {
 					DownloadTemplate(c)
 				}

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -35,38 +35,6 @@ func Commands() {
 	app.Commands = []cli.Command{
 
 		{
-			Name:    "clone",
-			Aliases: []string{"c"},
-			Usage:   "Clone a template from github",
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "branch, b",
-					Value: "master",
-					Usage: "repository branch",
-				},
-				cli.StringFlag{
-					Name:     "destination, d",
-					Required: true,
-					Usage:    "absolute destination file path",
-				},
-				cli.StringFlag{
-					Name:     "owner",
-					Required: true,
-					Usage:    "repository owner",
-				},
-				cli.StringFlag{
-					Name:     "repo",
-					Required: true,
-					Usage:    "repository to download",
-				},
-			},
-			Action: func(c *cli.Context) error {
-				CloneTemplate(c)
-				return nil
-			},
-		},
-
-		{
 			Name:  "project",
 			Usage: "Project management",
 			Flags: []cli.Flag{
@@ -80,7 +48,7 @@ func Commands() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				CloneTemplate(c)
+				DownloadTemplate(c)
 				return nil
 			},
 		},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -67,6 +67,25 @@ func Commands() {
 		},
 
 		{
+			Name:  "project",
+			Usage: "Project management",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "r",
+					Usage: "repository url",
+				},
+				cli.StringFlag{
+					Name:  "a",
+					Usage: "archive url",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				CloneTemplate(c)
+				return nil
+			},
+		},
+
+		{
 			Name:    "install",
 			Aliases: []string{"in"},
 			Usage:   "Pull pfe, performance & intialize images from dockerhub",

--- a/actions/project.go
+++ b/actions/project.go
@@ -32,7 +32,7 @@ func DownloadTemplate(c *cli.Context) {
 
 	repoURL := c.String("r")
 
-	// expecting string in format 'https://github.com/<owner>/<repo>
+	// expecting string in format 'https://github.com/<owner>/<repo>'
 	if strings.HasPrefix(repoURL, "https://") {
 		repoURL = strings.TrimPrefix(repoURL, "https://")
 	}

--- a/actions/project.go
+++ b/actions/project.go
@@ -22,8 +22,8 @@ import (
 	"github.com/urfave/cli"
 )
 
-// CloneTemplate from github
-func CloneTemplate(c *cli.Context) {
+// DownloadTemplate from github
+func DownloadTemplate(c *cli.Context) {
 	destination := c.Args().Get(0)
 	if destination == "" {
 		log.Fatal("destination not set")

--- a/actions/project.go
+++ b/actions/project.go
@@ -22,7 +22,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-// DownloadTemplate from github
+// DownloadTemplate using the url/link provided
 func DownloadTemplate(c *cli.Context) {
 	destination := c.Args().Get(0)
 	if destination == "" {

--- a/actions/project.go
+++ b/actions/project.go
@@ -65,3 +65,8 @@ func DownloadTemplate(c *cli.Context) {
 	//delete zip file
 	utils.DeleteTempFile(zipFileName)
 }
+
+//ValidateProject type
+func ValidateProject() {
+	//code here
+}

--- a/actions/project.go
+++ b/actions/project.go
@@ -25,11 +25,14 @@ import (
 // DownloadTemplate using the url/link provided
 func DownloadTemplate(c *cli.Context) {
 	destination := c.Args().Get(0)
+
 	if destination == "" {
 		log.Fatal("destination not set")
 	}
+
 	repoURL := c.String("r")
 
+	// expecting string in format 'https://github.com/<owner>/<repo>
 	if strings.HasPrefix(repoURL, "https://") {
 		repoURL = strings.TrimPrefix(repoURL, "https://")
 	}

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/eclipse/codewind-installer/errors"
 	"github.com/google/go-github/github"
-	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
 )
 
@@ -113,11 +112,7 @@ func PingHealth(healthEndpoint string) bool {
 }
 
 //GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
-func GetZipURL(c *cli.Context) string {
-	branch := c.String("branch")
-	owner := c.String("owner")
-	repo := c.String("repo")
-
+func GetZipURL(owner, repo, branch string) string {
 	client := github.NewClient(nil)
 
 	opt := &github.RepositoryContentGetOptions{Ref: branch}


### PR DESCRIPTION
**Problem**
The clone command needs to be part of a parent command. It also needs to have less flag requirements.

**Solution**
1. Introduce a parent command - `project`. This enables a user to enter a git url and the extraction of the previous flags needed `owner` & `repo` are extracted automatically.
2. Example command - `./installer project -r https://github.com/microclimate-dev2ops/microclimateGoTemplate ./downloadtest

**Tested**
Bats test output:
```
➜  codewind-installer git:(add-project-cmd) ✗ bats integration.bats
 ✓ invoke install command - default to latest tag
 ✓ invoke start command - Start dockerhub images'
 ✓ invoke stop-all command - Stop dockerhub images'
 ✓ invoke remove command - remove dockerhub images
 ✓ invoke project command - using -r download microclimate-dev2ops/microclimateGoTemplate into ./downloadtest

5 tests, 0 failures
```
Signed-off-by: Liam Hampton liam.hampton@ibm.com