### PR TITLE
Output hard-coded port

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -97,8 +97,14 @@ func Commands() {
 		{
 			Name:  "status",
 			Usage: "Print the installation status of Codewind",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "json, j",
+					Usage: "specify terminal output",
+				},
+			},
 			Action: func(c *cli.Context) error {
-				StatusCommand()
+				StatusCommand(c)
 				return nil
 			},
 		},

--- a/actions/status.go
+++ b/actions/status.go
@@ -14,23 +14,40 @@ package actions
 import (
 	"fmt"
 	"os"
-
+	"encoding/json"
+	"github.com/urfave/cli"
 	"github.com/eclipse/codewind-installer/utils"
 )
 
 //StatusCommand to show the status
-func StatusCommand() {
+func StatusCommand(c *cli.Context) {
+	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {
-		fmt.Println("Codewind is installed and running on port " + utils.GetPort())
-		os.Exit(202)
+		if jsonOutput {
+			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://localhost:9090"})
+			fmt.Println(string(output))
+		} else {
+			fmt.Println("Codewind is installed and running on port " + utils.GetPort())
+		}
+		os.Exit(0)
 	}
 
 	if utils.CheckImageStatus() {
-		fmt.Println("Codewind is installed but not running")
-		os.Exit(201)
+		if jsonOutput {
+			output, _ := json.Marshal(map[string]string{"status": "stopped"})
+			fmt.Println(string(output))
+	  } else {
+			fmt.Println("Codewind is installed but not running")
+		}
+		os.Exit(0)
 	} else {
-		fmt.Println("Codewind is not installed")
-		os.Exit(200)
+		if jsonOutput {
+			output, _ := json.Marshal(map[string]string{"status": "uninstalled"})
+			fmt.Println(string(output))
+		} else {
+			fmt.Println("Codewind is not installed")
+		}
+		os.Exit(0)
 	}
 	return
 }

--- a/actions/status.go
+++ b/actions/status.go
@@ -21,7 +21,7 @@ import (
 //StatusCommand to show the status
 func StatusCommand() {
 	if utils.CheckContainerStatus() {
-		fmt.Println("Codewind is installed and running")
+		fmt.Println("Codewind is installed and running on port " + utils.GetPort())
 		os.Exit(202)
 	}
 

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -283,3 +283,8 @@ func RemoveNetwork(network types.NetworkResource) {
 		errors.CheckErr(err, 111, "Cannot remove "+network.Name+". Use 'stop-all' flag to ensure all containers have been terminated")
 	}
 }
+
+// GetPort will return the current port that PFE is running on (hardcoded to 9090 for now)
+func GetPort() string {
+	return "9090";
+}

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -97,7 +97,7 @@ func PingHealth(healthEndpoint string) bool {
 		} else {
 			if resp.StatusCode == 200 {
 				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
-				fmt.Println("Codewind successfully started")
+				fmt.Println("Codewind successfully started on port " + GetPort())
 				started = true
 				break
 			}


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

### Problem
When starting Codewind, the user is not told what port it is started on. The user requires knowledge of pre-existing defaults to continue.

### Solution
This PR adds hard-coded port info to the output obtained from the `start` and `status` commands. Further work to dynamically obtain this port will be done in a future PR.

### Tested
Manually
```
C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>.\win-installer.exe start
Debug: false
==> created file installer-docker-compose.yaml
==> environment structure written to installer-docker-compose.yaml
System architecture is:  amd64
Host operating system is:  windows
Please wait whilst containers initialize...
Creating codewind-performance ...
[1BCreating codewind-pfe         ... mdone[0m
[1B==> finished deleting file installer-docker-compose.yaml
Waiting for Codewind to start
.
HTTP Response Status: 200 OK
Codewind successfully started on port 9090

C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>.\win-installer.exe status
Codewind is installed and running on port 9090
```