### PR TITLE
Let Docker assign PFE Port: discover port for Status and Health Endpoint

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -22,7 +22,7 @@ import (
 var tempFilePath = "installer-docker-compose.yaml"
 
 const versionNum = "0.2.0"
-const healthEndpoint = "http://localhost:9090/api/v1/environment"
+const healthEndpoint = "/api/v1/environment"
 
 //Commands for the installer
 func Commands() {

--- a/actions/status.go
+++ b/actions/status.go
@@ -23,11 +23,12 @@ import (
 func StatusCommand(c *cli.Context) {
 	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {
+		port := utils.GetPFEPort()
 		if jsonOutput {
-			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://localhost:9090"})
+			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://localhost:" + port})
 			fmt.Println(string(output))
 		} else {
-			fmt.Println("Codewind is installed and running on port " + utils.GetPort())
+			fmt.Println("Codewind is installed and running on port " + port)
 		}
 		os.Exit(0)
 	}

--- a/actions/status.go
+++ b/actions/status.go
@@ -28,7 +28,7 @@ func StatusCommand(c *cli.Context) {
 			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://localhost:" + port})
 			fmt.Println(string(output))
 		} else {
-			fmt.Println("Codewind is installed and running on port " + port)
+			fmt.Println("Codewind is installed and running on http://localhost:" + port)
 		}
 		os.Exit(0)
 	}

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -288,7 +288,7 @@ func RemoveNetwork(network types.NetworkResource) {
 	}
 }
 
-// GetPFEPort will return the current port that PFE is running on (hardcoded to 9090 for now)
+// GetPFEPort will return the current port that PFE is running on
 func GetPFEPort() string {
 	if CheckContainerStatus() {
 		containerList := GetContainerList()

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -38,7 +39,7 @@ services:
   user: root
   environment: ["HOST_WORKSPACE_DIRECTORY=${WORKSPACE_DIRECTORY}","CONTAINER_WORKSPACE_DIRECTORY=/codewind-workspace","HOST_OS=${HOST_OS}","CODEWIND_VERSION=${TAG}","PERFORMANCE_CONTAINER=codewind-performance${PLATFORM}:${TAG}"]
   depends_on: [codewind-performance]
-  ports: ["127.0.0.1:9090:9090"]
+  ports: ["127.0.0.1::9090"]
   volumes: ["/var/run/docker.sock:/var/run/docker.sock","${WORKSPACE_DIRECTORY}:/codewind-workspace"]
   networks: [network]
  codewind-performance:
@@ -77,6 +78,9 @@ type Compose struct {
 		Network map[string]string `yaml:"network"`
 	} `yaml:"networks"`
 }
+
+// constant to identify the internal port of PFE in its container
+const internalPFEPort = 9090
 
 // DockerCompose to set up the Codewind environment
 func DockerCompose(tag string) {
@@ -284,7 +288,19 @@ func RemoveNetwork(network types.NetworkResource) {
 	}
 }
 
-// GetPort will return the current port that PFE is running on (hardcoded to 9090 for now)
-func GetPort() string {
-	return "9090";
+// GetPFEPort will return the current port that PFE is running on (hardcoded to 9090 for now)
+func GetPFEPort() string {
+	if CheckContainerStatus() {
+		containerList := GetContainerList()
+		for _, container := range containerList {
+			if strings.HasPrefix(container.Image, "codewind-pfe") {
+				for _, port := range container.Ports {
+					if port.PrivatePort == internalPFEPort {
+						return strconv.Itoa(int(port.PublicPort))
+					}
+				}
+			}
+		}
+	}
+	return ""
 }

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -90,14 +90,15 @@ func DeleteTempFile(tempFilePath string) (boolean bool, err error) {
 func PingHealth(healthEndpoint string) bool {
 	var started = false
 	fmt.Println("Waiting for Codewind to start")
+	port := GetPFEPort()
 	for i := 0; i < 120; i++ {
-		resp, err := http.Get(healthEndpoint)
+		resp, err := http.Get("http://localhost:" + port + healthEndpoint)
 		if err != nil {
 			fmt.Printf(".")
 		} else {
 			if resp.StatusCode == 200 {
 				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
-				fmt.Println("Codewind successfully started on port " + GetPort())
+				fmt.Println("Codewind successfully started on port " + port)
 				started = true
 				break
 			}

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -98,7 +98,7 @@ func PingHealth(healthEndpoint string) bool {
 		} else {
 			if resp.StatusCode == 200 {
 				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
-				fmt.Println("Codewind successfully started on port " + port)
+				fmt.Println("Codewind successfully started on http://localhost:" + port)
 				started = true
 				break
 			}


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

### Problem
We can't run several instances of Codewind at once if they're all trying to use external port 9090
### Solution
This PR allows Docker to select a free external port to use per Codewind instance. The installer `start` and `status` commands have been updated to query and display the port, as has the health endpoint checker 
### Tested

Manually

```
C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>go build -o win_container.exe

C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>.\win_container.exe stop-all
Stopping Codewind and Project containers
Stopping container  [/cw-libproj-4a5ea420-b376-11e9-86e2-61bb062eb4b6] ...
Stopping container  [/codewind-pfe] ...
Stopping container  [/codewind-performance] ...

C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>.\win_container.exe start -d
Debug: true
==> created file installer-docker-compose.yaml
==> installer-docker-compose.yaml structure is:
version: "2"
services:
    codewind-pfe:
        image: ${REPOSITORY}codewind-pfe${PLATFORM}:${TAG}
        container_name: codewind-pfe
        user: root
        environment:
          - HOST_WORKSPACE_DIRECTORY=${WORKSPACE_DIRECTORY}
          - CONTAINER_WORKSPACE_DIRECTORY=/codewind-workspace
          - HOST_OS=${HOST_OS}
          - CODEWIND_VERSION=${TAG}
          - PERFORMANCE_CONTAINER=codewind-performance${PLATFORM}:${TAG}
        depends_on:
          - codewind-performance
        ports:
          - 127.0.0.1::9090
        volumes:
          - /var/run/docker.sock:/var/run/docker.sock
          - ${WORKSPACE_DIRECTORY}:/codewind-workspace
        networks:
          - network
    codewind-performance:
        image: codewind-performance${PLATFORM}:${TAG}
        ports:
          - 127.0.0.1:9095:9095
        container_name: codewind-performance
        volumes:
          - /var/run/docker.sock:/var/run/docker.sock
          - ${WORKSPACE_DIRECTORY}:/codewind-workspace
        networks:
          - network
networks:
    network: {}


System architecture is:  amd64
Host operating system is:  windows
Please wait whilst containers initialize...
Creating codewind-performance ...
[1BCreating codewind-pfe         ... mdone[0m
[1B==> finished deleting file installer-docker-compose.yaml
Waiting for Codewind to start
.
HTTP Response Status: 200 OK
Codewind successfully started on port 32791

C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>.\win_container.exe status
Codewind is installed and running on port 32791

C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>.\win_container.exe status -j
{"status":"started","url":"http://localhost:32791"}
```