### PR TITLE
Allow `templates list` cmd to filter via 2 flags

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -27,7 +27,7 @@ const healthEndpoint = "/api/v1/environment"
 //Commands for the installer
 func Commands() {
 	app := cli.NewApp()
-	app.Name = "Codewind Installer"
+	app.Name = "codewind-installer"
 	app.Version = versionNum
 	app.Usage = "Start, Stop and Remove Codewind"
 
@@ -159,7 +159,7 @@ func Commands() {
 					Aliases: []string{"ls"},
 					Usage:   "list available templates",
 					Action: func(c *cli.Context) error {
-						ListTemplates()
+						ListTemplates(c)
 						return nil
 					},
 				},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -157,7 +157,19 @@ func Commands() {
 				{
 					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage:   "list available templates",
+					Usage: "List available templates",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "projectStyle",
+							Value: "Codewind",
+							Usage: "Filter by project style",
+						},
+						cli.StringFlag{
+							Name:  "showEnabledOnly",
+							Value: "false",
+							Usage: "Filter by whether a template is enabled or not",
+						},
+					},
 					Action: func(c *cli.Context) error {
 						ListTemplates(c)
 						return nil
@@ -165,7 +177,7 @@ func Commands() {
 				},
 				{
 					Name:  "styles",
-					Usage: "list available template styles",
+					Usage: "List available template styles",
 					Action: func(c *cli.Context) error {
 						ListTemplateStyles()
 						return nil
@@ -173,7 +185,7 @@ func Commands() {
 				},
 				{
 					Name:  "repos",
-					Usage: "list available template repos",
+					Usage: "List available template repos",
 					Action: func(c *cli.Context) error {
 						ListTemplateRepos()
 						return nil

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -39,7 +39,8 @@ type (
 	}
 )
 
-// ListTemplates lists all project templates of which Codewind is aware.
+// ListTemplates lists project templates of which Codewind is aware.
+// Filter them by providing flags
 func ListTemplates(c *cli.Context) {
 	templates, err := GetTemplates(
 		c.String("projectStyle"),
@@ -72,7 +73,8 @@ func ListTemplateRepos() {
 	PrettyPrintJSON(repos)
 }
 
-// GetTemplates gets project templates from PFE's REST API
+// GetTemplates gets project templates from PFE's REST API.
+// Filter them using the function arguments
 func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
 	req, err := http.NewRequest("GET", config.PFEApiRoute + "templates", nil)
 	if err != nil {

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/config"
+	"github.com/urfave/cli"
 )
 
 type (
@@ -39,8 +40,11 @@ type (
 )
 
 // ListTemplates lists all project templates of which Codewind is aware.
-func ListTemplates() {
-	templates, err := GetTemplates()
+func ListTemplates(c *cli.Context) {
+	templates, err := GetTemplates(
+		c.String("projectStyle"),
+		c.String("showEnabledOnly"),
+	)
 	if err != nil {
 		log.Printf("Error getting templates: %q", err)
 		return
@@ -68,9 +72,23 @@ func ListTemplateRepos() {
 	PrettyPrintJSON(repos)
 }
 
-// GetTemplates gets all project templates from PFE's REST API
-func GetTemplates() ([]Template, error) {
-	resp, err := http.Get(config.PFEApiRoute + "templates")
+// GetTemplates gets project templates from PFE's REST API
+func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
+	req, err := http.NewRequest("GET", config.PFEApiRoute + "templates", nil)
+	if err != nil {
+		return nil, err
+	}
+	query := req.URL.Query()
+	if projectStyle != "" {
+		query.Add("projectStyle", projectStyle)
+	}
+	if showEnabledOnly != "" {
+		query.Add("showEnabledOnly", showEnabledOnly)
+	}
+    req.URL.RawQuery = query.Encode()
+
+	client := &http.Client{}
+    resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var numCodewindTemplates int = 8
+var numAppsodyTemplates int = 8
+var numTemplates int = numCodewindTemplates + numAppsodyTemplates
+
 func TestGetTemplates(t *testing.T) {
 	tests := map[string]struct {
 		inProjectStyle string
@@ -28,25 +32,25 @@ func TestGetTemplates(t *testing.T) {
 			inProjectStyle: "",
 			inShowEnabledOnly: "",
 			wantedType:     []Template{},
-			wantedLength:   8,
+			wantedLength:   numTemplates,
 		},
 		"filter templates by known style": {
 			inProjectStyle: "Codewind",
 			wantedType:   []Template{},
-			wantedLength: 8,
+			wantedLength: numCodewindTemplates,
 		},
 		"filter templates by unknown style": {
-			inProjectStyle: "Appsody",
+			inProjectStyle: "unknownStyle",
 			wantedType:   []Template{},
 			wantedLength: 0,
 		},
 		"filter templates by enabled templates": {
 			inShowEnabledOnly: "true",
 			wantedType:   []Template{},
-			wantedLength: 8,
+			wantedLength: numTemplates,
 		},
 		"filter templates by enabled templates of unknown style": {
-			inProjectStyle: "Appsody",
+			inProjectStyle: "unknownStyle",
 			inShowEnabledOnly: "false",
 			wantedType:     []Template{},
 			wantedLength:   0,
@@ -68,7 +72,7 @@ func TestGetTemplateStyles(t *testing.T) {
 		wantedErr error
 	}{
 		"success case": {
-			want:      []string{"Codewind"},
+			want:      []string{"Appsody", "Codewind"},
 			wantedErr: nil,
 		},
 	}

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -19,22 +19,45 @@ import (
 
 func TestGetTemplates(t *testing.T) {
 	tests := map[string]struct {
-		wantedType   []Template
-		wantedLength int
-		wantedErr    error
+		inProjectStyle string
+		inShowEnabledOnly string
+		wantedType     []Template
+		wantedLength   int
 	}{
-		"success case": {
+		"get templates of all styles": {
+			inProjectStyle: "",
+			inShowEnabledOnly: "",
+			wantedType:     []Template{},
+			wantedLength:   8,
+		},
+		"filter templates by known style": {
+			inProjectStyle: "Codewind",
 			wantedType:   []Template{},
 			wantedLength: 8,
-			wantedErr:    nil,
+		},
+		"filter templates by unknown style": {
+			inProjectStyle: "Appsody",
+			wantedType:   []Template{},
+			wantedLength: 0,
+		},
+		"filter templates by enabled templates": {
+			inShowEnabledOnly: "true",
+			wantedType:   []Template{},
+			wantedLength: 8,
+		},
+		"filter templates by enabled templates of unknown style": {
+			inProjectStyle: "Appsody",
+			inShowEnabledOnly: "false",
+			wantedType:     []Template{},
+			wantedLength:   0,
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := GetTemplates()
+			got, err := GetTemplates(test.inProjectStyle, test.inShowEnabledOnly)
 			assert.IsType(t, test.wantedType, got)
 			assert.Equal(t, test.wantedLength, len(got))
-			assert.Equal(t, test.wantedErr, err)
+			assert.Nil(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## Problem
To manage project templates, Codewind Vscode plugins want to call this Go CLI rather than Codewind's REST API directly. Currently the CLI can list all templates, but cannot filter those templates.

## Solution
Add 2 optional flags to filter templates:
1. `codewind-installer templates list -projectStyle="Codewind"` calls Codewind's REST API `GET templates?projectStyle=Codewind` to list all templates with projectStyle "Codewind"

2. `codewind-installer templates list -showEnabledOnly="true"` calls Codewind's REST API `GET templates?showEnabledOnly=true` to list all templates from enabled template repositories.

The 2 flags can be combined.

## Tests
- Unit tests (automated)
- Integration tests (manual. Automated tests coming soon).