### PR TITLE
Add first templates command to list templates

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -143,7 +143,7 @@ func Commands() {
 				{
 					Name:  "list",
 					Aliases: []string{"ls"},
-					Usage: "list available template repositories",
+					Usage: "list available templates",
 					Action: func(c *cli.Context) error {
 						ListTemplates()
 						return nil

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -135,6 +135,22 @@ func Commands() {
 				return nil
 			},
 		},
+
+		{
+			Name:    "templates",
+			Usage:   "Manage project templates",
+			Subcommands: []cli.Command{
+				{
+					Name:  "list",
+					Aliases: []string{"ls"},
+					Usage: "list available template repositories",
+					Action: func(c *cli.Context) error {
+						ListTemplates()
+						return nil
+					},
+				},
+			},
+		},
 	}
 
 	// Start application

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -20,7 +20,7 @@ import (
 	"github.com/eclipse/codewind-installer/config"
 )
 
-// Template represents a template.
+// Template represents a project template.
 type Template struct {
 	Label       string `json:"label"`
 	Description string `json:"description"`
@@ -29,7 +29,7 @@ type Template struct {
 	ProjectType string `json:"projectType"`
 }
 
-// ListTemplates lists all templates Codewind is aware of.
+// ListTemplates lists all project templates Codewind is aware of.
 func ListTemplates() {
 	templates, err := GetTemplates()
 	if err != nil {

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// Template represents a template.
+type Template struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Language    string `json:"language"`
+	URL         string `json:"url"`
+	ProjectType string `json:"projectType"`
+}
+
+// ListTemplates lists all templates Codewind is aware of.
+func ListTemplates() {
+	templates, err := GetTemplates()
+	if err != nil {
+		fmt.Printf("Error getting templates: %q", err)
+		return
+	}
+	PrettyPrintJSON(templates)
+}
+
+// GetTemplates extracts URLs from the file at the provided path,
+// then gets the template descriptions from those URLs,
+// then formats the descriptions into template objects.
+func GetTemplates() ([]Template, error) {
+	resp, err := http.Get("http://localhost:9090/api/v1/templates")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var templates []Template
+	json.Unmarshal(byteArray, &templates)
+
+	return templates, nil
+}
+
+// PrettyPrintJSON prints JSON prettily.
+func PrettyPrintJSON(i interface{}) {
+	s, _ := json.MarshalIndent(i, "", "\t")
+	fmt.Println(string(s))
+}

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/eclipse/codewind-installer/config"
 )
 
 // Template represents a template.
@@ -41,7 +43,7 @@ func ListTemplates() {
 // then gets the template descriptions from those URLs,
 // then formats the descriptions into template objects.
 func GetTemplates() ([]Template, error) {
-	resp, err := http.Get("http://localhost:9090/api/v1/templates")
+	resp, err := http.Get(config.PFEApiRoute + "templates")
 	if err != nil {
 		return nil, err
 	}

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -29,7 +29,7 @@ type Template struct {
 	ProjectType string `json:"projectType"`
 }
 
-// ListTemplates lists all project templates Codewind is aware of.
+// ListTemplates lists all project templates Codewind of which is aware.
 func ListTemplates() {
 	templates, err := GetTemplates()
 	if err != nil {
@@ -39,9 +39,7 @@ func ListTemplates() {
 	PrettyPrintJSON(templates)
 }
 
-// GetTemplates extracts URLs from the file at the provided path,
-// then gets the template descriptions from those URLs,
-// then formats the descriptions into template objects.
+// GetTemplates gets all project templates from PFE's REST API
 func GetTemplates() ([]Template, error) {
 	resp, err := http.Get(config.PFEApiRoute + "templates")
 	if err != nil {

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -23,7 +23,7 @@ func TestGetTemplates(t *testing.T) {
 			got, err := GetTemplates()
 			assert.IsType(t, test.wantedType, got)
 			assert.Equal(t, test.wantedLength, len(got))
-			assert.IsType(t, test.wantedErr, err)
+			assert.Equal(t, test.wantedErr, err)
 		})
 	}
 }

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -1,0 +1,29 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTemplates(t *testing.T) {
+	tests := map[string]struct {
+		wantedType   []Template
+		wantedLength int
+		wantedErr    error
+	}{
+		"success case: no input": {
+			wantedType:   []Template{},
+			wantedLength: 8,
+			wantedErr:    nil,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetTemplates()
+			assert.IsType(t, test.wantedType, got)
+			assert.Equal(t, test.wantedLength, len(got))
+			assert.IsType(t, test.wantedErr, err)
+		})
+	}
+}

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -12,7 +12,7 @@ func TestGetTemplates(t *testing.T) {
 		wantedLength int
 		wantedErr    error
 	}{
-		"success case: no input": {
+		"success case": {
 			wantedType:   []Template{},
 			wantedLength: 8,
 			wantedErr:    nil,

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package config
+
+import (
+	"github.com/eclipse/codewind-installer/utils"
+)
+
+var hostname, port = utils.GetPFEHostAndPort()
+
+// PFEHostname is the hostname at which PFE is running, e.g. "127.0.0.1"
+var PFEHostname = hostname
+
+// PFEPort is the port on which PFE is running, e.g. "9090"
+var PFEPort = port
+
+// PFEHost is the host at which PFE is running, e.g. "127.0.0.1:9090"
+var PFEHost = hostname + ":" + port
+
+// PFEOrigin is the origin from which PFE is running, e.g. "http://127.0.0.1:9090"
+var PFEOrigin = "http://" + PFEHost
+
+// PFEApiRoute is the API route at which the PFE REST API can be accessed, e.g. "http://127.0.0.1:9090/api/v1/"
+var PFEApiRoute = PFEOrigin + "/api/v1/"


### PR DESCRIPTION
## Problem
To manage project templates, Codewind Vscode plugins want to call this Go CLI rather than Codewind's REST API directly. 

## Solution
Add the first `codewind-installer templates` command. (This will be followed by further PRs).

`codewind-installer templates list` calls Codewind's REST API `GET templates` to output:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/18170169/63275886-3a471580-c29a-11e9-96c1-ffeaca8e0387.png">


Covered by a test. 