### PR TITLE
update cli usage text

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -30,6 +30,7 @@ func Commands() {
 	app.Name = "Codewind Installer"
 	app.Version = versionNum
 	app.Usage = "Start, Stop and Remove Codewind"
+	app.UsageText = "codewind-installer-<OS> [global options] command [command options] [arguments...]"
 
 	// create commands
 	app.Commands = []cli.Command{


### PR DESCRIPTION
**Problem**
Previously the usage text stated `main [global options]...`. The installer binary is not called `main`.

**Solution**
Change:
`main [global options] command [command options] [arguments...]` 
to
`codewind-installer-<OS> [global options] command [command options] [arguments...]`
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>