### PR TITLE
Add 2 commands to list templates styles and list template repos

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -164,6 +164,21 @@ func Commands() {
 						},
 					},
 				},
+				{
+					Name:  "repos",
+					Usage: "list available template repos",
+					Subcommands: []cli.Command{
+						{
+							Name:  "list",
+							Aliases: []string{"ls"},
+							Usage: "list available template repos",
+							Action: func(c *cli.Context) error {
+								ListTemplateRepos()
+								return nil
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -152,31 +152,17 @@ func Commands() {
 				{
 					Name:  "styles",
 					Usage: "list available template styles",
-					Subcommands: []cli.Command{
-						{
-							Name:  "list",
-							Aliases: []string{"ls"},
-							Usage: "list available template styles",
-							Action: func(c *cli.Context) error {
-								ListTemplateStyles()
-								return nil
-							},
-						},
+					Action: func(c *cli.Context) error {
+						ListTemplateStyles()
+						return nil
 					},
 				},
 				{
 					Name:  "repos",
 					Usage: "list available template repos",
-					Subcommands: []cli.Command{
-						{
-							Name:  "list",
-							Aliases: []string{"ls"},
-							Usage: "list available template repos",
-							Action: func(c *cli.Context) error {
-								ListTemplateRepos()
-								return nil
-							},
-						},
+					Action: func(c *cli.Context) error {
+						ListTemplateRepos()
+						return nil
 					},
 				},
 			},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -149,6 +149,21 @@ func Commands() {
 						return nil
 					},
 				},
+				{
+					Name:  "styles",
+					Usage: "list available template styles",
+					Subcommands: []cli.Command{
+						{
+							Name:  "list",
+							Aliases: []string{"ls"},
+							Usage: "list available template styles",
+							Action: func(c *cli.Context) error {
+								ListTemplateStyles()
+								return nil
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -39,6 +39,17 @@ func ListTemplates() {
 	PrettyPrintJSON(templates)
 }
 
+
+// ListTemplateStyles lists all template styles Codewind of which is aware.
+func ListTemplateStyles() {
+	styles, err := GetTemplateStyles()
+	if err != nil {
+		fmt.Printf("Error getting template styles: %q", err)
+		return
+	}
+	PrettyPrintJSON(styles)
+}
+
 // GetTemplates gets all project templates from PFE's REST API
 func GetTemplates() ([]Template, error) {
 	resp, err := http.Get(config.PFEApiRoute + "templates")
@@ -57,6 +68,26 @@ func GetTemplates() ([]Template, error) {
 	json.Unmarshal(byteArray, &templates)
 
 	return templates, nil
+}
+
+// GetTemplateStyles gets all template styles from PFE's REST API
+func GetTemplateStyles() ([]string, error) {
+	resp, err := http.Get(config.PFEApiRoute + "templates/styles")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var styles []string
+	json.Unmarshal(byteArray, &styles)
+
+	return styles, nil
 }
 
 // PrettyPrintJSON prints JSON prettily.

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/config"
@@ -41,18 +42,17 @@ type (
 func ListTemplates() {
 	templates, err := GetTemplates()
 	if err != nil {
-		fmt.Printf("Error getting templates: %q", err)
+		log.Printf("Error getting templates: %q", err)
 		return
 	}
 	PrettyPrintJSON(templates)
 }
 
-
 // ListTemplateStyles lists all template styles of which Codewind is aware.
 func ListTemplateStyles() {
 	styles, err := GetTemplateStyles()
 	if err != nil {
-		fmt.Printf("Error getting template styles: %q", err)
+		log.Printf("Error getting template styles: %q", err)
 		return
 	}
 	PrettyPrintJSON(styles)

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -20,16 +20,24 @@ import (
 	"github.com/eclipse/codewind-installer/config"
 )
 
-// Template represents a project template.
-type Template struct {
-	Label       string `json:"label"`
-	Description string `json:"description"`
-	Language    string `json:"language"`
-	URL         string `json:"url"`
-	ProjectType string `json:"projectType"`
-}
+type (
+	// Template represents a project template.
+	Template struct {
+		Label       string `json:"label"`
+		Description string `json:"description"`
+		Language    string `json:"language"`
+		URL         string `json:"url"`
+		ProjectType string `json:"projectType"`
+	}
 
-// ListTemplates lists all project templates Codewind of which is aware.
+	// TemplateRepo represents a template repository.
+	TemplateRepo struct {
+		Description string `json:"description"`
+		URL         string `json:"url"`
+	}
+)
+
+// ListTemplates lists all project templates of which Codewind is aware.
 func ListTemplates() {
 	templates, err := GetTemplates()
 	if err != nil {
@@ -40,7 +48,7 @@ func ListTemplates() {
 }
 
 
-// ListTemplateStyles lists all template styles Codewind of which is aware.
+// ListTemplateStyles lists all template styles of which Codewind is aware.
 func ListTemplateStyles() {
 	styles, err := GetTemplateStyles()
 	if err != nil {
@@ -48,6 +56,16 @@ func ListTemplateStyles() {
 		return
 	}
 	PrettyPrintJSON(styles)
+}
+
+// ListTemplateRepos lists all template repos of which Codewind is aware.
+func ListTemplateRepos() {
+	repos, err := GetTemplateRepos()
+	if err != nil {
+		fmt.Printf("Error getting template repos: %q", err)
+		return
+	}
+	PrettyPrintJSON(repos)
 }
 
 // GetTemplates gets all project templates from PFE's REST API
@@ -88,6 +106,26 @@ func GetTemplateStyles() ([]string, error) {
 	json.Unmarshal(byteArray, &styles)
 
 	return styles, nil
+}
+
+// GetTemplateRepos gets all template repos from PFE's REST API
+func GetTemplateRepos() ([]TemplateRepo, error) {
+	resp, err := http.Get(config.PFEApiRoute + "templates/repositories")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []TemplateRepo
+	json.Unmarshal(byteArray, &repos)
+
+	return repos, nil
 }
 
 // PrettyPrintJSON prints JSON prettily.

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -62,7 +62,7 @@ func ListTemplateStyles() {
 func ListTemplateRepos() {
 	repos, err := GetTemplateRepos()
 	if err != nil {
-		fmt.Printf("Error getting template repos: %q", err)
+		log.Printf("Error getting template repos: %q", err)
 		return
 	}
 	PrettyPrintJSON(repos)

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -30,12 +30,12 @@ func TestGetTemplates(t *testing.T) {
 
 func TestGetTemplateStyles(t *testing.T) {
 	tests := map[string]struct {
-		want []string
-		wantedErr    error
+		want      []string
+		wantedErr error
 	}{
 		"success case": {
-			want:   []string{"Codewind"},
-			wantedErr:    nil,
+			want:      []string{"Codewind"},
+			wantedErr: nil,
 		},
 	}
 	for name, test := range tests {

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -27,3 +27,22 @@ func TestGetTemplates(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTemplateStyles(t *testing.T) {
+	tests := map[string]struct {
+		want []string
+		wantedErr    error
+	}{
+		"success case": {
+			want:   []string{"Codewind"},
+			wantedErr:    nil,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetTemplateStyles()
+			assert.Equal(t, test.want, got)
+			assert.IsType(t, test.wantedErr, err)
+		})
+	}
+}

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -46,3 +46,25 @@ func TestGetTemplateStyles(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTemplateRepos(t *testing.T) {
+	tests := map[string]struct {
+		wantedType   []TemplateRepo
+		wantedLength int
+		wantedErr    error
+	}{
+		"success case": {
+			wantedType:   []TemplateRepo{},
+			wantedLength: 1,
+			wantedErr:    nil,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetTemplateRepos()
+			assert.IsType(t, test.wantedType, got)
+			assert.Equal(t, test.wantedLength, len(got))
+			assert.Equal(t, test.wantedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Problem
To manage project templates, Codewind Vscode plugins want to call this Go CLI rather than Codewind's REST API directly. 

## Solution
Add 2 commands:
1. `codewind-installer templates styles list` calls Codewind's REST API `GET templates/styles` to output:
<img width="579" alt="image" src="https://user-images.githubusercontent.com/18170169/63361233-a6437f80-c367-11e9-9f35-fd206bb87e7b.png">

2. `codewind-installer templates repos list` calls Codewind's REST API `GET templates/repositories` to output:
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/18170169/63361311-ca06c580-c367-11e9-8086-ef697330adeb.png">

## Tests
- Unit tests (automated)
- Integration tests (manual. Automated tests coming soon).