### PR TITLE
Ensure parent ~/.codewind directory is created.

### DIFF
--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -57,7 +57,7 @@ type Deployment struct {
 func InitDeploymentConfigIfRequired() {
 	_, err := os.Stat(getDeploymentConfigFilename())
 	if os.IsNotExist(err) {
-		os.Mkdir(getDeploymentConfigPath(), 0777)
+		os.MkdirAll(getDeploymentConfigPath(), 0777)
 		ResetDeploymentsFile()
 	}
 }


### PR DESCRIPTION
If the `~/.codewind` directory doesn't exist the installer won't start as it fails to create `~/.codewind/config/` directory to put the `deployments.json` file in. This PR just ensures the parent directories are created.