### PR TITLE
Remove image by tag

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -132,12 +132,7 @@ func Commands() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "tag, t",
-					Value: "latest",
 					Usage: "dockerhub image tag",
-				},
-				cli.BoolFlag{
-					Name:  "alltags, at",
-					Usage: "remove all tagged codewind images",
 				},
 			},
 			Usage: "Remove Codewind/Project docker images and the codewind network",

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -129,9 +129,20 @@ func Commands() {
 		{
 			Name:    "remove",
 			Aliases: []string{"rm"},
-			Usage:   "Remove Codewind/Project docker images and the codewind network",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "tag, t",
+					Value: "latest",
+					Usage: "dockerhub image tag",
+				},
+				cli.BoolFlag{
+					Name:  "alltags, at",
+					Usage: "remove all tagged codewind images",
+				},
+			},
+			Usage: "Remove Codewind/Project docker images and the codewind network",
 			Action: func(c *cli.Context) error {
-				RemoveCommand()
+				RemoveCommand(c)
 				return nil
 			},
 		},

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -22,7 +22,6 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand(c *cli.Context) {
 	tag := c.String("tag")
-	allTags := c.Bool("alltags")
 	imageArr := [4]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
@@ -30,7 +29,7 @@ func RemoveCommand(c *cli.Context) {
 	imageArr[3] = "cw-"
 	networkName := "codewind"
 
-	if allTags == true {
+	if tag != "" {
 		for i := 0; i < len(imageArr); i++ {
 			if i == 3 {
 				break

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -16,16 +16,28 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/utils"
+	"github.com/urfave/cli"
 )
 
 //RemoveCommand to remove all codewind and project images
-func RemoveCommand() {
+func RemoveCommand(c *cli.Context) {
+	tag := c.String("tag")
+	allTags := c.Bool("alltags")
 	imageArr := [4]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
 	imageArr[2] = "eclipse/codewind-initialize"
 	imageArr[3] = "cw-"
 	networkName := "codewind"
+
+	if allTags == true {
+		for i := 0; i < len(imageArr); i++ {
+			if i == 3 {
+				break
+			}
+			imageArr[i] = imageArr[i] + "-amd64:" + tag
+		}
+	}
 
 	images := utils.GetImageList()
 


### PR DESCRIPTION
**Problem #50**
The installer `remove` command will remove all codewind images. As releases happen, the chances of having multiple images with different tags increases. Therefore the instaler needs to be able to remove a select image should a tag be provided.

**Solution**
This will expect no codewind images to be running on the machine at time of removal.
1. If no tag is provided, continue to remove all images (default behavior) - `./installer rm`
2. Providing a tag will modify the array indexes to contain the image tag so that an exact match can be found when searching the image list for images to remove - `./installer rm -t 0.2`

**Testing**
Bats output:
```
✓ invoke install command - default to latest tag
 ✓ invoke install command - image 0.2
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove dockerhub images (0.2)
 ✓ invoke remove command - remove dockerhub images (latest)
 ✓ invoke project command - using -r download microclimate-dev2ops/microclimateGoTemplate into ./downloadtest

7 tests, 0 failures
```
Signed-off-by: Liam Hampton liam.hampton@ibm.com