### PR TITLE
add project validation on project command

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -56,7 +56,7 @@ func Commands() {
 		{
 			Name:    "install",
 			Aliases: []string{"in"},
-			Usage:   "Pull pfe, performance & intialize images from dockerhub",
+			Usage:   "Pull pfe, performance & initialize images from dockerhub",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "tag, t",

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -44,11 +44,10 @@ func Commands() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				if c.NumFlags() == 0 {
-					ValidateProject(c)
-				} else {
+				if c.NumFlags() != 0 {
 					DownloadTemplate(c)
 				}
+				ValidateProject(c)
 				return nil
 			},
 		},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -45,7 +45,7 @@ func Commands() {
 			},
 			Action: func(c *cli.Context) error {
 				if c.NumFlags() == 0 {
-					// TODO: add ValidateProject() func
+					ValidateProject(c)
 				} else {
 					DownloadTemplate(c)
 				}

--- a/actions/project.go
+++ b/actions/project.go
@@ -14,7 +14,6 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -39,17 +38,6 @@ type (
 		Status string      `json:"status"`
 		Path   string      `json:"path"`
 		Result ProjectType `json:"result"`
-	}
-
-	// CWSettings represents the .cw-settings file which is written to a project
-	CWSettings struct {
-		ContextRoot       string   `json:"contextRoot"`
-		InternalPort      string   `json:"internalPort"`
-		HealthCheck       string   `json:"healthCheck"`
-		InternalDebugPort *string  `json:"internalDebugPort"`
-		IgnoredPaths      []string `json:"ignoredPaths"`
-		MavenProfiles     []string `json:"mavenProfiles,omitempty"`
-		MavenProperties   []string `json:"mavenProperties,omitempty"`
 	}
 )
 
@@ -100,12 +88,13 @@ func DownloadTemplate(c *cli.Context) {
 	utils.DeleteTempFile(zipFileName)
 }
 
-// ValidateProject returns the language and buildType for a project at given filesystem path
+// ValidateProject returns the language and buildType for a project at given filesystem path,
+// and writes a default .cw-settings file to that project
 func ValidateProject(c *cli.Context) {
 	projectPath := c.Args().Get(0)
-	checkProjectPath(projectPath)
+	utils.CheckProjectPath(projectPath)
 
-	language, buildType := determineProjectInfo(projectPath)
+	language, buildType := utils.DetermineProjectInfo(projectPath)
 	response := ValidationResponse{
 		Status: "success",
 		Result: ProjectType{language, buildType},
@@ -114,109 +103,18 @@ func ValidateProject(c *cli.Context) {
 	projectInfo, err := json.Marshal(response)
 
 	errors.CheckErr(err, 203, "")
-	writeToCwSettings(projectPath, buildType)
+	writeCwSettings(projectPath, buildType)
 	fmt.Println(string(projectInfo))
 }
 
-func checkProjectPath(projectPath string) {
-	if projectPath == "" {
-		log.Fatal("Project path has not been set")
-	}
-
-	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
-		log.Fatal("Project not found at given path")
-	}
-}
-
-func determineProjectInfo(projectPath string) (string, string) {
-	language := "unknown"
-	buildType := "docker"
-	if _, err := os.Stat(path.Join(projectPath, "pom.xml")); err == nil {
-		language = "java"
-		buildType = determineJavaBuildType(projectPath)
-	}
-	if _, err := os.Stat(path.Join(projectPath, "package.json")); err == nil {
-		language = "nodejs"
-		buildType = "nodejs"
-	}
-	if _, err := os.Stat(path.Join(projectPath, "Package.swift")); err == nil {
-		language = "swift"
-		buildType = "swift"
-	}
-	return language, buildType
-}
-
-func determineJavaBuildType(projectPath string) string {
-	pathToPomXML := path.Join(projectPath, "pom.xml")
-	pomXMLContents, _err := ioutil.ReadFile(pathToPomXML)
-	// if there is an error reading the pom.xml, build as docker
-	if _err != nil {
-		return "docker"
-	}
-	pomXMLString := string(pomXMLContents)
-	if strings.Contains(pomXMLString, "<groupId>org.springframework.boot</groupId>") {
-		return "spring"
-	}
-	if strings.Contains(pomXMLString, "<groupId>org.eclipse.microprofile</groupId>") {
-		return "liberty"
-	}
-	return "docker"
-}
-
-func writeToCwSettings(projectPath string, ProjectType string) {
+func writeCwSettings(projectPath string, BuildType string) {
 	pathToCwSettings := path.Join(projectPath, ".cw-settings")
 	pathToLegacySettings := path.Join(projectPath, ".mc-settings")
 
 	if _, err := os.Stat(pathToLegacySettings); os.IsExist(err) {
-		renameLegacySettings(pathToLegacySettings, pathToCwSettings)
+		utils.RenameLegacySettings(pathToLegacySettings, pathToCwSettings)
 	} else if _, err := os.Stat(pathToCwSettings); os.IsNotExist(err) {
 		// Don't overwrite existing .cw-settings
-		writeNewCwSettings(ProjectType, pathToCwSettings)
+		utils.WriteNewCwSettings(pathToCwSettings, BuildType)
 	}
-}
-
-func renameLegacySettings(pathToLegacySettings string, pathToCwSettings string) {
-	err := os.Rename(pathToLegacySettings, pathToCwSettings)
-	errors.CheckErr(err, 205, "")
-}
-
-func writeNewCwSettings(ProjectType string, pathToCwSettings string) {
-	defaultCwSettings := getDefaultCwSettings()
-	cwSettings := addNonDefaultFields(defaultCwSettings, ProjectType)
-	settings, err := json.MarshalIndent(cwSettings, "", "")
-	errors.CheckErr(err, 203, "")
-	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)
-}
-
-func getDefaultCwSettings() CWSettings {
-	return CWSettings{
-		ContextRoot:  "",
-		InternalPort: "",
-		HealthCheck:  "",
-		IgnoredPaths: []string{""},
-	}
-}
-
-func addNonDefaultFields(cwSettings CWSettings, ProjectType string) CWSettings {
-	projectTypesWithInternalDebugPort := []string{"liberty", "spring", "nodejs"}
-	projectTypesWithMavenSettings := []string{"liberty", "spring"}
-	if stringInSlice(ProjectType, projectTypesWithInternalDebugPort) {
-		// We use a pointer, as an empty string would be removed due to omitempty on struct
-		defaultValue := ""
-		cwSettings.InternalDebugPort = &defaultValue
-	}
-	if stringInSlice(ProjectType, projectTypesWithMavenSettings) {
-		cwSettings.MavenProfiles = []string{""}
-		cwSettings.MavenProperties = []string{""}
-	}
-	return cwSettings
-}
-
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }

--- a/actions/project.go
+++ b/actions/project.go
@@ -120,7 +120,6 @@ func ValidateProject(c *cli.Context) {
 
 func checkProjectPath(projectPath string) {
 	if projectPath == "" {
-
 		log.Fatal("Project path has not been set")
 	}
 
@@ -170,30 +169,32 @@ func writeToCwSettings(projectPath string, ProjectType string) {
 
 	if _, err := os.Stat(pathToLegacySettings); os.IsExist(err) {
 		renameLegacySettings(pathToLegacySettings, pathToCwSettings)
-	} else if _, err := os.Stat(pathToCwSettings); os.IsExist(err) {
+	} else if _, err := os.Stat(pathToCwSettings); os.IsNotExist(err) {
 		// Don't overwrite existing .cw-settings
-	} else {
 		writeNewCwSettings(ProjectType, pathToCwSettings)
 	}
 }
 
-func writeNewCwSettings(ProjectType string, pathToCwSettings string) {
-	defaultCwSettings := CWSettings{
-		ContextRoot:  "",
-		InternalPort: "",
-		HealthCheck:  "",
-		IgnoredPaths: []string{""},
-	}
+func renameLegacySettings(pathToLegacySettings string, pathToCwSettings string) {
+	err := os.Rename(pathToLegacySettings, pathToCwSettings)
+	errors.CheckErr(err, 205, "")
+}
 
+func writeNewCwSettings(ProjectType string, pathToCwSettings string) {
+	defaultCwSettings := getDefaultCwSettings()
 	cwSettings := addNonDefaultFields(defaultCwSettings, ProjectType)
 	settings, err := json.MarshalIndent(cwSettings, "", "")
 	errors.CheckErr(err, 203, "")
 	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)
 }
 
-func renameLegacySettings(pathToLegacySettings string, pathToCwSettings string) {
-	err := os.Rename(pathToLegacySettings, pathToCwSettings)
-	errors.CheckErr(err, 205, "")
+func getDefaultCwSettings() CWSettings {
+	return CWSettings{
+		ContextRoot:  "",
+		InternalPort: "",
+		HealthCheck:  "",
+		IgnoredPaths: []string{""},
+	}
 }
 
 func addNonDefaultFields(cwSettings CWSettings, ProjectType string) CWSettings {

--- a/actions/project.go
+++ b/actions/project.go
@@ -27,13 +27,13 @@ import (
 )
 
 type (
-	// ProjectType represents the information codewind requires to build a project.
+	// ProjectType represents the information Codewind requires to build a project.
 	ProjectType struct {
 		Language  string `json:"language"`
 		BuildType string `json:"buildType"`
 	}
 
-	// ValidationResponse represents the respose to validating a project on local filesystem.
+	// ValidationResponse represents the response to validating a project on the users filesystem.
 	ValidationResponse struct {
 		Status string      `json:"status"`
 		Path   string      `json:"path"`
@@ -103,18 +103,17 @@ func ValidateProject(c *cli.Context) {
 	projectInfo, err := json.Marshal(response)
 
 	errors.CheckErr(err, 203, "")
-	writeCwSettings(projectPath, buildType)
+	writeCwSettingsIfNotInProject(projectPath, buildType)
 	fmt.Println(string(projectInfo))
 }
 
-func writeCwSettings(projectPath string, BuildType string) {
+func writeCwSettingsIfNotInProject(projectPath string, BuildType string) {
 	pathToCwSettings := path.Join(projectPath, ".cw-settings")
 	pathToLegacySettings := path.Join(projectPath, ".mc-settings")
 
 	if _, err := os.Stat(pathToLegacySettings); os.IsExist(err) {
 		utils.RenameLegacySettings(pathToLegacySettings, pathToCwSettings)
 	} else if _, err := os.Stat(pathToCwSettings); os.IsNotExist(err) {
-		// Don't overwrite existing .cw-settings
 		utils.WriteNewCwSettings(pathToCwSettings, BuildType)
 	}
 }

--- a/errors/error.go
+++ b/errors/error.go
@@ -15,7 +15,7 @@ import (
 	"log"
 )
 
-// CheckErr function to responde with appropriate error messages
+// CheckErr function to respond with appropriate error messages
 func CheckErr(err error, code int, optMsg string) {
 	if err != nil {
 		switch code {

--- a/utils/project.go
+++ b/utils/project.go
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/eclipse/codewind-installer/errors"
+)
+
+// CWSettings represents the .cw-settings file which is written to a project
+type CWSettings struct {
+	ContextRoot       string   `json:"contextRoot"`
+	InternalPort      string   `json:"internalPort"`
+	HealthCheck       string   `json:"healthCheck"`
+	InternalDebugPort *string  `json:"internalDebugPort"`
+	IgnoredPaths      []string `json:"ignoredPaths"`
+	MavenProfiles     []string `json:"mavenProfiles,omitempty"`
+	MavenProperties   []string `json:"mavenProperties,omitempty"`
+}
+
+// DetermineProjectInfo returns language and buildType for a project
+func DetermineProjectInfo(projectPath string) (string, string) {
+	language := "unknown"
+	buildType := "docker"
+	if _, err := os.Stat(path.Join(projectPath, "pom.xml")); err == nil {
+		language = "java"
+		buildType = determineJavaBuildType(projectPath)
+	}
+	if _, err := os.Stat(path.Join(projectPath, "package.json")); err == nil {
+		language = "nodejs"
+		buildType = "nodejs"
+	}
+	if _, err := os.Stat(path.Join(projectPath, "Package.swift")); err == nil {
+		language = "swift"
+		buildType = "swift"
+	}
+	return language, buildType
+}
+
+// CheckProjectPath will error if the path to a project is invalid
+func CheckProjectPath(projectPath string) {
+	if projectPath == "" {
+		log.Fatal("Project path has not been set")
+	}
+
+	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
+		log.Fatal("Project not found at given path")
+	}
+}
+
+func determineJavaBuildType(projectPath string) string {
+	pathToPomXML := path.Join(projectPath, "pom.xml")
+	pomXMLContents, _err := ioutil.ReadFile(pathToPomXML)
+	// if there is an error reading the pom.xml, build as docker
+	if _err != nil {
+		return "docker"
+	}
+	pomXMLString := string(pomXMLContents)
+	if strings.Contains(pomXMLString, "<groupId>org.springframework.boot</groupId>") {
+		return "spring"
+	}
+	if strings.Contains(pomXMLString, "<groupId>org.eclipse.microprofile</groupId>") {
+		return "liberty"
+	}
+	return "docker"
+}
+
+// WriteNewCwSettings writes a default .cw-settings file to the given path, dependent on buildType
+func WriteNewCwSettings(pathToCwSettings string, BuildType string,) {
+	defaultCwSettings := getDefaultCwSettings()
+	cwSettings := addNonDefaultFieldsToCwSettings(defaultCwSettings, BuildType)
+	settings, err := json.MarshalIndent(cwSettings, "", "")
+	errors.CheckErr(err, 203, "")
+	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)
+}
+
+// RenameLegacySettings renames a legacy .mc-settings file to .cw-settings
+func RenameLegacySettings(pathToLegacySettings string, pathToCwSettings string) {
+	err := os.Rename(pathToLegacySettings, pathToCwSettings)
+	errors.CheckErr(err, 205, "")
+}
+
+func getDefaultCwSettings() CWSettings {
+	return CWSettings{
+		ContextRoot:  "",
+		InternalPort: "",
+		HealthCheck:  "",
+		IgnoredPaths: []string{""},
+	}
+}
+
+func addNonDefaultFieldsToCwSettings(cwSettings CWSettings, ProjectType string) CWSettings {
+	projectTypesWithInternalDebugPort := []string{"liberty", "spring", "nodejs"}
+	projectTypesWithMavenSettings := []string{"liberty", "spring"}
+	if stringInSlice(ProjectType, projectTypesWithInternalDebugPort) {
+		// We use a pointer, as an empty string would be removed due to omitempty on struct
+		defaultValue := ""
+		cwSettings.InternalDebugPort = &defaultValue
+	}
+	if stringInSlice(ProjectType, projectTypesWithMavenSettings) {
+		cwSettings.MavenProfiles = []string{""}
+		cwSettings.MavenProperties = []string{""}
+	}
+	return cwSettings
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/project.go
+++ b/utils/project.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path"
 	"strings"
-
 	"github.com/eclipse/codewind-installer/errors"
 )
 

--- a/utils/project.go
+++ b/utils/project.go
@@ -33,10 +33,9 @@ type CWSettings struct {
 	MavenProperties   []string `json:"mavenProperties,omitempty"`
 }
 
-// DetermineProjectInfo returns language and buildType for a project
+// DetermineProjectInfo returns the language and build-type of a project
 func DetermineProjectInfo(projectPath string) (string, string) {
-	language := "unknown"
-	buildType := "docker"
+	language, buildType := "unknown", "docker"
 	if _, err := os.Stat(path.Join(projectPath, "pom.xml")); err == nil {
 		language = "java"
 		buildType = determineJavaBuildType(projectPath)
@@ -52,7 +51,8 @@ func DetermineProjectInfo(projectPath string) (string, string) {
 	return language, buildType
 }
 
-// CheckProjectPath will error if the path to a project is invalid
+// CheckProjectPath will stop the process and return an error if path does not
+// exist or is invalid
 func CheckProjectPath(projectPath string) {
 	if projectPath == "" {
 		log.Fatal("Project path has not been set")
@@ -66,7 +66,7 @@ func CheckProjectPath(projectPath string) {
 func determineJavaBuildType(projectPath string) string {
 	pathToPomXML := path.Join(projectPath, "pom.xml")
 	pomXMLContents, _err := ioutil.ReadFile(pathToPomXML)
-	// if there is an error reading the pom.xml, build as docker
+	// if there is an error reading the pom.xml, we build as docker
 	if _err != nil {
 		return "docker"
 	}
@@ -80,7 +80,8 @@ func determineJavaBuildType(projectPath string) string {
 	return "docker"
 }
 
-// WriteNewCwSettings writes a default .cw-settings file to the given path, dependent on buildType
+// WriteNewCwSettings writes a default .cw-settings file to the given path,
+// dependant on the build type of the project
 func WriteNewCwSettings(pathToCwSettings string, BuildType string,) {
 	defaultCwSettings := getDefaultCwSettings()
 	cwSettings := addNonDefaultFieldsToCwSettings(defaultCwSettings, BuildType)
@@ -89,7 +90,7 @@ func WriteNewCwSettings(pathToCwSettings string, BuildType string,) {
 	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)
 }
 
-// RenameLegacySettings renames a legacy .mc-settings file to .cw-settings
+// RenameLegacySettings renames a .mc-settings file to .cw-settings
 func RenameLegacySettings(pathToLegacySettings string, pathToCwSettings string) {
 	err := os.Rename(pathToLegacySettings, pathToCwSettings)
 	errors.CheckErr(err, 205, "")


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

**Problem** 

Project validation is currently performed by the initialize container within pfe, this includes determining the project language and buildType, and writing a .cw-settings file to the project. We are getting rid of this container as we move forwards towards a Hybrid architecture. This is because we won't have direct access to a users file system.

**Solution**

This moves the determining of language and buildType to this cli, with the writing of the settings to come. The same JSON is returned from the command ./installer <project-path> as was by the /validate API on PFE.

**Tested** 

Manual so far, adding unit tests now. 