### PR TITLE
Limit PFE Port range; look up hostname & port for status

### DIFF
--- a/actions/status.go
+++ b/actions/status.go
@@ -23,12 +23,12 @@ import (
 func StatusCommand(c *cli.Context) {
 	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {
-		port := utils.GetPFEPort()
+		hostname, port := utils.GetPFEHostAndPort()
 		if jsonOutput {
-			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://localhost:" + port})
+			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://"+ hostname + ":" + port})
 			fmt.Println(string(output))
 		} else {
-			fmt.Println("Codewind is installed and running on http://localhost:" + port)
+			fmt.Println("Codewind is installed and running on http://" + hostname + ":" + port)
 		}
 		os.Exit(0)
 	}

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -39,7 +39,7 @@ services:
   user: root
   environment: ["HOST_WORKSPACE_DIRECTORY=${WORKSPACE_DIRECTORY}","CONTAINER_WORKSPACE_DIRECTORY=/codewind-workspace","HOST_OS=${HOST_OS}","CODEWIND_VERSION=${TAG}","PERFORMANCE_CONTAINER=codewind-performance${PLATFORM}:${TAG}","HOST_HOME=${HOST_HOME}","HOST_MAVEN_OPTS=${HOST_MAVEN_OPTS}"]
   depends_on: [codewind-performance]
-  ports: ["127.0.0.1::9090"]
+  ports: ["127.0.0.1:10000-11000:9090"]
   volumes: ["/var/run/docker.sock:/var/run/docker.sock","${WORKSPACE_DIRECTORY}:/codewind-workspace"]
   networks: [network]
  codewind-performance:
@@ -294,19 +294,19 @@ func RemoveNetwork(network types.NetworkResource) {
 	}
 }
 
-// GetPFEPort will return the current port that PFE is running on
-func GetPFEPort() string {
+// GetPFEHostAndPort will return the current hostname and port that PFE is running on
+func GetPFEHostAndPort() (string, string) {
 	if CheckContainerStatus() {
 		containerList := GetContainerList()
 		for _, container := range containerList {
 			if strings.HasPrefix(container.Image, "codewind-pfe") {
 				for _, port := range container.Ports {
 					if port.PrivatePort == internalPFEPort {
-						return strconv.Itoa(int(port.PublicPort))
+						return port.IP, strconv.Itoa(int(port.PublicPort))
 					}
 				}
 			}
 		}
 	}
-	return ""
+	return "",""
 }

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -90,15 +90,15 @@ func DeleteTempFile(tempFilePath string) (boolean bool, err error) {
 func PingHealth(healthEndpoint string) bool {
 	var started = false
 	fmt.Println("Waiting for Codewind to start")
-	port := GetPFEPort()
+	hostname, port := GetPFEHostAndPort()
 	for i := 0; i < 120; i++ {
-		resp, err := http.Get("http://localhost:" + port + healthEndpoint)
+		resp, err := http.Get("http://" + hostname + ":" + port + healthEndpoint)
 		if err != nil {
 			fmt.Printf(".")
 		} else {
 			if resp.StatusCode == 200 {
 				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
-				fmt.Println("Codewind successfully started on http://localhost:" + port)
+				fmt.Println("Codewind successfully started on http://" + hostname + ":" + port)
 				started = true
 				break
 			}


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>
### Problem
PFE exposure mapped docker-assigned port to localhost interface only - clashes with first application to be created, which maps to 0.0.0.0 (all interfaces) and takes the same port, as it wasn't allocated on that interface
### Solution
Limit PFE to a specified port range (10000-11000) - does not clash with docker assigned range
### Tested
Manually
```
C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>go run main.go start
Debug: false
==> created file installer-docker-compose.yaml
==> environment structure written to installer-docker-compose.yaml
System architecture is:  amd64
Host operating system is:  windows
Please wait whilst containers initialize...
Creating codewind-performance ...
[1BCreating codewind-pfe         ... mdone[0m
[1B==> finished deleting file installer-docker-compose.yaml
Waiting for Codewind to start
.
HTTP Response Status: 200 OK
Codewind successfully started on http://127.0.0.1:10001
C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>go run main.go status
Codewind is installed and running on http://127.0.0.1:10001
```

### Addendum
Tidied up GETPFEPorts() to get both hostname & port, and ensured this was displayed correctly in the start and status outpt