### PR TITLE
Add a new Deployments Command

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -31,6 +31,14 @@ func Commands() {
 	app.Version = versionNum
 	app.Usage = "Start, Stop and Remove Codewind"
 
+	// Global Flags
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "insecure",
+			Usage: "disable certificate checking",
+		},
+	}
+
 	// create commands
 	app.Commands = []cli.Command{
 
@@ -143,13 +151,13 @@ func Commands() {
 		},
 
 		{
-			Name:    "templates",
-			Usage:   "Manage project templates",
+			Name:  "templates",
+			Usage: "Manage project templates",
 			Subcommands: []cli.Command{
 				{
-					Name:  "list",
+					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage: "list available templates",
+					Usage:   "list available templates",
 					Action: func(c *cli.Context) error {
 						ListTemplates()
 						return nil
@@ -168,6 +176,77 @@ func Commands() {
 					Usage: "list available template repos",
 					Action: func(c *cli.Context) error {
 						ListTemplateRepos()
+						return nil
+					},
+				},
+			},
+		},
+
+		//  Deployment maintenance //
+		{
+			Name:    "deployments",
+			Aliases: []string{"dep"},
+			Usage:   "Maintain local deployments list",
+			Subcommands: []cli.Command{
+				{
+					Name:    "add",
+					Aliases: []string{"a"},
+					Usage:   "Add a new deployment to the list",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "name", Usage: "A reference name", Required: true},
+						cli.StringFlag{Name: "label", Usage: "A displayable name", Required: false},
+						cli.StringFlag{Name: "url", Usage: "The ingress url of the PFE instance", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						AddDeploymentToList(c)
+						return nil
+					},
+				},
+				{
+					Name:    "remove",
+					Aliases: []string{"rm"},
+					Usage:   "Remove a deployment from the list",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "name", Usage: "The reference name of the deployment to be removed", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						if c.NumFlags() != 1 {
+						} else {
+							RemoveDeploymentFromList(c)
+						}
+						return nil
+					},
+				},
+				{
+					Name:    "target",
+					Aliases: []string{"t"},
+					Usage:   "Show/Change the current target deployment",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "name", Usage: "The deployment name of a new target"},
+					},
+					Action: func(c *cli.Context) error {
+						if c.NumFlags() == 0 {
+							ListTargetDeployment()
+						} else {
+							SetTargetDeployment(c)
+						}
+						return nil
+					},
+				},
+				{
+					Name:    "list",
+					Aliases: []string{"ls"},
+					Usage:   "List known deployments",
+					Action: func(c *cli.Context) error {
+						ListDeployments()
+						return nil
+					},
+				},
+				{
+					Name:  "reset",
+					Usage: "Resets the deployments list",
+					Action: func(c *cli.Context) error {
+						ResetDeploymentsFile()
 						return nil
 					},
 				},

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -156,8 +156,7 @@ func SetTargetDeployment(c *cli.Context) {
 		}
 	}
 	if foundName == "" {
-		log.Println("Unable to change deployment. '" + newTargetName + "' has no matching configuration")
-		os.Exit(1)
+		log.Fatal("Unable to change deployment. '" + newTargetName + "' has no matching configuration")
 	}
 
 	data.Active = foundName
@@ -182,8 +181,7 @@ func AddDeploymentToList(c *cli.Context) {
 	// check the name is not already in use
 	for i := 0; i < len(data.Deployments); i++ {
 		if strings.EqualFold(name, data.Deployments[i].Name) {
-			log.Println("Deployment '" + name + "' already exists, to update:  first remove, then add")
-			os.Exit(1)
+			log.Fatal("Deployment '" + name + "' already exists, to update:  first remove, then add")
 		}
 	}
 
@@ -209,8 +207,7 @@ func AddDeploymentToList(c *cli.Context) {
 func RemoveDeploymentFromList(c *cli.Context) {
 	name := c.String("name")
 	if strings.EqualFold(name, "local") {
-		log.Println("Local is a required deployment and can not be removed")
-		os.Exit(1)
+		log.Fatal("Local is a required deployment and can not be removed")
 	}
 	data, err, errCode := loadDeploymentsConfigFile()
 	errors.CheckErr(err, errCode, "Unable to process the deployments config file")

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -25,7 +25,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-func getDeploymentConfigFilename() string {
+func getDeploymentConfigPath() string {
 	const GOOS string = runtime.GOOS
 	homeDir := ""
 	if GOOS == "windows" {
@@ -33,7 +33,11 @@ func getDeploymentConfigFilename() string {
 	} else {
 		homeDir = os.Getenv("HOME")
 	}
-	return path.Join(homeDir, ".codewind", "config", "deployments.json")
+	return path.Join(homeDir, ".codewind", "config")
+}
+
+func getDeploymentConfigFilename() string {
+	return path.Join(getDeploymentConfigPath(), "deployments.json")
 }
 
 type DeploymentConfig struct {
@@ -51,8 +55,9 @@ type Deployment struct {
 * Check the config file exist, if it does not then create a new default configuration
  */
 func InitDeploymentConfigIfRequired() {
-	_, err, code := loadDeploymentsConfigFile()
-	if err != nil && code == 207 {
+	_, err := os.Stat(getDeploymentConfigFilename())
+	if os.IsNotExist(err) {
+		os.Mkdir(getDeploymentConfigPath(), 0777)
 		ResetDeploymentsFile()
 	}
 }

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/eclipse/codewind-installer/errors"
+	"github.com/eclipse/codewind-installer/utils"
+	"github.com/urfave/cli"
+)
+
+func getDeploymentConfigFilename() string {
+	const GOOS string = runtime.GOOS
+	homeDir := ""
+	if GOOS == "windows" {
+		homeDir = os.Getenv("USERPROFILE")
+	} else {
+		homeDir = os.Getenv("HOME")
+	}
+	return path.Join(homeDir, ".codewind", "config", "deployments.json")
+}
+
+type DeploymentConfig struct {
+	Active      string       `json:"active"`
+	Deployments []Deployment `json:"deployments"`
+}
+
+type Deployment struct {
+	Name  string `json:"name"`
+	Label string `json:"label"`
+	Url   string `json:"url"`
+}
+
+/**
+* Check the file exist, if it does not, create a new configuration
+ */
+func initDeploymentConfigIfRequired() {
+	_, err, code := loadDeploymentsConfigFile()
+	if err != nil && code == 207 {
+		ResetDeploymentsFile()
+	}
+}
+
+/***
+ * ResetDeploymentsFile
+ * Creates a new / overwrites deployment config file with a default single local Codewind deployment
+ */
+func ResetDeploymentsFile() {
+	// create the default local deployment
+	initialConfig := DeploymentConfig{
+		Active: "local",
+		Deployments: []Deployment{
+			Deployment{
+				Name:  "local",
+				Label: "Codewind local deployment",
+				Url:   "tbd",
+			},
+		},
+	}
+	body, err := json.MarshalIndent(initialConfig, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+/***
+ * Load the deployments configuration file from disk
+ * returns:  the contents of the file, an error, an error code
+ */
+func loadDeploymentsConfigFile() (*DeploymentConfig, error, int) {
+	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+	if err != nil {
+		return nil, err, 207
+	}
+	data := DeploymentConfig{}
+	err = json.Unmarshal([]byte(file), &data)
+	if err != nil {
+		return nil, err, 208
+	}
+	return &data, nil, 0
+}
+
+/***
+ * Save the deployments configuration file to disk
+ * returns:  an error,  and error code
+ */
+func saveDeploymentsConfigFile() (error, int) {
+	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+	if err != nil {
+		return err, 207
+	}
+	data := DeploymentConfig{}
+	err = json.Unmarshal([]byte(file), &data)
+	if err != nil {
+		return err, 208
+	}
+	return nil, 0
+}
+
+/***
+ * FindTargetDeployment
+ * returns:  The single active deployment
+ */
+func FindTargetDeployment() *Deployment {
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	activeID := data.Active
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(activeID, data.Deployments[i].Name) {
+			return &data.Deployments[i]
+		}
+	}
+	return nil
+}
+
+/***
+ * GetDeploymentConfig
+ * returns:  The entire Deployment configuration contents
+ */
+func GetDeploymentsConfig() *DeploymentConfig {
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	return data
+}
+
+/**
+* Set active deployment
+* If the deployment is unknown the command will fail with an error message
+ */
+func SetTargetDeployment(c *cli.Context) {
+	newTargetName := c.String("name")
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	foundName := ""
+
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(newTargetName, data.Deployments[i].Name) {
+			foundName = data.Deployments[i].Name
+			break
+		}
+	}
+	if foundName == "" {
+		log.Println("Unable to change deployment. '" + newTargetName + "' has no matching configuration")
+		os.Exit(1)
+	}
+
+	data.Active = foundName
+	body, err := json.MarshalIndent(data, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+/**
+ * AddDeploymentToList
+ * Adds a new deployment to the deployment config
+ */
+func AddDeploymentToList(c *cli.Context) {
+	name := strings.ToLower(c.String("name"))
+	label := c.String("label")
+	url := c.String("url")
+
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+
+	// check the name is not already in use
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(name, data.Deployments[i].Name) {
+			log.Println("Deployment '" + name + "' already exists, to update:  first remove, then add")
+			os.Exit(1)
+		}
+	}
+
+	// create the new deployment
+	newDeployment := Deployment{
+		Name:  name,
+		Label: label,
+		Url:   url,
+	}
+
+	// append it to the list
+	data.Deployments = append(data.Deployments, newDeployment)
+	body, err := json.MarshalIndent(data, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+/**
+ * RemoveDeploymentFromList
+ * Removes a deployment from the list
+ */
+func RemoveDeploymentFromList(c *cli.Context) {
+	name := c.String("name")
+	if strings.EqualFold(name, "local") {
+		log.Println("Local is a required deployment and can not be removed")
+		os.Exit(1)
+	}
+	data, err, errCode := loadDeploymentsConfigFile()
+	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(name, data.Deployments[i].Name) {
+			copy(data.Deployments[i:], data.Deployments[i+1:])
+			data.Deployments = data.Deployments[:len(data.Deployments)-1]
+		}
+	}
+	data.Active = "local"
+	body, err := json.MarshalIndent(data, "", "\t")
+	errors.CheckErr(err, 208, "Unable to format deployments file")
+	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	errors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
+}
+
+// Display the deployment details for the current target deployment
+func ListTargetDeployment() {
+	targetDeployment := FindTargetDeployment()
+	utils.PrettyPrintJSON(targetDeployment)
+}
+
+// Display saved deployments
+func ListDeployments() {
+	targetDeployment := GetDeploymentsConfig()
+	utils.PrettyPrintJSON(targetDeployment)
+}

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -230,11 +230,19 @@ func RemoveDeploymentFromList(c *cli.Context) {
 // Display the deployment details for the current target deployment
 func ListTargetDeployment() {
 	targetDeployment := FindTargetDeployment()
-	utils.PrettyPrintJSON(targetDeployment)
+	if targetDeployment != nil {
+		utils.PrettyPrintJSON(targetDeployment)
+	} else {
+		log.Fatal("Unable to find a matching target - set one now using the target command")
+	}
 }
 
 // Display saved deployments
 func ListDeployments() {
-	targetDeployment := GetDeploymentsConfig()
-	utils.PrettyPrintJSON(targetDeployment)
+	deploymentConfig := GetDeploymentsConfig()
+	if deploymentConfig != nil && deploymentConfig.Deployments != nil && len(deploymentConfig.Deployments) > 0 {
+		utils.PrettyPrintJSON(deploymentConfig)
+	} else {
+		log.Fatal("Unable to any deployments - please run the reset command")
+	}
 }

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -128,7 +128,9 @@ func FindTargetDeployment() *Deployment {
 	activeID := data.Active
 	for i := 0; i < len(data.Deployments); i++ {
 		if strings.EqualFold(activeID, data.Deployments[i].Name) {
-			return &data.Deployments[i]
+			targetDeployment := data.Deployments[i]
+			targetDeployment.Url = strings.TrimSuffix(targetDeployment.Url, "/")
+			return &targetDeployment
 		}
 	}
 	return nil
@@ -176,9 +178,12 @@ func SetTargetDeployment(c *cli.Context) {
  * Adds a new deployment to the deployment config
  */
 func AddDeploymentToList(c *cli.Context) {
-	name := strings.ToLower(c.String("name"))
-	label := c.String("label")
+	name := strings.TrimSpace(strings.ToLower(c.String("name")))
+	label := strings.TrimSpace(c.String("label"))
 	url := c.String("url")
+	if url != "" && len(strings.TrimSpace(url)) > 0 {
+		url = strings.TrimSuffix(url, "/")
+	}
 
 	data, err, errCode := loadDeploymentsConfigFile()
 	errors.CheckErr(err, errCode, "Unable to process the deployments config file")

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -48,9 +48,9 @@ type Deployment struct {
 }
 
 /**
-* Check the file exist, if it does not, create a new configuration
+* Check the config file exist, if it does not then create a new default configuration
  */
-func initDeploymentConfigIfRequired() {
+func InitDeploymentConfigIfRequired() {
 	_, err, code := loadDeploymentsConfigFile()
 	if err != nil && code == 207 {
 		ResetDeploymentsFile()

--- a/actions/deployment_test.go
+++ b/actions/deployment_test.go
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetActiveDeployment(t *testing.T) {
+	t.Run("ActiveDeployment", func(t *testing.T) {
+		ResetDeploymentsFile()
+		result := FindTargetDeployment()
+		assert.Equal(t, "local", result.Name)
+		assert.Equal(t, "Codewind local deployment", result.Label)
+		assert.Equal(t, "tbd", result.Url)
+	})
+}
+
+func Test_GetDeploymentsConfig(t *testing.T) {
+	t.Run("GetDeploymentsConfig", func(t *testing.T) {
+		ResetDeploymentsFile()
+		result := GetDeploymentsConfig()
+		assert.Equal(t, "local", result.Active)
+		assert.Len(t, result.Deployments, 1)
+	})
+}
+
+//TODO:  add coverage

--- a/actions/install.go
+++ b/actions/install.go
@@ -37,6 +37,4 @@ func InstallCommand(c *cli.Context) {
 	}
 
 	fmt.Println("Image Tagging Successful")
-
-	initDeploymentConfigIfRequired()
 }

--- a/actions/install.go
+++ b/actions/install.go
@@ -37,4 +37,6 @@ func InstallCommand(c *cli.Context) {
 	}
 
 	fmt.Println("Image Tagging Successful")
+
+	initDeploymentConfigIfRequired()
 }

--- a/actions/status.go
+++ b/actions/status.go
@@ -15,13 +15,69 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/eclipse/codewind-installer/apiroutes"
 	"github.com/eclipse/codewind-installer/utils"
 	"github.com/urfave/cli"
 )
 
 //StatusCommand to show the status
 func StatusCommand(c *cli.Context) {
+	targetDeployment := FindTargetDeployment()
+	if strings.EqualFold(targetDeployment.Name, "local") {
+		StatusCommandLocalDeployment(c)
+	} else {
+		StatusCommandRemoteDeployment(c, targetDeployment)
+	}
+}
+
+func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
+	jsonOutput := c.Bool("json")
+	apiResponse, err := apiroutes.GetAPIEnvironment(c, d.Url)
+	if err != nil {
+		if jsonOutput {
+			type status struct {
+				Status   string   `json:"status"`
+				Versions []string `json:"installed-versions"`
+			}
+			respStatus := &status{
+				Status:   "stopped",
+				Versions: []string{},
+			}
+			output, _ := json.Marshal(respStatus)
+			fmt.Println(string(output))
+		} else {
+			fmt.Println("Codewind remote deployment did not respond on " + d.Url)
+		}
+		os.Exit(0)
+	}
+
+	// Codewind responded
+	if jsonOutput {
+		type status struct {
+			Status   string   `json:"status"`
+			URL      string   `json:"url"`
+			Versions []string `json:"installed-versions"`
+			Started  []string `json:"started"`
+		}
+		versions := []string{}
+		resp := &status{
+			Status:   "started",
+			Versions: append(versions, apiResponse.Version),
+			Started:  append(versions, apiResponse.Version),
+			URL:      d.Url,
+		}
+		output, _ := json.Marshal(resp)
+		fmt.Println(string(output))
+	} else {
+		fmt.Println("Codewind is installed and running on: " + d.Url)
+	}
+	os.Exit(0)
+
+}
+
+func StatusCommandLocalDeployment(c *cli.Context) {
 	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {
 		// STARTED

--- a/actions/status.go
+++ b/actions/status.go
@@ -14,6 +14,7 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -49,6 +50,7 @@ func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 			fmt.Println(string(output))
 		} else {
 			fmt.Println("Codewind remote deployment did not respond on " + d.Url)
+			log.Println(err)
 		}
 		os.Exit(0)
 	}

--- a/apiroutes/environment.go
+++ b/apiroutes/environment.go
@@ -35,7 +35,7 @@ func GetAPIEnvironment(c *cli.Context, host string) (*Environment, error) {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	resp, err := http.Get(host + "/api/v1/environment")
+	resp, err := http.Get(host + "api/v1/environment")
 	if err != nil {
 		return nil, err
 	}

--- a/apiroutes/environment.go
+++ b/apiroutes/environment.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/urfave/cli"
+)
+
+type Environment struct {
+	RunningOnICP      bool   `json:"running_on_icp"`
+	UserString        string `json:"user_string"`
+	SocketNamespace   string `json:"socket_namespace"`
+	Version           string `json:"codewind_version"`
+	WorkspaceLocation string `json:"workspace_location"`
+	Platform          string `json:"os_platform"`
+}
+
+func GetAPIEnvironment(c *cli.Context, host string) (*Environment, error) {
+
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	resp, err := http.Get(host + "/api/v1/environment")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var environment Environment
+	err = json.Unmarshal(byteArray, &environment)
+	if err != nil {
+		return nil, err
+	}
+	return &environment, nil
+}

--- a/apiroutes/environment.go
+++ b/apiroutes/environment.go
@@ -35,7 +35,7 @@ func GetAPIEnvironment(c *cli.Context, host string) (*Environment, error) {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	resp, err := http.Get(host + "api/v1/environment")
+	resp, err := http.Get(host + "/api/v1/environment")
 	if err != nil {
 		return nil, err
 	}

--- a/errors/error.go
+++ b/errors/error.go
@@ -52,6 +52,10 @@ func CheckErr(err error, code int, optMsg string) {
 		case 206:
 			// Do not want to exit if this is thrown
 			log.Print("DELETE_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 207:
+			log.Fatal("READ_FILE_ERROR", "[", code, "]: ", err, ". ", optMsg)
+		case 208:
+			log.Fatal("PARSING_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 300:
 			log.Fatal("APPLICATION_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		case 400:

--- a/main.go
+++ b/main.go
@@ -14,5 +14,6 @@ package main
 import "github.com/eclipse/codewind-installer/actions"
 
 func main() {
+	actions.InitDeploymentConfigIfRequired()
 	actions.Commands()
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,6 +11,11 @@
 
 package utils
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // RemoveDuplicateEntries elements
 func RemoveDuplicateEntries(inputArr []string) []string {
 
@@ -30,4 +35,9 @@ func RemoveDuplicateEntries(inputArr []string) []string {
 	}
 
 	return result
+}
+
+func PrettyPrintJSON(i interface{}) {
+	s, _ := json.MarshalIndent(i, "", "\t")
+	fmt.Println(string(s))
 }


### PR DESCRIPTION
# Problem: 

The cli will need to know the url of where the Codewind server is running. Need to have getters and setters for the location of the Codewind server

Issue raised in https://github.com/eclipse/codewind/issues/254

# Solution: 

This PR adds a new deployments command with the following sub-commands : 

```
   add, a      Add a new deployment to the list
   remove, rm  Remove a deployment from the list
   target, t   Show/Change the current target deployment
   list, ls    List known deployments
   reset       Resets the deployments list
```

### options for add : 
```
OPTIONS:
   --name value   A reference name
   --label value  A displayable name
   --url value    The ingress url of the PFE instance
```

### options for remove : 
```
OPTIONS:
   --name value   The reference name of the deployment to be removed
```

### options for target.
```
OPTIONS:
   --name value  Sets the target to this deployment reference name
```

### options for list and reset
NONE



# Extras 

* On first use a new configuration file is created containing "local" deployment settings
* The status command has been updated to retrieve Codewind server status from the deployment identified using the target sub-command.   By default "local" will be the target
* A new global option --insecure has been added to bypass X.509 certificate validation if required when testing against a TLS enabled ingress without a properly configured certificate
* Initial tests have been included - additional coverage to follow
* Documentation and samples to follow 


Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>