### PR TITLE
Add bats tests

### DIFF
--- a/integration.bats
+++ b/integration.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+@test "invoke install command - install latest with --json" {
+  run go run main.go install --json
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+    [ "$status" -eq 0 ]
+}
+
+@test "invoke status -j command - output = '{"status":"stopped","installed-versions":["latest"]}'" {
+  run go run main.go status -j
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"status":"stopped","installed-versions":["latest"]}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke start command - Start dockerhub images (latest)" {
+  run go run main.go start
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke stop-all command - Stop dockerhub images (latest)" {
+  run go run main.go stop-all
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke remove command - remove all dockerhub images" {
+  run go run main.go remove
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
**Problem**
The installer is currently tested manually with unit tests and testing each command by hand. 

**Solution**
Automate the command testing by using bats-core (https://github.com/bats-core/bats-core). This is a simple framework to test the installer from outside of itself. This will call each command individually and check the return status/output. The setup for bats will be included in a follow up PR for the docs overhaul.

**Test output**
```
➜  codewind-installer git:(bats-tests) ✗ bats integration.bats
 ✓ invoke install command - install latest with --json
 ✓ invoke status -j command - output = '{status:stopped,installed-versions:[latest]}'
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images

5 tests, 0 failures
```

**Extra**
Following this we will need to get this working inside the Jenkins environment to run against all builds.
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>