### PR TITLE
Check for available TCP port in range

### DIFF
--- a/utils/docker.go
+++ b/utils/docker.go
@@ -328,7 +328,7 @@ func IsTCPPortAvailable() (bool, string) {
 			log.Println(status)
 		} else {
 			status = "Port " + strconv.Itoa(port) + " Available"
-			log.Println(status)
+			fmt.Println(status)
 			conn.Close()
 			return true, strconv.Itoa(port)
 		}

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -313,7 +313,7 @@ func GetPFEPort() string {
 	return ""
 }
 
-// IsTCPPortAvailable checks to see if a specified port is available
+// IsTCPPortAvailable checks to find the next available port and returns it
 func IsTCPPortAvailable() (bool, string) {
 	var status string
 	const (


### PR DESCRIPTION
**Problem #69**
There is an issue where docker will select and assign a random port, or at least attempt to. If the port is restricted or unreachable then it will fail to do so.

**Solution**
Write a function to check for a free port within the range specified `10000 -> 11000`. It will return a bool & port number. This will then allow docker to use it knowing it is available.

**Tested**
Manually - output:
```
2019/08/13 14:47:46 Port 10000 Available
```

**Extra**
Removed some white space elsewhere in the file
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>