### PR TITLE
Run `appsody init` when creating a project from an Appsody template

### DIFF
--- a/utils/appsody.go
+++ b/utils/appsody.go
@@ -13,7 +13,6 @@
 
  import (
 	"bytes"
-	"fmt"
 	"os/exec"
 	"log"
 )
@@ -29,9 +28,9 @@
 		log.Println("There was a problem initializing the Appsody project: ", err, ". Project was not initialized.")
 		return false, err
 	}
-	fmt.Printf("Please wait while the Appsody project is initialized... %s \n", output.String())
+	log.Printf("Please wait while the Appsody project is initialized... %s \n", output.String())
 	cmd.Wait()
-	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
+	log.Println(output.String()) // Wait to finish execution, so we can read all output
 	return true, nil
  }
  

--- a/utils/appsody.go
+++ b/utils/appsody.go
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+ package utils
+
+ import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"log"
+)
+ 
+ // SuccessfullyCallAppsodyInit calls Appsody Init to initialise Appsody projects and returns a boolean to indicate success
+ func SuccessfullyCallAppsodyInit(projectPath string) (bool, error) {
+	cmd := exec.Command("appsody", "init")
+	cmd.Dir = projectPath
+	output := new(bytes.Buffer)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
+		log.Println("There was a problem initializing the Appsody project: ", err, ". Project was not initialized.")
+		return false, err
+	}
+	fmt.Printf("Please wait while the Appsody project is initialized... %s \n", output.String())
+	cmd.Wait()
+	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
+	return true, nil
+ }
+ 

--- a/utils/project.go
+++ b/utils/project.go
@@ -33,10 +33,10 @@ type CWSettings struct {
 	MavenProperties   []string `json:"mavenProperties,omitempty"`
 }
 
-// DetermineProjectInfo returns the language and build-type of a project
-func DetermineProjectInfo(projectPath string) (string, string) {
-	language, buildType := "unknown", "docker"
-	if PathExists(path.Join(projectPath, "pom.xml")) {
+// DetermineProjectInfo returns the language and build-type of a project, as well as if it's an Appsody project
+func DetermineProjectInfo(projectPath string) (string, string, bool) {
+	language, buildType, isAppsody := "unknown", "docker", false
+	if _, err := os.Stat(path.Join(projectPath, "pom.xml")); err == nil {
 		language = "java"
 		buildType = determineJavaBuildType(projectPath)
 	}
@@ -48,7 +48,13 @@ func DetermineProjectInfo(projectPath string) (string, string) {
 		language = "swift"
 		buildType = "swift"
 	}
-	return language, buildType
+	if _, err := os.Stat(path.Join(projectPath, "stack.yaml")); err == nil {
+		isAppsody = true
+	}
+	if _, err := os.Stat(path.Join(projectPath, ".appsody-config.yaml")); err == nil {
+		isAppsody = true
+	}
+	return language, buildType, isAppsody
 }
 
 // CheckProjectPath will stop the process and return an error if path does not

--- a/utils/project.go
+++ b/utils/project.go
@@ -36,7 +36,7 @@ type CWSettings struct {
 // DetermineProjectInfo returns the language and build-type of a project, as well as if it's an Appsody project
 func DetermineProjectInfo(projectPath string) (string, string, bool) {
 	language, buildType, isAppsody := "unknown", "docker", false
-	if _, err := os.Stat(path.Join(projectPath, "pom.xml")); err == nil {
+	if PathExists(path.Join(projectPath, "pom.xml")) {
 		language = "java"
 		buildType = determineJavaBuildType(projectPath)
 	}
@@ -48,10 +48,10 @@ func DetermineProjectInfo(projectPath string) (string, string, bool) {
 		language = "swift"
 		buildType = "swift"
 	}
-	if _, err := os.Stat(path.Join(projectPath, "stack.yaml")); err == nil {
+	if PathExists(path.Join(projectPath, "stack.yaml")) {
 		isAppsody = true
 	}
-	if _, err := os.Stat(path.Join(projectPath, ".appsody-config.yaml")); err == nil {
+	if PathExists(path.Join(projectPath, ".appsody-config.yaml")) {
 		isAppsody = true
 	}
 	return language, buildType, isAppsody


### PR DESCRIPTION
### Problem
https://github.com/eclipse/codewind/issues/270
Appsody templates need `appsody init` running

### Solution
When a template is downloaded, a check to see if it's an appsody template is made (project contains `stack.yaml` or `.appsody-config.yaml`). If it is, call `appsody init` to initialise the project. If the user hasn't installed Appsody CLI, log a message to that affect and return an InitializationFailure.

### Testing
Manual
```
C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>go run main.go project -u https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz .\appsodyProj
Downloaded file from 'https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz' to '.\appsodyProj/temp.tar.gz'
Please wait while the Appsody project is initialized...
Setting up the development environment
Running command: docker[pull appsody/nodejs:0.2]
Running command: docker[run --rm --entrypoint /bin/bash appsody/nodejs:0.2 -c find /project -type f -name .appsody-init.bat]
Successfully initialized Appsody project
{"status":"success","path":".\\appsodyProj","result":{"language":"nodejs","buildType":"nodejs"}}

C:\Users\MattColegate\go\src\github.com\eclipse\codewind-installer>go run main.go project -u https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz .\appsodyProj2
Downloaded file from 'https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz' to '.\appsodyProj2/temp.tar.gz'
2019/08/30 14:14:57 There was a problem initializing the Appsody project:  exec: "appsody": executable file not found in %PATH% . Project was not initialized.
{"status":"failed","path":".\\appsodyProj2","result":"exec: \"appsody\": executable file not found in %PATH%"}
```

Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>