### PR TITLE
remove appsody from array of images to remove

### DIFF
--- a/actions/remove.go
+++ b/actions/remove.go
@@ -22,12 +22,11 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand(c *cli.Context) {
 	tag := c.String("tag")
-	imageArr := [5]string{}
+	imageArr := [4]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
 	imageArr[2] = "eclipse/codewind-initialize"
 	imageArr[3] = "cw-"
-	imageArr[4] = "appsody"
 	networkName := "codewind"
 
 	if tag != "" {


### PR DESCRIPTION
The previous PR left in `appsody` in the array of prefixes to check when removing images. This doesn't actually remove images, but isn't needed and is confusing.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>