### PR TITLE
Increase resource memory 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,13 @@ spec:
     tty: true
     command:
     - cat
+    resources:
+      limits:
+        memory: "2Gi"
+        cpu: "1"
+      requests:
+        memory: "2Gi"
+        cpu: "1"
 """
     	}
 	}


### PR DESCRIPTION
fixes https://github.com/eclipse/codewind/issues/189

Increase the allocated memory from 512mb to 2GB

Reference: https://wiki.eclipse.org/Jenkins#What_is_killing_my_build.3F_I.27m_using_custom_containers.21
