### PR TITLE
Fix broken url flag for projects cmd

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -39,8 +39,8 @@ func Commands() {
 			Usage: "Manage Codewind projects",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "r",
-					Usage: "repository url",
+					Name:  "url, u",
+					Usage: "URL of project to download",
 				},
 			},
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

In https://github.com/eclipse/codewind-installer/pull/75, I broke the url flag by changing it from `r` to `u` in `project.go` and forgetting to make that change in `command.go`. This fixes that.

Manually tested. I'd like to get integration tests in asap to prevent this sort of thing in future