### PR TITLE
report status of codewind

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -101,11 +101,6 @@ func Commands() {
 					Name:  "json, j",
 					Usage: "specify terminal output",
 				},
-				cli.StringFlag{
-					Name:  "tag, t",
-					Value: "latest",
-					Usage: "dockerhub image tag",
-				},
 			},
 			Action: func(c *cli.Context) error {
 				StatusCommand(c)

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -101,6 +101,11 @@ func Commands() {
 					Name:  "json, j",
 					Usage: "specify terminal output",
 				},
+				cli.StringFlag{
+					Name:  "tag, t",
+					Value: "latest",
+					Usage: "dockerhub image tag",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				StatusCommand(c)

--- a/actions/status.go
+++ b/actions/status.go
@@ -28,6 +28,9 @@ func StatusCommand(c *cli.Context) {
 		hostname, port := utils.GetPFEHostAndPort()
 		if jsonOutput {
 
+			imageTagArr := utils.GetImageTag()
+			containerTagArr := utils.GetContainerTag()
+
 			type status struct {
 				Status   string   `json:"status"`
 				URL      string   `json:"url"`
@@ -35,8 +38,6 @@ func StatusCommand(c *cli.Context) {
 				Started  []string `json:"started"`
 			}
 
-			imageTagArr := utils.GetImageTag()
-			containerTagArr := utils.GetContainerTag()
 			resp := &status{
 				Status:   "started",
 				URL:      "http://" + hostname + ":" + port,
@@ -44,7 +45,6 @@ func StatusCommand(c *cli.Context) {
 				Started:  containerTagArr,
 			}
 
-			//output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://" + hostname + ":" + port})
 			output, _ := json.Marshal(resp)
 			fmt.Println(string(output))
 		} else {
@@ -54,8 +54,10 @@ func StatusCommand(c *cli.Context) {
 	}
 
 	if utils.CheckImageStatus() {
-		// INSTALLED NOT STARTED
+		// INSTALLED BUT NOT STARTED
 		if jsonOutput {
+
+			imageTagArr := utils.GetImageTag()
 
 			type status struct {
 				Status   string   `json:"status"`
@@ -63,10 +65,9 @@ func StatusCommand(c *cli.Context) {
 				Started  []string `json:"started"`
 			}
 
-			tagArr := utils.GetImageTag()
 			resp := &status{
 				Status:   "stopped",
-				Versions: tagArr,
+				Versions: imageTagArr,
 				Started:  []string{},
 			}
 

--- a/actions/status.go
+++ b/actions/status.go
@@ -62,13 +62,11 @@ func StatusCommand(c *cli.Context) {
 			type status struct {
 				Status   string   `json:"status"`
 				Versions []string `json:"installed-versions"`
-				Started  []string `json:"started"`
 			}
 
 			resp := &status{
 				Status:   "stopped",
 				Versions: imageTagArr,
-				Started:  []string{},
 			}
 
 			output, _ := json.Marshal(resp)

--- a/actions/status.go
+++ b/actions/status.go
@@ -12,11 +12,12 @@
 package actions
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
-	"encoding/json"
-	"github.com/urfave/cli"
+
 	"github.com/eclipse/codewind-installer/utils"
+	"github.com/urfave/cli"
 )
 
 //StatusCommand to show the status
@@ -25,7 +26,7 @@ func StatusCommand(c *cli.Context) {
 	if utils.CheckContainerStatus() {
 		hostname, port := utils.GetPFEHostAndPort()
 		if jsonOutput {
-			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://"+ hostname + ":" + port})
+			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://" + hostname + ":" + port})
 			fmt.Println(string(output))
 		} else {
 			fmt.Println("Codewind is installed and running on http://" + hostname + ":" + port)
@@ -34,10 +35,23 @@ func StatusCommand(c *cli.Context) {
 	}
 
 	if utils.CheckImageStatus() {
+
 		if jsonOutput {
-			output, _ := json.Marshal(map[string]string{"status": "stopped"})
+
+			type status struct {
+				Status   string   `json:"status"`
+				Versions []string `json:"installed-versions"`
+			}
+
+			tagArr := utils.GetImageTag()
+			resp := &status{
+				Status:   "stopped",
+				Versions: tagArr,
+			}
+
+			output, _ := json.Marshal(resp)
 			fmt.Println(string(output))
-	  } else {
+		} else {
 			fmt.Println("Codewind is installed but not running")
 		}
 		os.Exit(0)

--- a/actions/status.go
+++ b/actions/status.go
@@ -24,9 +24,28 @@ import (
 func StatusCommand(c *cli.Context) {
 	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {
+		// STARTED
 		hostname, port := utils.GetPFEHostAndPort()
 		if jsonOutput {
-			output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://" + hostname + ":" + port})
+
+			type status struct {
+				Status   string   `json:"status"`
+				URL      string   `json:"url"`
+				Versions []string `json:"installed-versions"`
+				Started  []string `json:"started"`
+			}
+
+			tagArr := utils.GetImageTag()
+			startedArr := utils.GetStartedTag()
+			resp := &status{
+				Status:   "started",
+				URL:      "http://" + hostname + ":" + port,
+				Versions: tagArr,
+				Started:  startedArr,
+			}
+
+			//output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://" + hostname + ":" + port})
+			output, _ := json.Marshal(resp)
 			fmt.Println(string(output))
 		} else {
 			fmt.Println("Codewind is installed and running on http://" + hostname + ":" + port)
@@ -35,18 +54,20 @@ func StatusCommand(c *cli.Context) {
 	}
 
 	if utils.CheckImageStatus() {
-
+		// INSTALLED NOT STARTED
 		if jsonOutput {
 
 			type status struct {
 				Status   string   `json:"status"`
 				Versions []string `json:"installed-versions"`
+				Started  []string `json:"started"`
 			}
 
 			tagArr := utils.GetImageTag()
 			resp := &status{
 				Status:   "stopped",
 				Versions: tagArr,
+				Started:  []string{},
 			}
 
 			output, _ := json.Marshal(resp)
@@ -56,6 +77,7 @@ func StatusCommand(c *cli.Context) {
 		}
 		os.Exit(0)
 	} else {
+		// NOT INSTALLED
 		if jsonOutput {
 			output, _ := json.Marshal(map[string]string{"status": "uninstalled"})
 			fmt.Println(string(output))

--- a/actions/status.go
+++ b/actions/status.go
@@ -28,8 +28,8 @@ func StatusCommand(c *cli.Context) {
 		hostname, port := utils.GetPFEHostAndPort()
 		if jsonOutput {
 
-			imageTagArr := utils.GetImageTag()
-			containerTagArr := utils.GetContainerTag()
+			imageTagArr := utils.GetImageTags()
+			containerTagArr := utils.GetContainerTags()
 
 			type status struct {
 				Status   string   `json:"status"`
@@ -57,7 +57,7 @@ func StatusCommand(c *cli.Context) {
 		// INSTALLED BUT NOT STARTED
 		if jsonOutput {
 
-			imageTagArr := utils.GetImageTag()
+			imageTagArr := utils.GetImageTags()
 
 			type status struct {
 				Status   string   `json:"status"`

--- a/actions/status.go
+++ b/actions/status.go
@@ -35,13 +35,13 @@ func StatusCommand(c *cli.Context) {
 				Started  []string `json:"started"`
 			}
 
-			tagArr := utils.GetImageTag()
-			startedArr := utils.GetStartedTag()
+			imageTagArr := utils.GetImageTag()
+			containerTagArr := utils.GetContainerTag()
 			resp := &status{
 				Status:   "started",
 				URL:      "http://" + hostname + ":" + port,
-				Versions: tagArr,
-				Started:  startedArr,
+				Versions: imageTagArr,
+				Started:  containerTagArr,
 			}
 
 			//output, _ := json.Marshal(map[string]string{"status": "started", "url": "http://" + hostname + ":" + port})

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -325,8 +325,8 @@ func GetPFEHostAndPort() (string, string) {
 	return "", ""
 }
 
-// GetImageTag of Codewind images
-func GetImageTag() []string {
+// GetImageTags of Codewind images
+func GetImageTags() []string {
 	imageArr := [3]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
@@ -352,7 +352,7 @@ func GetImageTag() []string {
 		}
 	}
 
-	tagArr = RemoveArrayDuplicate(tagArr)
+	tagArr = RemoveDuplicateEntries(tagArr)
 	return tagArr
 }
 
@@ -373,8 +373,8 @@ func IsTCPPortAvailable(minTCPPort int, maxTCPPort int) (bool, string) {
 	return false, ""
 }
 
-// GetContainerTag of the Codewind version(s) currently running
-func GetContainerTag() []string {
+// GetContainerTags of the Codewind version(s) currently running
+func GetContainerTags() []string {
 	containerArr := [2]string{}
 	containerArr[0] = "codewind-pfe"
 	containerArr[1] = "codewind-performance"
@@ -391,6 +391,6 @@ func GetContainerTag() []string {
 		}
 	}
 
-	tagArr = RemoveArrayDuplicate(tagArr)
+	tagArr = RemoveDuplicateEntries(tagArr)
 	return tagArr
 }

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -358,25 +358,8 @@ func GetImageTag() []string {
 		}
 	}
 
-	//fmt.Println("FULL tag array = ", tagArr)
-
-	// Use map to record duplicates if found
-	encountered := map[string]bool{}
-	result := []string{}
-
-	for element := range tagArr {
-		if encountered[tagArr[element]] == true {
-			// Don't add duplicate
-		} else {
-			// Record said element as an encountered
-			encountered[tagArr[element]] = true
-			// Append to the new result slice
-			result = append(result, tagArr[element])
-		}
-	}
-
-	//fmt.Println("refactored result =  ", result)
-	return result
+	tagArr = RemoveArrayDuplicate(tagArr)
+	return tagArr
 }
 
 // IsTCPPortAvailable checks to find the next available port and returns it
@@ -394,4 +377,26 @@ func IsTCPPortAvailable(minTCPPort int, maxTCPPort int) (bool, string) {
 		}
 	}
 	return false, ""
+// GetContainerTag of the Codewind version(s) currently running
+func GetContainerTag() []string {
+	containerArr := [2]string{}
+	containerArr[0] = "codewind-pfe"
+	containerArr[1] = "codewind-performance"
+	tagArr := []string{}
+
+	containers := GetContainerList()
+
+	for _, container := range containers {
+		for _, key := range containerArr {
+			if strings.HasPrefix(container.Image, key) {
+				fmt.Println(container.Image)
+				tag := strings.Split(container.Image, ":")[1]
+				fmt.Println("container tag: ", tag)
+				tagArr = append(tagArr, tag)
+			}
+		}
+	}
+
+	tagArr = RemoveArrayDuplicate(tagArr)
+	return tagArr
 }

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -328,10 +328,10 @@ func GetPFEHostAndPort() (string, string) {
 
 // GetImageTag of Codewind images
 func GetImageTag() []string {
-	keyArr := [3]string{}
-	keyArr[0] = "eclipse/codewind-pfe"
-	keyArr[1] = "eclipse/codewind-performance"
-	keyArr[2] = "eclipse/codewind-initialize"
+	imageArr := [3]string{}
+	imageArr[0] = "eclipse/codewind-pfe"
+	imageArr[1] = "eclipse/codewind-performance"
+	imageArr[2] = "eclipse/codewind-initialize"
 	tagArr := []string{}
 
 	images := utils.GetImageList()
@@ -339,7 +339,7 @@ func GetImageTag() []string {
 	for _, image := range images {
 		imageRepo := strings.Join(image.RepoDigests, " ")
 		imageTags := strings.Join(image.RepoTags, " ")
-		for _, key := range keyArr {
+		for _, key := range imageArr {
 			if strings.HasPrefix(imageRepo, key) || strings.HasPrefix(imageTags, key) {
 				if len(image.RepoTags) > 0 {
 					tag := image.RepoTags[0]

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
 	"github.com/eclipse/codewind-installer/errors"
-	"github.com/eclipse/codewind-installer/utils"
 	"github.com/moby/moby/client"
 )
 
@@ -334,7 +333,7 @@ func GetImageTag() []string {
 	imageArr[2] = "eclipse/codewind-initialize"
 	tagArr := []string{}
 
-	images := utils.GetImageList()
+	images := GetImageList()
 
 	for _, image := range images {
 		imageRepo := strings.Join(image.RepoDigests, " ")

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -335,18 +335,13 @@ func GetImageTag() []string {
 	tagArr := []string{}
 
 	images := utils.GetImageList()
-	//fmt.Println(images)
-
-	fmt.Println("Searching images for a match..")
 
 	for _, image := range images {
 		imageRepo := strings.Join(image.RepoDigests, " ")
 		imageTags := strings.Join(image.RepoTags, " ")
-		//fmt.Println(imageTags)
 		for _, key := range keyArr {
 			if strings.HasPrefix(imageRepo, key) || strings.HasPrefix(imageTags, key) {
 				if len(image.RepoTags) > 0 {
-					fmt.Println("Image + tag: ", image.RepoTags[0])
 					tag := image.RepoTags[0]
 					tag = strings.Split(tag, ":")[1]
 					tagArr = append(tagArr, tag)
@@ -389,9 +384,7 @@ func GetContainerTag() []string {
 	for _, container := range containers {
 		for _, key := range containerArr {
 			if strings.HasPrefix(container.Image, key) {
-				fmt.Println(container.Image)
 				tag := strings.Split(container.Image, ":")[1]
-				fmt.Println("container tag: ", tag)
 				tagArr = append(tagArr, tag)
 			}
 		}

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -372,6 +372,8 @@ func IsTCPPortAvailable(minTCPPort int, maxTCPPort int) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
 // GetContainerTag of the Codewind version(s) currently running
 func GetContainerTag() []string {
 	containerArr := [2]string{}

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -28,8 +28,8 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
 	"github.com/eclipse/codewind-installer/errors"
+	"github.com/eclipse/codewind-installer/utils"
 	"github.com/moby/moby/client"
-	"github.ibm.com/codewind-installer/utils"
 )
 
 // docker-compose yaml data

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+// RemoveArrayDuplicate elements
+func RemoveArrayDuplicate(tagArr []string) []string {
+	// Use map to record duplicates if found
+	encountered := map[string]bool{}
+	result := []string{}
+
+	for element := range tagArr {
+		if encountered[tagArr[element]] == true {
+			// Don't add duplicate
+		} else {
+			// Record said element as an encountered
+			encountered[tagArr[element]] = true
+			// Append to the new result slice
+			result = append(result, tagArr[element])
+		}
+	}
+
+	return result
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,21 +11,22 @@
 
 package utils
 
-// RemoveArrayDuplicate elements
-func RemoveArrayDuplicate(tagArr []string) []string {
-	// Use map to record duplicates if found
-	encountered := map[string]bool{}
+// RemoveDuplicateEntries elements
+func RemoveDuplicateEntries(inputArr []string) []string {
+
+	encounteredElement := map[string]bool{}
 	result := []string{}
 
-	for element := range tagArr {
-		if encountered[tagArr[element]] == true {
-			// Don't add duplicate
-		} else {
-			// Record said element as an encountered
-			encountered[tagArr[element]] = true
-			// Append to the new result slice
-			result = append(result, tagArr[element])
+	// Populate map if element != ""
+	for _, element := range inputArr {
+		if element != "" {
+			encounteredElement[element] = true
 		}
+	}
+
+	// Convert map => slice
+	for key := range encounteredElement {
+		result = append(result, key)
 	}
 
 	return result

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -14,7 +14,6 @@ package utils
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -109,13 +108,23 @@ func TestDeleteTempFileFail(t *testing.T) {
 	assert.EqualError(t, err, errString)
 }
 
-func TestRemoveArrayDuplicate(t *testing.T) {
+func TestRemoveDuplicateEntries(t *testing.T) {
 	dupArr := []string{"test", "test", "test"}
-	result := RemoveArrayDuplicate(dupArr)
-	fmt.Println(result)
+	result := RemoveDuplicateEntries(dupArr)
 
 	if len(result) != 1 {
-		log.Fatal("Failed to delete duplicate array index")
+		log.Fatal("Test 1: Failed to delete duplicate array index")
 	}
 
+	dupArr = []string{"", "test", "test"}
+	result = RemoveDuplicateEntries(dupArr)
+	if len(result) != 1 {
+		log.Fatal("Test 2: Failed to delete duplicate array index")
+	}
+
+	dupArr = []string{"", "", ""}
+	result = RemoveDuplicateEntries(dupArr)
+	if len(result) != 0 {
+		log.Fatal("Test 3: Failed to identify empty array values")
+	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -14,6 +14,7 @@ package utils
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -106,4 +107,15 @@ func TestDeleteTempFileFail(t *testing.T) {
 	errString := "stat TestFile.yaml: no such file or directory"
 	_, err := DeleteTempFile("TestFile.yaml")
 	assert.EqualError(t, err, errString)
+}
+
+func TestRemoveArrayDuplicate(t *testing.T) {
+	dupArr := []string{"test", "test", "test"}
+	result := RemoveArrayDuplicate(dupArr)
+	fmt.Println(result)
+
+	if len(result) != 1 {
+		log.Fatal("Failed to delete duplicate array index")
+	}
+
 }


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/176**
The end user does not currently have an easy way to tell which version of Codewind images are installed or started. The status command will tell the end user whether it is installed or not/what port it is running on but not the version of images.

**Solution**
Modify the json output of the status command by adding `installed-versions` and `started` arrays. This will notify the end user which versions of codewind images are installed on the host machine and which one is currently running. As per the issue, "apparently there may be cases in the future where we have multiple running versions, so started could be an array too." -`started` is an array to accommodate for this in the future. 

Installed but not running - `./installer status -j` => `{"status":"stopped","installed-versions":["latest","0.2"]}`
Installed and running - `./installer status -j` => `{"status":"started","url":"http://127.0.0.1:10000","installed-versions":["latest","0.2"],"started":["latest"]}`

**Tested**
- Unit test written to test removal of duplicate elements in an array. Output:
```
Running tool: /usr/local/bin/go test -timeout 30s github.com/eclipse/codewind-installer/utils -run ^(TestRemoveArrayDuplicate)$

ok  	github.com/eclipse/codewind-installer/utils	0.048s
Success: Tests passed.
```

- Bats testing all commands. Output:
```
➜  codewind-installer git:(status-tag) ✗ bats integration.bats 
 ✓ invoke install command - default to latest tag
 ✓ invoke status -j command - output = '{status:stopped,installed-versions:[latest]}'
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✓ invoke project command - using -r download microclimate-dev2ops/microclimateGoTemplate into ./downloadtest
 ✓ cleanup

7 tests, 0 failures
```
Signed-off-by: Liam Hampton liam.hampton@ibm.com