### PR TITLE
Fix incorrect output on project generation/validation

### DIFF
--- a/actions/project.go
+++ b/actions/project.go
@@ -27,13 +27,13 @@ type (
 	// ProjectType represents the information Codewind requires to build a project.
 	ProjectType struct {
 		Language  string `json:"language"`
-		BuildType string `json:"buildType"`
+		BuildType string `json:"projectType"`
 	}
 
 	// ValidationResponse represents the response to validating a project on the users filesystem.
 	ValidationResponse struct {
 		Status string      `json:"status"`
-		Path   string      `json:"path"`
+		Path   string      `json:"projectPath"`
 		Result ProjectType `json:"result"`
 	}
 )

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -138,13 +138,14 @@ func DownloadFile(URL, destination string) error {
 	// Create the file
 	file, err := os.Create(destination)
 	if err != nil {
+		log.Println(err)
 		return err
 	}
 	defer file.Close()
 
 	// Write body to file
 	_, err = io.Copy(file, resp.Body)
-	fmt.Printf("Downloaded file from '%s' to '%s'\n", URL, destination)
+	log.Printf("Downloaded file from '%s' to '%s'\n", URL, destination)
 
 	return err
 }
@@ -191,7 +192,7 @@ func UnZip(filePath, destination string) error {
 			errors.CheckErr(err, 404, "")
 		}
 	}
-	fmt.Printf("Extracted file from '%s' to '%s'\n", filePath, destination)
+	log.Printf("Extracted file from '%s' to '%s'\n", filePath, destination)
 	return nil
 }
 


### PR DESCRIPTION
This is for issue #96.

It fixes the format of the JSON output to use the correct field names and moves the extra output to the logger so it goes to stderr.
