### PR TITLE
Add cmds to add and delete template repos

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -185,10 +185,51 @@ func Commands() {
 				},
 				{
 					Name:  "repos",
-					Usage: "List available template repos",
-					Action: func(c *cli.Context) error {
-						ListTemplateRepos()
-						return nil
+					Usage: "Manage template repos",
+					Subcommands: []cli.Command{
+						{
+							Name:    "list",
+							Aliases: []string{"ls"},
+							Usage: "List available template repos",
+							Action: func(c *cli.Context) error {
+								ListTemplateRepos()
+								return nil
+							},
+						},
+						{
+							Name:  "add",
+							Usage: "Add a template repo",
+							Flags: []cli.Flag{
+								cli.StringFlag{
+									Name:  "URL",
+									Usage: "URL of the template repo",
+								},
+								cli.StringFlag{
+									Name:  "description",
+									Value: "",
+									Usage: "Description of the template repo",
+								},
+							},
+							Action: func(c *cli.Context) error {
+								CmdToAddTemplateRepo(c)
+								return nil
+							},
+						},
+						{
+							Name:  "remove",
+							Aliases: []string{"rm"},
+							Usage: "Remove a template repo",
+							Flags: []cli.Flag{
+								cli.StringFlag{
+									Name:  "URL",
+									Usage: "URL of the template repo",
+								},
+							},
+							Action: func(c *cli.Context) error {
+								CmdToDeleteTemplateRepo(c)
+								return nil
+							},
+						},
 					},
 				},
 			},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -157,7 +157,7 @@ func Commands() {
 				{
 					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage: "List available templates",
+					Usage:   "List available templates",
 					Flags: []cli.Flag{
 						cli.StringFlag{
 							Name:  "projectStyle",
@@ -190,7 +190,7 @@ func Commands() {
 						{
 							Name:    "list",
 							Aliases: []string{"ls"},
-							Usage: "List available template repos",
+							Usage:   "List available template repos",
 							Action: func(c *cli.Context) error {
 								ListTemplateRepos()
 								return nil
@@ -211,14 +211,14 @@ func Commands() {
 								},
 							},
 							Action: func(c *cli.Context) error {
-								CmdToAddTemplateRepo(c)
+								AddTemplateRepo(c)
 								return nil
 							},
 						},
 						{
-							Name:  "remove",
+							Name:    "remove",
 							Aliases: []string{"rm"},
-							Usage: "Remove a template repo",
+							Usage:   "Remove a template repo",
 							Flags: []cli.Flag{
 								cli.StringFlag{
 									Name:  "URL",
@@ -226,7 +226,7 @@ func Commands() {
 								},
 							},
 							Action: func(c *cli.Context) error {
-								CmdToDeleteTemplateRepo(c)
+								DeleteTemplateRepo(c)
 								return nil
 							},
 						},

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -12,11 +12,13 @@
 package actions
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 
 	"github.com/eclipse/codewind-installer/config"
 	"github.com/urfave/cli"
@@ -73,10 +75,33 @@ func ListTemplateRepos() {
 	PrettyPrintJSON(repos)
 }
 
+// CmdToAddTemplateRepo adds the provided template repo to PFE.
+func CmdToAddTemplateRepo(c *cli.Context) {
+	repos, err := AddTemplateRepo(
+		c.String("URL"),
+		c.String("description"),
+	)
+	if err != nil {
+		log.Printf("Error adding template repo: %q", err)
+		return
+	}
+	PrettyPrintJSON(repos)
+}
+
+// CmdToDeleteTemplateRepo deletes the provided template repo from PFE.
+func CmdToDeleteTemplateRepo(c *cli.Context) {
+	repos, err := DeleteTemplateRepo(c.String("URL"))
+	if err != nil {
+		log.Printf("Error deleting template repo: %q", err)
+		return
+	}
+	PrettyPrintJSON(repos)
+}
+
 // GetTemplates gets project templates from PFE's REST API.
 // Filter them using the function arguments
 func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
-	req, err := http.NewRequest("GET", config.PFEApiRoute + "templates", nil)
+	req, err := http.NewRequest("GET", config.PFEApiRoute+"templates", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -87,10 +112,10 @@ func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, erro
 	if showEnabledOnly != "" {
 		query.Add("showEnabledOnly", showEnabledOnly)
 	}
-    req.URL.RawQuery = query.Encode()
+	req.URL.RawQuery = query.Encode()
 
 	client := &http.Client{}
-    resp, err := client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -133,6 +158,83 @@ func GetTemplateRepos() ([]TemplateRepo, error) {
 	resp, err := http.Get(config.PFEApiRoute + "templates/repositories")
 	if err != nil {
 		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []TemplateRepo
+	json.Unmarshal(byteArray, &repos)
+
+	return repos, nil
+}
+
+// AddTemplateRepo adds a template repo to PFE and
+// returns the new list of existing repos
+func AddTemplateRepo(URL, description string) ([]TemplateRepo, error) {
+	if _, err := url.ParseRequestURI(URL); err != nil {
+		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
+	}
+
+	values := map[string]string{
+		"url":         URL,
+		"description": description,
+	}
+	jsonValue, _ := json.Marshal(values)
+
+	resp, err := http.Post(
+		config.PFEApiRoute+"templates/repositories",
+		"application/json",
+		bytes.NewBuffer(jsonValue),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []TemplateRepo
+	json.Unmarshal(byteArray, &repos)
+
+	return repos, nil
+}
+
+// DeleteTemplateRepo deletes a template repo from PFE and
+// returns the new list of existing repos
+func DeleteTemplateRepo(URL string) ([]TemplateRepo, error) {
+	if _, err := url.ParseRequestURI(URL); err != nil {
+		return nil, err
+	}
+
+	values := map[string]string{"url": URL}
+	jsonValue, _ := json.Marshal(values)
+
+	req, err := http.NewRequest(
+		"DELETE",
+		config.PFEApiRoute+"templates/repositories",
+		bytes.NewBuffer(jsonValue),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
 	}
 
 	defer resp.Body.Close()

--- a/actions/templates_test.go
+++ b/actions/templates_test.go
@@ -12,6 +12,9 @@
 package actions
 
 import (
+	"errors"
+	"log"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,37 +26,37 @@ var numTemplates int = numCodewindTemplates + numAppsodyTemplates
 
 func TestGetTemplates(t *testing.T) {
 	tests := map[string]struct {
-		inProjectStyle string
+		inProjectStyle    string
 		inShowEnabledOnly string
-		wantedType     []Template
-		wantedLength   int
+		wantedType        []Template
+		wantedLength      int
 	}{
 		"get templates of all styles": {
-			inProjectStyle: "",
+			inProjectStyle:    "",
 			inShowEnabledOnly: "",
-			wantedType:     []Template{},
-			wantedLength:   numTemplates,
+			wantedType:        []Template{},
+			wantedLength:      numTemplates,
 		},
 		"filter templates by known style": {
 			inProjectStyle: "Codewind",
-			wantedType:   []Template{},
-			wantedLength: numCodewindTemplates,
+			wantedType:     []Template{},
+			wantedLength:   numCodewindTemplates,
 		},
 		"filter templates by unknown style": {
 			inProjectStyle: "unknownStyle",
-			wantedType:   []Template{},
-			wantedLength: 0,
+			wantedType:     []Template{},
+			wantedLength:   0,
 		},
 		"filter templates by enabled templates": {
 			inShowEnabledOnly: "true",
-			wantedType:   []Template{},
-			wantedLength: numTemplates,
+			wantedType:        []Template{},
+			wantedLength:      numTemplates,
 		},
 		"filter templates by enabled templates of unknown style": {
-			inProjectStyle: "unknownStyle",
+			inProjectStyle:    "unknownStyle",
 			inShowEnabledOnly: "false",
-			wantedType:     []Template{},
-			wantedLength:   0,
+			wantedType:        []Template{},
+			wantedLength:      0,
 		},
 	}
 	for name, test := range tests {
@@ -105,4 +108,86 @@ func TestGetTemplateRepos(t *testing.T) {
 			assert.Equal(t, test.wantedErr, err)
 		})
 	}
+}
+
+func TestFailuresAddTemplateRepo(t *testing.T) {
+	tests := map[string]struct {
+		inURL         string
+		inDescription string
+		wantedType    []TemplateRepo
+		wantedErr     error
+	}{
+		"fail case: add invalid URL": {
+			inURL:         "invalidURL",
+			inDescription: "invalidURL",
+			wantedType:    nil,
+			wantedErr:     errors.New("Error: 'invalidURL' is not a valid URL"),
+		},
+		"fail case: add duplicate URL": {
+			inURL:         "https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json",
+			inDescription: "example repository containing links to templates",
+			wantedType:    nil,
+			wantedErr:     errors.New("Error: PFE responded with status code 400"),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := AddTemplateRepo(test.inURL, test.inDescription)
+			assert.IsType(t, test.wantedType, got, "got: %v", got)
+			assert.Equal(t, test.wantedErr, err)
+		})
+	}
+}
+
+func TestFailuresDeleteTemplateRepo(t *testing.T) {
+	tests := map[string]struct {
+		inURL      string
+		wantedType []TemplateRepo
+		wantedErr  error
+	}{
+		"fail case: remove invalid URL": {
+			inURL:      "invalidURL",
+			wantedType: nil,
+			wantedErr:  new(url.Error),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := DeleteTemplateRepo(test.inURL)
+			assert.IsType(t, test.wantedType, got, "got: %v", got)
+			assert.IsType(t, test.wantedErr, err)
+		})
+	}
+}
+
+func TestSuccessfulAddAndDeleteTemplateRepo(t *testing.T) {
+	testRepoURL := "https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json"
+
+	originalRepos, err := GetTemplateRepos()
+	if err != nil {
+		log.Fatalf("[TestSuccessfulAddAndDeleteTemplateRepo] Error getting template repos: %s", err)
+	}
+	originalNumRepos := len(originalRepos)
+
+	t.Run("Successfully add template repo", func(t *testing.T) {
+		wantedNumRepos := originalNumRepos + 1
+
+		got, err := AddTemplateRepo(testRepoURL, "example description")
+
+		assert.IsType(t, []TemplateRepo{}, got)
+		assert.Equal(t, wantedNumRepos, len(got), "got: %v", got)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Successfully delete template repo", func(t *testing.T) {
+		wantedNumRepos := originalNumRepos
+
+		got, err := DeleteTemplateRepo(testRepoURL)
+
+		assert.IsType(t, []TemplateRepo{}, got)
+		assert.Equal(t, wantedNumRepos, len(got), "got: %v", got)
+		assert.Nil(t, err)
+	})
+
+	// This test cleans up after itself
 }

--- a/apiroutes/templates.go
+++ b/apiroutes/templates.go
@@ -1,0 +1,192 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/eclipse/codewind-installer/config"
+)
+
+type (
+	// Template represents a project template.
+	Template struct {
+		Label       string `json:"label"`
+		Description string `json:"description"`
+		Language    string `json:"language"`
+		URL         string `json:"url"`
+		ProjectType string `json:"projectType"`
+	}
+
+	// TemplateRepo represents a template repository.
+	TemplateRepo struct {
+		Description string `json:"description"`
+		URL         string `json:"url"`
+	}
+)
+
+// GetTemplates gets project templates from PFE's REST API.
+// Filter them using the function arguments
+func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
+	req, err := http.NewRequest("GET", config.PFEApiRoute+"templates", nil)
+	if err != nil {
+		return nil, err
+	}
+	query := req.URL.Query()
+	if projectStyle != "" {
+		query.Add("projectStyle", projectStyle)
+	}
+	if showEnabledOnly != "" {
+		query.Add("showEnabledOnly", showEnabledOnly)
+	}
+	req.URL.RawQuery = query.Encode()
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var templates []Template
+	json.Unmarshal(byteArray, &templates)
+
+	return templates, nil
+}
+
+// GetTemplateStyles gets all template styles from PFE's REST API
+func GetTemplateStyles() ([]string, error) {
+	resp, err := http.Get(config.PFEApiRoute + "templates/styles")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var styles []string
+	json.Unmarshal(byteArray, &styles)
+
+	return styles, nil
+}
+
+// GetTemplateRepos gets all template repos from PFE's REST API
+func GetTemplateRepos() ([]TemplateRepo, error) {
+	resp, err := http.Get(config.PFEApiRoute + "templates/repositories")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []TemplateRepo
+	json.Unmarshal(byteArray, &repos)
+
+	return repos, nil
+}
+
+// AddTemplateRepo adds a template repo to PFE and
+// returns the new list of existing repos
+func AddTemplateRepo(URL, description string) ([]TemplateRepo, error) {
+	if _, err := url.ParseRequestURI(URL); err != nil {
+		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
+	}
+
+	values := map[string]string{
+		"url":         URL,
+		"description": description,
+	}
+	jsonValue, _ := json.Marshal(values)
+
+	resp, err := http.Post(
+		config.PFEApiRoute+"templates/repositories",
+		"application/json",
+		bytes.NewBuffer(jsonValue),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []TemplateRepo
+	json.Unmarshal(byteArray, &repos)
+
+	return repos, nil
+}
+
+// DeleteTemplateRepo deletes a template repo from PFE and
+// returns the new list of existing repos
+func DeleteTemplateRepo(URL string) ([]TemplateRepo, error) {
+	if _, err := url.ParseRequestURI(URL); err != nil {
+		return nil, err
+	}
+
+	values := map[string]string{"url": URL}
+	jsonValue, _ := json.Marshal(values)
+
+	req, err := http.NewRequest(
+		"DELETE",
+		config.PFEApiRoute+"templates/repositories",
+		bytes.NewBuffer(jsonValue),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []TemplateRepo
+	json.Unmarshal(byteArray, &repos)
+
+	return repos, nil
+}

--- a/apiroutes/templates_test.go
+++ b/apiroutes/templates_test.go
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package actions
+package apiroutes
 
 import (
 	"errors"


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## Problem
To manage project templates, Codewind Vscode plugins want to call this Go CLI rather than Codewind's REST API directly. Currently the CLI cannot add and remove template repos.

## Solution
Add 2 commands:
1. `codewind-installer templates repos add -URL=<string> -description=<string>` calls Codewind's REST API `POST templates/repositories` with body `{ url: <string>, description: <string> }` to add that template repository to PFE

2. `codewind-installer templates repos remove -URL=<string>` calls Codewind's REST API `DELETE templates/repositories` with body `{ url: <string> }` to delete that template repository from PFE

The 2nd commit splits our template code into 2 files, to make it more maintainable

## Tests
- Unit tests (automated)
- Integration tests (manual. Automated tests coming soon).

