### PR TITLE
Fix incorrect change of 'nodejs' type to 'node'.

### DIFF
--- a/utils/project.go
+++ b/utils/project.go
@@ -41,8 +41,8 @@ func DetermineProjectInfo(projectPath string) (string, string) {
 		buildType = determineJavaBuildType(projectPath)
 	}
 	if PathExists(path.Join(projectPath, "package.json")) {
-		language = "node"
-		buildType = "node"
+		language = "nodejs"
+		buildType = "nodejs"
 	}
 	if PathExists(path.Join(projectPath, "Package.swift")) {
 		language = "swift"

--- a/utils/project_test.go
+++ b/utils/project_test.go
@@ -41,8 +41,8 @@ func TestDetermineProjectInfo(t *testing.T) {
 		},
 		"success case: node.js project": {
 			in:            path.Join("..", "resources", "test", "node-project"),
-			wantLanguage:  "node",
-			wantBuildType: "node",
+			wantLanguage:  "nodejs",
+			wantBuildType: "nodejs",
 		},
 		"success case: swift project": {
 			in:            path.Join("..", "resources", "test", "swift-project"),


### PR DESCRIPTION
This error was introduced here:
https://github.com/eclipse/codewind-installer/pull/79/files#diff-d19b0c7f5ba248ae0ac585477f469744R44