### PR TITLE
print message to stderr instead of stdout using log instead of fmt

### DIFF
--- a/utils/docker.go
+++ b/utils/docker.go
@@ -345,7 +345,7 @@ func GetImageTags() []string {
 					tag = strings.Split(tag, ":")[1]
 					tagArr = append(tagArr, tag)
 				} else {
-					fmt.Println("No tag available. Defaulting to ''.")
+					log.Println("No tag available. Defaulting to ''")
 					tagArr = append(tagArr, "")
 				}
 			}


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/234**
Status command prints error message to stdout when infact it should go to stderr.

**Solution**
Using `fmt` by default prints to stdout. By changing this to use `log` it will default to stderr, see (https://golang.org/pkg/log/) for reference.

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>