### PR TITLE
Check ports

### DIFF
--- a/utils/docker.go
+++ b/utils/docker.go
@@ -313,7 +313,7 @@ func GetPFEHostAndPort() (string, string) {
 	return "",""
 }
 
-// IsTCPPortAvailable checks to see if a specified port is available
+// IsTCPPortAvailable checks to find the next available port and returns it
 func IsTCPPortAvailable() (bool, string) {
 	var status string
 	const (

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -328,7 +328,7 @@ func IsTCPPortAvailable() (bool, string) {
 			log.Println(status)
 		} else {
 			status = "Port " + strconv.Itoa(port) + " Available"
-			log.Println(status)
+			fmt.Println(status)
 			conn.Close()
 			return true, strconv.Itoa(port)
 		}

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -16,11 +16,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
+	"net"
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -113,7 +115,7 @@ func DockerCompose(tag string) {
 	}
 	os.Setenv("HOST_OS", GOOS)
 	os.Setenv("COMPOSE_PROJECT_NAME", "codewind")
-	os.Setenv("HOST_MAVEN_OPTS", os.Getenv("MAVEN_OPTS"))         
+	os.Setenv("HOST_MAVEN_OPTS", os.Getenv("MAVEN_OPTS"))
 
 	cmd := exec.Command("docker-compose", "-f", "installer-docker-compose.yaml", "up", "-d")
 	output := new(bytes.Buffer)
@@ -309,4 +311,27 @@ func GetPFEHostAndPort() (string, string) {
 		}
 	}
 	return "",""
+}
+
+// IsTCPPortAvailable checks to see if a specified port is available
+func IsTCPPortAvailable() (bool, string) {
+	var status string
+	const (
+		minTCPPort = 10000
+		maxTCPPort = 11000
+	)
+	for port := minTCPPort; port < maxTCPPort; port++ {
+		conn, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+		if err != nil {
+			log.Println("Connection error:", err)
+			status = "Port " + strconv.Itoa(port) + " Unreachable"
+			log.Println(status)
+		} else {
+			status = "Port " + strconv.Itoa(port) + " Available"
+			log.Println(status)
+			conn.Close()
+			return true, strconv.Itoa(port)
+		}
+	}
+	return false, ""
 }


### PR DESCRIPTION
This supercedes PR https://github.com/eclipse/codewind-installer/pull/71

### Problem #69
There is an issue where docker will select and assign a random port, or at least attempt to. If the port is restricted or unreachable then it will fail to do so.

### Solution
Write a function to check for a free port within the range specified 10000 -> 11000. It will return a bool & port number. This will then allow docker to use it knowing it is available. The checked port is inserted into the docker compose yaml via an environment property.

### Tested
Manually - output:

```
C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>go run main.go start
Debug: false
==> created file installer-docker-compose.yaml
==> environment structure written to installer-docker-compose.yaml
System architecture is:  amd64
Host operating system is:  windows
Attempting to find available port
2019/08/15 16:49:34 Unable to connect to port 10000 : listen tcp 127.0.0.1:10000: bind: An attempt was made to access a socket in a way forbidden by its access permissions.
2019/08/15 16:49:34 Port 10000 Unreachable
Port 10001 Available
Please wait whilst containers initialize...
Creating codewind-performance ...
[1BCreating codewind-pfe         ... mdone[0m
[1B==> finished deleting file installer-docker-compose.yaml
Waiting for Codewind to start
.
HTTP Response Status: 200 OK
Codewind successfully started on http://127.0.0.1:10001
```

### Extra
Removed some white space elsewhere in the file