### PR TITLE
add ability to download from tar.gz; add tests

### DIFF
--- a/actions/project.go
+++ b/actions/project.go
@@ -60,8 +60,6 @@ func DownloadTemplate(c *cli.Context) {
 // DownloadFromURLThenExtract downloads files from a URL
 // to a destination, extracting them if necessary
 func DownloadFromURLThenExtract(URL string, destination string) error {
-	// TODO: warn if destination already exists?
-
 	if _, err := url.ParseRequestURI(URL); err != nil {
 		return err
 	}

--- a/actions/project.go
+++ b/actions/project.go
@@ -51,78 +51,10 @@ func DownloadTemplate(c *cli.Context) {
 
 	url := c.String("u")
 
-	err := DownloadFromURLThenExtract(url, destination)
+	err := utils.DownloadFromURLThenExtract(url, destination)
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-// DownloadFromURLThenExtract downloads files from a URL
-// to a destination, extracting them if necessary
-func DownloadFromURLThenExtract(URL string, destination string) error {
-	if _, err := url.ParseRequestURI(URL); err != nil {
-		return err
-	}
-
-	if IsTarGzURL(URL) {
-		return DownloadFromTarGzURL(URL, destination)
-	}
-	return DownloadFromRepoURL(URL, destination)
-}
-
-// DownloadFromTarGzURL downloads a tar.gz file from a URL
-// and extracts it to a destination
-func DownloadFromTarGzURL(URL string, destination string) error {
-	_ = os.MkdirAll(destination, 0700) // gives User rwx permission
-
-	pathToTempFile := destination + "/temp.tar.gz"
-	err := utils.DownloadFile(URL, pathToTempFile)
-	if err != nil {
-		return err
-	}
-	err = utils.UnTar(pathToTempFile, destination)
-	utils.DeleteTempFile(pathToTempFile)
-	return err
-}
-
-// DownloadFromRepoURL downloads a repo from a URL to a destination
-func DownloadFromRepoURL(repoURL string, destination string) error {
-	// expecting string in format 'https://github.com/<owner>/<repo>'
-	if strings.HasPrefix(repoURL, "https://") {
-		repoURL = strings.TrimPrefix(repoURL, "https://")
-	}
-	repoArray := strings.Split(repoURL, "/")
-	owner := repoArray[1]
-	repo := repoArray[2]
-	branch := "master"
-
-	zipURL, err := utils.GetZipURL(owner, repo, branch)
-	if err != nil {
-		return err
-	}
-
-	return DownloadAndExtractZip(zipURL, destination)
-}
-
-// DownloadAndExtractZip downloads a zip file from a URL
-// and extracts it to a destination
-func DownloadAndExtractZip(zipURL string, destination string) error {
-	time := time.Now().Format(time.RFC3339)
-	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
-	pathToTempZipFile := os.TempDir() + "_" + time + ".zip"
-
-	err := utils.DownloadFile(zipURL, pathToTempZipFile)
-	if err != nil {
-		return err
-	}
-
-	err = utils.UnZip(pathToTempZipFile, destination)
-	if err != nil {
-		return err
-	}
-
-	utils.DeleteTempFile(pathToTempZipFile)
-	return nil
 }
 
 // ValidateProject returns the language and buildType for a project at given filesystem path,
@@ -153,9 +85,4 @@ func writeCwSettingsIfNotInProject(projectPath string, BuildType string) {
 	} else if _, err := os.Stat(pathToCwSettings); os.IsNotExist(err) {
 		utils.WriteNewCwSettings(pathToCwSettings, BuildType)
 	}
-}
-
-// IsTarGzURL returns whether the provided URL is a tar.gz file
-func IsTarGzURL(URL string) bool {
-	return strings.HasSuffix(URL, ".tar.gz")
 }

--- a/actions/project.go
+++ b/actions/project.go
@@ -15,11 +15,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 	"path"
-	"strings"
-	"time"
 
 	"github.com/eclipse/codewind-installer/errors"
 	"github.com/eclipse/codewind-installer/utils"

--- a/actions/project_test.go
+++ b/actions/project_test.go
@@ -1,0 +1,226 @@
+package actions
+
+import (
+	"errors"
+	"io/ioutil"
+
+	"net/url"
+	"os"
+	"testing"
+	"path/filepath"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var exampleGitURL = "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
+var exampleZipURL = "https://codeload.github.com/microclimate-dev2ops/nodeExpressTemplate/legacy.zip/master"
+var exampleTarGzURL = "https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz"
+var testDir = "./testDir"
+
+func TestDownloadFromURLThenExtract(t *testing.T) {
+	tests := map[string]struct {
+		inURL          string
+		inDestination  string
+		wantedType     error
+		wantedNumFiles int
+	}{
+		"success case: input good Git URL": {
+			inURL:          exampleGitURL,
+			inDestination:  filepath.Join(testDir, "git"),
+			wantedType:     nil,
+			wantedNumFiles: 17,
+		},
+		"success case: input good zip URL": {
+			inURL:          exampleZipURL,
+			inDestination:  filepath.Join(testDir, "zip"),
+			wantedType:     nil,
+			wantedNumFiles: 17,
+		},
+		"success case: input good tar.gz URL": {
+			inURL:          exampleTarGzURL,
+			inDestination:  filepath.Join(testDir, "targz"),
+			wantedType:     nil,
+			wantedNumFiles: 6,
+		},
+		"fail case: input bad URL": {
+			inURL:          "bad URL",
+			inDestination:  filepath.Join(testDir, "badURL"),
+			wantedType:     new(url.Error),
+			wantedNumFiles: 0,
+		},
+		"fail case: input URL that doesn't return 200": {
+			inURL:          "/bad/URL",
+			inDestination:  filepath.Join(testDir, "badURL"),
+			wantedType:     errors.New(""),
+			wantedNumFiles: 0,
+		},
+	}
+	for name, test := range tests {
+		os.RemoveAll(testDir)
+		t.Run(name, func(t *testing.T) {
+			got := DownloadFromURLThenExtract(test.inURL, test.inDestination)
+			assert.IsType(t, test.wantedType, got, "Got: %s", got)
+
+			createdFiles, _ := ioutil.ReadDir(test.inDestination)
+			assert.Truef(t, len(createdFiles) == test.wantedNumFiles, "len(createdFiles) was %d but should have been %d. createdFiles: %s", len(createdFiles), test.wantedNumFiles, getFilenames(createdFiles))
+
+		})
+		os.RemoveAll(testDir)
+	}
+}
+
+func getFilenames(files []os.FileInfo) []string {
+	var filenames []string
+	for _, file := range files {
+		filenames = append(filenames, file.Name()+",")
+	}
+	return filenames
+}
+
+func TestDownloadFromRepoURL(t *testing.T) {
+	tests := map[string]struct {
+		inURL          string
+		inDestination  string
+		wantedType     error
+		wantedNumFiles int
+	}{
+		"success case: input good path": {
+			inURL:          exampleGitURL,
+			inDestination:  filepath.Join(testDir, "git"),
+			wantedType:     nil,
+			wantedNumFiles: 17,
+		},
+		"fail case: input URL that doesn't return 200": {
+			inURL:          "/bad/URL",
+			inDestination:  filepath.Join(testDir, "badURL"),
+			wantedType:     errors.New(""),
+			wantedNumFiles: 0,
+		},
+	}
+	for name, test := range tests {
+		os.RemoveAll(testDir)
+		t.Run(name, func(t *testing.T) {
+			got := DownloadFromRepoURL(test.inURL, test.inDestination)
+
+			assert.IsType(t, test.wantedType, got, "Got: %s", got)
+
+			createdFiles, _ := ioutil.ReadDir(test.inDestination)
+			assert.Truef(t, len(createdFiles) == test.wantedNumFiles, "len(createdFiles) was %d but should have been %d. createdFiles: %s", len(createdFiles), test.wantedNumFiles, getFilenames(createdFiles))
+
+		})
+		os.RemoveAll(testDir)
+	}
+}
+
+func TestDownloadAndExtractZip(t *testing.T) {
+	tests := map[string]struct {
+		inURL          string
+		inDestination  string
+		wantedType     error
+		wantedNumFiles int
+	}{
+		"success case: input good path": {
+			inURL:          exampleZipURL,
+			inDestination:  filepath.Join(testDir, "zip"),
+			wantedType:     nil,
+			wantedNumFiles: 17,
+		},
+		"fail case: input bad URL": {
+			inURL:          "/bad/URL",
+			inDestination:  filepath.Join(testDir, "badURL"),
+			wantedType:     new(url.Error),
+			wantedNumFiles: 0,
+		},
+		"fail case: input URL that doesn't provide JSON": {
+			inURL:          "https://www.google.com/",
+			inDestination:  filepath.Join(testDir, "badURL"),
+			wantedType:     errors.New(""),
+			wantedNumFiles: 0,
+		},
+	}
+	for name, test := range tests {
+		os.RemoveAll(testDir)
+		t.Run(name, func(t *testing.T) {
+			got := DownloadAndExtractZip(test.inURL, test.inDestination)
+
+			assert.IsType(t, test.wantedType, got, "Got: %s", got)
+
+			createdFiles, _ := ioutil.ReadDir(test.inDestination)
+			assert.Truef(t, len(createdFiles) == test.wantedNumFiles, "len(createdFiles) was %d but should have been %d. createdFiles: %s", len(createdFiles), test.wantedNumFiles, getFilenames(createdFiles))
+
+		})
+		os.RemoveAll(testDir)
+	}
+}
+
+func TestDownloadFromTarGzURL(t *testing.T) {
+	tests := map[string]struct {
+		inURL          string
+		inDestination  string
+		wantedType     error
+		wantedNumFiles int
+	}{
+		"success case: input good path": {
+			inURL:          exampleTarGzURL,
+			inDestination:  "./testDir",
+			wantedType:     nil,
+			wantedNumFiles: 6,
+		},
+		"fail case: input bad URL": {
+			inURL:          "/bad/URL",
+			inDestination:  filepath.Join(testDir, "badURL"),
+			wantedType:     new(url.Error),
+			wantedNumFiles: 0,
+		},
+		"fail case: input URL that doesn't provide JSON": {
+			inURL:          "https://www.google.com/",
+			inDestination:  filepath.Join(testDir, "badURL"),
+			wantedType:     errors.New(""),
+			wantedNumFiles: 0,
+		},
+	}
+	for name, test := range tests {
+		os.RemoveAll(testDir)
+		t.Run(name, func(t *testing.T) {
+
+			got := DownloadFromTarGzURL(test.inURL, test.inDestination)
+
+			assert.IsType(t, test.wantedType, got, "Got: %s", got)
+
+			createdFiles, _ := ioutil.ReadDir(test.inDestination)
+			assert.Truef(t, len(createdFiles) == test.wantedNumFiles, "len(createdFiles) was %d but should have been %d. createdFiles: %s", len(createdFiles), test.wantedNumFiles, getFilenames(createdFiles))
+
+		})
+		os.RemoveAll(testDir)
+	}
+}
+
+func TestIsTarGzURL(t *testing.T) {
+	tests := map[string]struct {
+		in   string
+		want bool
+	}{
+		"success case": {
+			in:   exampleTarGzURL,
+			want: true,
+		},
+		"fail case: git repo URL": {
+			in:   exampleGitURL,
+			want: false,
+		},
+		"fail case: zip URL": {
+			in:   exampleZipURL,
+			want: false,
+		},
+		"fail case: other string": {
+			in:   "not a targz",
+			want: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := IsTarGzURL(test.in)
+			assert.Equal(t, got, test.want)
+		})
+	}
+}

--- a/utils/download.go
+++ b/utils/download.go
@@ -1,0 +1,82 @@
+package utils
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// DownloadFromURLThenExtract downloads files from a URL
+// to a destination, extracting them if necessary
+func DownloadFromURLThenExtract(URL string, destination string) error {
+	if _, err := url.ParseRequestURI(URL); err != nil {
+		return err
+	}
+
+	if IsTarGzURL(URL) {
+		return DownloadFromTarGzURL(URL, destination)
+	}
+	return DownloadFromRepoURL(URL, destination)
+}
+
+// DownloadFromTarGzURL downloads a tar.gz file from a URL
+// and extracts it to a destination
+func DownloadFromTarGzURL(URL string, destination string) error {
+	_ = os.MkdirAll(destination, 0700) // gives User rwx permission
+
+	pathToTempFile := destination + "/temp.tar.gz"
+	err := DownloadFile(URL, pathToTempFile)
+	if err != nil {
+		return err
+	}
+	err = UnTar(pathToTempFile, destination)
+	DeleteTempFile(pathToTempFile)
+	return err
+}
+
+// DownloadFromRepoURL downloads a repo from a URL to a destination
+func DownloadFromRepoURL(repoURL string, destination string) error {
+	// expecting string in format 'https://github.com/<owner>/<repo>'
+	if strings.HasPrefix(repoURL, "https://") {
+		repoURL = strings.TrimPrefix(repoURL, "https://")
+	}
+	repoArray := strings.Split(repoURL, "/")
+	owner := repoArray[1]
+	repo := repoArray[2]
+	branch := "master"
+
+	zipURL, err := GetZipURL(owner, repo, branch)
+	if err != nil {
+		return err
+	}
+
+	return DownloadAndExtractZip(zipURL, destination)
+}
+
+// DownloadAndExtractZip downloads a zip file from a URL
+// and extracts it to a destination
+func DownloadAndExtractZip(zipURL string, destination string) error {
+	time := time.Now().Format(time.RFC3339)
+	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
+	pathToTempZipFile := os.TempDir() + "_" + time + ".zip"
+
+	err := DownloadFile(zipURL, pathToTempZipFile)
+	if err != nil {
+		return err
+	}
+
+	err = UnZip(pathToTempZipFile, destination)
+	if err != nil {
+		return err
+	}
+
+	DeleteTempFile(pathToTempZipFile)
+	return nil
+}
+
+
+// IsTarGzURL returns whether the provided URL is a tar.gz file
+func IsTarGzURL(URL string) bool {
+	return strings.HasSuffix(URL, ".tar.gz")
+}

--- a/utils/download.go
+++ b/utils/download.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"path"
 )
 
 // DownloadFromURLThenExtract downloads files from a URL
@@ -25,7 +26,7 @@ func DownloadFromURLThenExtract(URL string, destination string) error {
 func DownloadFromTarGzURL(URL string, destination string) error {
 	_ = os.MkdirAll(destination, 0700) // gives User rwx permission
 
-	pathToTempFile := destination + "/temp.tar.gz"
+	pathToTempFile := path.Join(destination, "temp.tar.gz")
 	err := DownloadFile(URL, pathToTempFile)
 	if err != nil {
 		return err
@@ -74,7 +75,6 @@ func DownloadAndExtractZip(zipURL string, destination string) error {
 	DeleteTempFile(pathToTempZipFile)
 	return nil
 }
-
 
 // IsTarGzURL returns whether the provided URL is a tar.gz file
 func IsTarGzURL(URL string) bool {

--- a/utils/download_test.go
+++ b/utils/download_test.go
@@ -1,4 +1,4 @@
-package actions
+package utils
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 	"path/filepath"
+	"fmt"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -66,6 +67,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 
 		})
 		os.RemoveAll(testDir)
+		fmt.Println()
 	}
 }
 
@@ -109,6 +111,7 @@ func TestDownloadFromRepoURL(t *testing.T) {
 
 		})
 		os.RemoveAll(testDir)
+		fmt.Println()
 	}
 }
 
@@ -150,6 +153,7 @@ func TestDownloadAndExtractZip(t *testing.T) {
 
 		})
 		os.RemoveAll(testDir)
+		fmt.Println()
 	}
 }
 
@@ -192,6 +196,7 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 
 		})
 		os.RemoveAll(testDir)
+		fmt.Println()
 	}
 }
 

--- a/utils/download_test.go
+++ b/utils/download_test.go
@@ -2,13 +2,12 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
-	"testing"
 	"path/filepath"
-	"fmt"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -82,7 +82,7 @@ func DeleteTempFile(filePath string) (bool, error) {
 	}
 
 	os.Remove(filePath)
-	log.Printf("Deleted file: %s\n\n", filePath)
+	// fmt.Printf("==> Deleted file: %s\n", filePath)
 	return true, nil
 }
 
@@ -144,7 +144,7 @@ func DownloadFile(URL, destination string) error {
 
 	// Write body to file
 	_, err = io.Copy(file, resp.Body)
-	log.Printf("Downloaded file: from '%s' to '%s'\n", URL, destination)
+	fmt.Printf("Downloaded file from '%s' to '%s'\n", URL, destination)
 
 	return err
 }
@@ -172,10 +172,10 @@ func UnZip(filePath, destination string) error {
 		}
 
 		if file.FileInfo().IsDir() {
-			// log.Println("Directory Created:", extractedFilePath)
+			// fmt.Println("Directory Created:", extractedFilePath)
 			os.MkdirAll(extractedFilePath, file.Mode())
 		} else {
-			// log.Println("File extracted:", file.Name)
+			// fmt.Println("File extracted:", file.Name)
 
 			outputFile, err := os.OpenFile(
 				extractedFilePath,
@@ -189,7 +189,7 @@ func UnZip(filePath, destination string) error {
 			errors.CheckErr(err, 404, "")
 		}
 	}
-	log.Printf("Extracted file: from '%s' to '%s'\n", filePath, destination)
+	fmt.Printf("Extracted file from '%s' to '%s'\n", filePath, destination)
 	return nil
 }
 
@@ -213,22 +213,22 @@ func UnTar(pathToTarFile, destination string) error {
 			break
 		}
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 		target := filepath.Join(destination, header.Name)
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 		case tar.TypeReg:
 			fileToOverwrite, err := overwrite(target)
 			defer fileToOverwrite.Close()
 			if err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 			if _, err := io.Copy(fileToOverwrite, tarReader); err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 		default:
 			log.Printf("Can't: %c, %s\n", header.Typeflag, target)

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -233,7 +233,7 @@ func UnTar(pathToTarFile, destination string) error {
 				log.Fatal(err)
 			}
 		default:
-			log.Printf("Can't: %c, %s\n", header.Typeflag, target)
+			log.Printf("Can't extract to %s: unknown typeflag %c\n", target, header.Typeflag)
 		}
 	}
 	return nil

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -112,7 +112,7 @@ func PingHealth(healthEndpoint string) bool {
 	return started
 }
 
-//GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
+// GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
 func GetZipURL(owner, repo, branch string) (string, error) {
 	client := github.NewClient(nil)
 
@@ -126,7 +126,7 @@ func GetZipURL(owner, repo, branch string) (string, error) {
 	return url, nil
 }
 
-//DownloadFile from URL to file destination
+// DownloadFile from URL to file destination
 func DownloadFile(URL, destination string) error {
 	// Get the data
 	resp, err := http.Get(URL)
@@ -149,7 +149,7 @@ func DownloadFile(URL, destination string) error {
 	return err
 }
 
-//UnZip unzips a file to a destination
+// UnZip unzips a file to a destination
 func UnZip(filePath, destination string) error {
 	zipReader, _ := zip.OpenReader(filePath)
 	if zipReader == nil {
@@ -172,9 +172,11 @@ func UnZip(filePath, destination string) error {
 		}
 
 		if file.FileInfo().IsDir() {
+			// For debug:
 			// fmt.Println("Directory Created:", extractedFilePath)
 			os.MkdirAll(extractedFilePath, file.Mode())
 		} else {
+			// For debug:
 			// fmt.Println("File extracted:", file.Name)
 
 			outputFile, err := os.OpenFile(
@@ -195,7 +197,7 @@ func UnZip(filePath, destination string) error {
 
 // UnTar unpacks a tar.gz file to a destination
 func UnTar(pathToTarFile, destination string) error {
-	fileReader, err := read(pathToTarFile)
+	fileReader, err := readFile(pathToTarFile)
 	if err != nil {
 		return err
 	}
@@ -222,7 +224,7 @@ func UnTar(pathToTarFile, destination string) error {
 				log.Fatal(err)
 			}
 		case tar.TypeReg:
-			fileToOverwrite, err := overwrite(target)
+			fileToOverwrite, err := overwriteFile(target)
 			defer fileToOverwrite.Close()
 			if err != nil {
 				log.Fatal(err)
@@ -237,8 +239,8 @@ func UnTar(pathToTarFile, destination string) error {
 	return nil
 }
 
-func overwrite(filePath string) (*os.File, error) {
-	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_TRUNC, 0777)
+func overwriteFile(filePath string) (*os.File, error) {
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_TRUNC, 0777) // gives everyone rwx permission
 	if err != nil {
 		file, err = os.Create(filePath)
 		if err != nil {
@@ -248,8 +250,8 @@ func overwrite(filePath string) (*os.File, error) {
 	return file, nil
 }
 
-func read(filePath string) (*os.File, error) {
-	file, err := os.OpenFile(filePath, os.O_RDONLY, 0444)
+func readFile(filePath string) (*os.File, error) {
+	file, err := os.OpenFile(filePath, os.O_RDONLY, 0444) // gives everyone read permission
 	if err != nil {
 		return file, err
 	}

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -13,6 +13,8 @@ package utils
 
 import (
 	"archive/zip"
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -30,17 +32,16 @@ import (
 )
 
 // CreateTempFile in the same directory as the binary for docker compose
-func CreateTempFile(tempFilePath string) bool {
-
-	var _, err = os.Stat(tempFilePath)
+func CreateTempFile(filePath string) bool {
+	var _, err = os.Stat(filePath)
 
 	// create file if not exists
 	if os.IsNotExist(err) {
-		var file, err = os.Create(tempFilePath)
+		var file, err = os.Create(filePath)
 		errors.CheckErr(err, 201, "")
 		defer file.Close()
 
-		fmt.Println("==> created file", tempFilePath)
+		fmt.Println("==> created file", filePath)
 		return true
 	}
 	return false
@@ -61,7 +62,7 @@ func WriteToComposeFile(tempFilePath string, debug bool) bool {
 	errors.CheckErr(err, 203, "")
 
 	if debug == true {
-		fmt.Printf("==> "+tempFilePath+" structure is: \n%s\n\n", string(marshalledData))
+		fmt.Printf("==> %s structure is: \n%s\n\n", tempFilePath, string(marshalledData))
 	} else {
 		fmt.Println("==> environment structure written to " + tempFilePath)
 	}
@@ -72,17 +73,16 @@ func WriteToComposeFile(tempFilePath string, debug bool) bool {
 }
 
 // DeleteTempFile once the the Codewind environment has been created
-func DeleteTempFile(tempFilePath string) (boolean bool, err error) {
-
-	var _, file = os.Stat(tempFilePath)
+func DeleteTempFile(filePath string) (bool, error) {
+	var _, file = os.Stat(filePath)
 
 	if os.IsNotExist(file) {
 		errors.CheckErr(file, 206, "No files to delete")
 		return false, file
 	}
 
-	os.Remove(tempFilePath)
-	fmt.Println("==> finished deleting file " + tempFilePath)
+	os.Remove(filePath)
+	log.Printf("Deleted file: %s\n\n", filePath)
 	return true, nil
 }
 
@@ -113,63 +113,69 @@ func PingHealth(healthEndpoint string) bool {
 }
 
 //GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
-func GetZipURL(owner, repo, branch string) string {
+func GetZipURL(owner, repo, branch string) (string, error) {
 	client := github.NewClient(nil)
 
 	opt := &github.RepositoryContentGetOptions{Ref: branch}
 
 	URL, _, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt)
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 	url := URL.String()
-	fmt.Println("Repository archive link - ", URL)
-	return url
+	return url, nil
 }
 
-//DownloadFile into /temp dir using the git archive link
-func DownloadFile(zipFileName, url string) error {
-
+//DownloadFile from URL to file destination
+func DownloadFile(URL, destination string) error {
 	// Get the data
-	resp, err := http.Get(url)
-	errors.CheckErr(err, 400, "")
+	resp, err := http.Get(URL)
+	if err != nil {
+		return err
+	}
 	defer resp.Body.Close()
 
 	// Create the file
-	file, err := os.Create(zipFileName)
-	errors.CheckErr(err, 401, "")
+	file, err := os.Create(destination)
+	if err != nil {
+		return err
+	}
 	defer file.Close()
 
 	// Write body to file
 	_, err = io.Copy(file, resp.Body)
-	fmt.Println(zipFileName)
+	log.Printf("Downloaded file: from '%s' to '%s'\n", URL, destination)
 
 	return err
 }
 
-//UnZip downloaded file
-func UnZip(zipFileName, fileDestination string) {
-	zipReader, _ := zip.OpenReader(zipFileName)
+//UnZip unzips a file to a destination
+func UnZip(filePath, destination string) error {
+	zipReader, _ := zip.OpenReader(filePath)
+	if zipReader == nil {
+		return fmt.Errorf("file '%s' is empty", filePath)
+	}
 
-	var extractedFilePath = ""
-	for _, file := range zipReader.Reader.File {
+	var extractedFilePath string
+	zipFiles := zipReader.Reader.File
+	for _, file := range zipFiles {
 
 		zippedFile, err := file.Open()
 		errors.CheckErr(err, 402, "")
 		defer zippedFile.Close()
 
 		fileNameArr := strings.Split(file.Name, "/")
-		extractedFilePath = fileDestination
+		extractedFilePath = destination
 
 		for i := 1; i < len(fileNameArr); i++ {
 			extractedFilePath = filepath.Join(extractedFilePath, fileNameArr[i])
 		}
 
 		if file.FileInfo().IsDir() {
-			log.Println("Directory Created:", extractedFilePath)
+			// log.Println("Directory Created:", extractedFilePath)
 			os.MkdirAll(extractedFilePath, file.Mode())
 		} else {
-			log.Println("File extracted:", file.Name)
+			// log.Println("File extracted:", file.Name)
 
 			outputFile, err := os.OpenFile(
 				extractedFilePath,
@@ -183,5 +189,69 @@ func UnZip(zipFileName, fileDestination string) {
 			errors.CheckErr(err, 404, "")
 		}
 	}
-	log.Println("File extracted:", zipFileName)
+	log.Printf("Extracted file: from '%s' to '%s'\n", filePath, destination)
+	return nil
+}
+
+// UnTar unpacks a tar.gz file to a destination
+func UnTar(pathToTarFile, destination string) error {
+	fileReader, err := read(pathToTarFile)
+	if err != nil {
+		return err
+	}
+	defer fileReader.Close()
+	gzipReader, err := gzip.NewReader(fileReader)
+	if err != nil {
+		return err
+	}
+	defer gzipReader.Close()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+		target := filepath.Join(destination, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				panic(err)
+			}
+		case tar.TypeReg:
+			fileToOverwrite, err := overwrite(target)
+			defer fileToOverwrite.Close()
+			if err != nil {
+				panic(err)
+			}
+			if _, err := io.Copy(fileToOverwrite, tarReader); err != nil {
+				panic(err)
+			}
+		default:
+			log.Printf("Can't: %c, %s\n", header.Typeflag, target)
+		}
+	}
+	return nil
+}
+
+func overwrite(filePath string) (*os.File, error) {
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_TRUNC, 0777)
+	if err != nil {
+		file, err = os.Create(filePath)
+		if err != nil {
+			return file, err
+		}
+	}
+	return file, nil
+}
+
+func read(filePath string) (*os.File, error) {
+	file, err := os.OpenFile(filePath, os.O_RDONLY, 0444)
+	if err != nil {
+		return file, err
+	}
+	return file, nil
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## Problem
- The work done under https://github.com/eclipse/codewind/pull/62 has added the ability to create projects from urls that point to .tar.gz files. We need to add the same functionality to the installer.
- Our existing download functions were not covered by tests.

## Solution
- Write a function to download and extract `.tar.gz` files from appropriate URLs
- Cover our download functions in tests.

## Tested
Automatically. Output: 
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/18170169/63039448-35115180-bebb-11e9-93d8-3278b87595c0.png">

## Extra
- Renamed some variables for clarity (e.g. `tempFilePath` was actually a generic `filePath`)
- Make functions return errors so that we can handle them appropriately