### PR TITLE
quickfix to remove Appsody containers on stop-all command

### DIFF
--- a/actions/remove.go
+++ b/actions/remove.go
@@ -22,16 +22,17 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand(c *cli.Context) {
 	tag := c.String("tag")
-	imageArr := [4]string{}
+	imageArr := [5]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
 	imageArr[2] = "eclipse/codewind-initialize"
 	imageArr[3] = "cw-"
+	imageArr[4] = "appsody"
 	networkName := "codewind"
 
 	if tag != "" {
 		for i := 0; i < len(imageArr); i++ {
-			if i == 3 {
+			if i == 3 || i == 4 {
 				break
 			}
 			imageArr[i] = imageArr[i] + "-amd64:" + tag

--- a/actions/stop-all.go
+++ b/actions/stop-all.go
@@ -20,11 +20,11 @@ import (
 
 //StopAllCommand to stop codewind and project containers
 func StopAllCommand() {
-	containerArr := [4]string{}
+	containerArr := [2]string{}
 	containerArr[0] = "codewind-pfe"
 	containerArr[1] = "codewind-performance"
-	containerArr[2] = "cw-"
-	containerArr[3] = "appsody"
+	containerArr[0] = "cw-"
+	containerArr[1] = "appsody"
 
 	containers := utils.GetContainerList()
 
@@ -32,8 +32,12 @@ func StopAllCommand() {
 	for _, container := range containers {
 		for _, key := range containerArr {
 			if strings.HasPrefix(container.Image, key) {
-				fmt.Println("Stopping container ", container.Names, "... ")
-				utils.StopContainer(container)
+				fmt.Println(container)
+				// stop appsody containers with "cw-" in their name, and all other cw containers
+				if key != "appsody" || strings.Contains(container.Names[0], "cw-") {
+					fmt.Println("Stopping container ", container.Names, "... ")
+					utils.StopContainer(container)
+				}
 			}
 		}
 	}

--- a/actions/stop-all.go
+++ b/actions/stop-all.go
@@ -20,10 +20,11 @@ import (
 
 //StopAllCommand to stop codewind and project containers
 func StopAllCommand() {
-	containerArr := [3]string{}
+	containerArr := [4]string{}
 	containerArr[0] = "codewind-pfe"
 	containerArr[1] = "codewind-performance"
 	containerArr[2] = "cw-"
+	containerArr[3] = "appsody"
 
 	containers := utils.GetContainerList()
 


### PR DESCRIPTION
**Problem**
The stop-all command does stop Appsody project containers, as the code only checks for codewind prefixes on the image.
https://github.com/eclipse/codewind/issues/224

**Solution**
Add a check for `appsody` in the images (quickfix), this will also remove existing Appsody projects. A better solution will be required after ifix, one in which we can determine codewind Appsody projects only.

**Tests**
Manual
