### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $ brew upgrade dep
 
 Subcommands:</br>
 
-`list/ls` - Shows a list of commands or help for one command
+`list/ls` - List available templates
 
 ## help
 

--- a/README.md
+++ b/README.md
@@ -83,49 +83,58 @@ $ brew upgrade dep
 
 |Command         |Alias         |Usage                                                           |
 |----------------|--------------|----------------------------------------------------------------|
-|project         |-             |'Manage Codewind projects'                                      |
+|project         |`-`           |'Manage Codewind projects'                                      |
 |install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'      |
-|start           |-             |'Start the Codewind containers'                                 |
-|status          |-             |'Print the installation status of Codewind'                     |
-|stop            |-             |'Stop the running Codewind containers'                          |
-|stop-all        |-             |'Stop all of the Codewind and project containers'               |
+|start           |`-`           |'Start the Codewind containers'                                 |
+|status          |`-`           |'Print the installation status of Codewind'                     |
+|stop            |`-`           |'Stop the running Codewind containers'                          |
+|stop-all        |`-`           |'Stop all of the Codewind and project containers'               |
 |remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'|
+|templates       |`-`           |'Manage project templates'                                      |
 |help            |`h`           |'Shows a list of commands or help for one command'              |
 
 ## CLI Command Options
 
-### project
+## project
 
-`--url/-u` - URL of project to download
+`--url/-u <value>` - URL of project to download
 
-### install
+## install
 
-`--tag/t` - Dockerhub image tag (default: "latest")</br>
+`--tag/t <value>` - Dockerhub image tag (default: "latest")</br>
 `--json/-j` - Specify terminal output
 
-### start
+## start
 
-`--tag/-t` - Dockerhub image tag (default: "latest")</br>
+`--tag/-t <value>` - Dockerhub image tag (default: "latest")</br>
 `--debug/-d` - Add debug output
 
-### status
+## status
 
 `--json/-j` - Specify terminal output
 
-### stop
+## stop
 
 >**Note:** No additional flags
 
-### stop-all
+## stop-all
 
 >**Note:** No additional flags
 
-### remove
+## remove
 
-`--tag/-t` - Dockerhub image tag </br>
->**Note:** Specifying no tag will remove all Codewind images installed on the host machine 
+`--tag/-t <value>` - Dockerhub image tag.</br>
+**Note:** Failing to specify a `--tag`, will remove all Codewind images on the host machine.
 
-### help
+## templates
+
+>**Note:** No additional flags
+
+Subcommands:</br>
+
+`list/ls` - Shows a list of commands or help for one command
+
+## help
 
 `--help/-h` - Shows a list of commands or help for one command
 

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ $ brew upgrade dep
 
 |Command         |Alias         |Usage                                                           |
 |----------------|--------------|----------------------------------------------------------------|
-|project         |`-`           |'Manage Codewind projects'                                      |
+|project         |              |'Manage Codewind projects'                                      |
 |install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'      |
-|start           |`-`           |'Start the Codewind containers'                                 |
-|status          |`-`           |'Print the installation status of Codewind'                     |
-|stop            |`-`           |'Stop the running Codewind containers'                          |
-|stop-all        |`-`           |'Stop all of the Codewind and project containers'               |
+|start           |              |'Start the Codewind containers'                                 |
+|status          |              |'Print the installation status of Codewind'                     |
+|stop            |              |'Stop the running Codewind containers'                          |
+|stop-all        |              |'Stop all of the Codewind and project containers'               |
 |remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'|
-|templates       |`-`           |'Manage project templates'                                      |
+|templates       |              |'Manage project templates'                                      |
 |help            |`h`           |'Shows a list of commands or help for one command'              |
 
 ## CLI Command Options
@@ -101,7 +101,7 @@ $ brew upgrade dep
 
 ## install
 
-`--tag/t <value>` - Dockerhub image tag (default: "latest")</br>
+`--tag/-t <value>` - Dockerhub image tag (default: "latest")</br>
 `--json/-j` - Specify terminal output
 
 ## start

--- a/README.md
+++ b/README.md
@@ -67,9 +67,16 @@ $ brew upgrade dep
 ## Unit testing
 
 1. Clone the `codewind-installer` repository.
-2. Use the `cd` command to go to the test directory. The `utils.go` tests are located in the `utils/utils_test.go` file.
+2. Use the `cd` command to go to a directory with test files in. For example, the `utils.go` tests are located in the `utils/utils_test.go` file.
 3. To run the tests, enter the `go test -v` command in the command line window and wait for the tests to finish.
 4. For any other unit tests, the same steps apply, but the directory might change.
+
+## Bats-core testing
+
+1. Clone the `codewind-installer` repository.
+2. Use the `cd` command to go to the top level project directory.
+3. Ensure your system environment is clean by having no Codewind images installed or containers running.
+4. To run the tests, enter the `bats integration.bats` command in the command line window and wait for the tests to finish.
 
 ## Contributing
 
@@ -77,3 +84,53 @@ Submit issues and contributions:
 
 1. [Submitting issues](https://github.com/eclipse/codewind/issues)
 2. [Contributing](CONTRIBUTING.md)
+
+## CLI Commands
+
+|Command         |Alias         |Usage                                                           |
+|----------------|--------------|----------------------------------------------------------------|
+|project         |-             |'Manage Codewind projects'                                      |
+|install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'      |
+|start           |-             |'Start the Codewind containers'                                 |
+|status          |-             |'Print the installation status of Codewind'                     |
+|stop            |-             |'Stop the running Codewind containers'                          |
+|stop-all        |-             |'Stop all of the Codewind and project containers'               |
+|remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'|
+|help            |`h`           |'Shows a list of commands or help for one command'              |
+
+## CLI Command Options
+
+### project
+
+`--url/-u` - URL of project to download
+
+### install
+
+`--tag/t` - Dockerhub image tag (default: "latest")</br>
+`--json/-j` - Specify terminal output
+
+### start
+
+`--tag/-t` - Dockerhub image tag (default: "latest")</br>
+`--debug/-d` - Add debug output
+
+### status
+
+`--json/-j` - Specify terminal output
+
+### stop
+
+>**Note:** No additional flags
+
+### stop-all
+
+>**Note:** No additional flags
+
+### remove
+
+`--tag/-t` - Dockerhub image tag </br>
+>**Note:** Specifying no tag will remove all Codewind images installed on the host machine 
+
+### help
+
+`--help/-h` - Shows a list of commands or help for one command

--- a/README.md
+++ b/README.md
@@ -73,17 +73,11 @@ $ brew upgrade dep
 
 ## Bats-core testing
 
-1. Clone the `codewind-installer` repository.
-2. Use the `cd` command to go to the top level project directory.
-3. Ensure your system environment is clean by having no Codewind images installed or containers running.
-4. To run the tests, enter the `bats integration.bats` command in the command line window and wait for the tests to finish.
-
-## Contributing
-
-Submit issues and contributions:
-
-1. [Submitting issues](https://github.com/eclipse/codewind/issues)
-2. [Contributing](CONTRIBUTING.md)
+1. Set up your environment by installing bats-core as per the bats-core instructions found at <https://github.com/bats-core/bats-core>.
+2. Clone the `codewind-installer` repository.
+3. Use the `cd` command to go to the top level project directory.
+4. Ensure your system environment is clean by having no Codewind images installed or containers running.
+5. To run the tests, enter the `bats integration.bats` command in the command line window and wait for the tests to finish.
 
 ## CLI Commands
 
@@ -134,3 +128,10 @@ Submit issues and contributions:
 ### help
 
 `--help/-h` - Shows a list of commands or help for one command
+
+## Contributing
+
+Submit issues and contributions:
+
+1. [Submitting issues](https://github.com/eclipse/codewind/issues)
+2. [Contributing](CONTRIBUTING.md)

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -143,13 +143,13 @@ func Commands() {
 		},
 
 		{
-			Name:    "templates",
-			Usage:   "Manage project templates",
+			Name:  "templates",
+			Usage: "Manage project templates",
 			Subcommands: []cli.Command{
 				{
-					Name:  "list",
+					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage: "list available templates",
+					Usage:   "list available templates",
 					Action: func(c *cli.Context) error {
 						ListTemplates()
 						return nil


### PR DESCRIPTION
**Problem**
Now bats tests have gone into the repository there needs to be accompanying documentation on how to set it up on a machine. There is also no documentation of the actual commands available within in the installer. 

**Solution**
- add bats installation instructions
- add table of available commands followed by flags/subcommand information

**Extra**
- code formatting

Signed-off-by: Liam Hampton liam.hampton@ibm.com