### PR TITLE
Replace "[PROJ_NAME_PLACEHOLDER]" with the project name.

### DIFF
--- a/actions/project.go
+++ b/actions/project.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"regexp"
 
 	"github.com/eclipse/codewind-installer/errors"
 	"github.com/eclipse/codewind-installer/utils"
@@ -46,9 +47,23 @@ func DownloadTemplate(c *cli.Context) {
 		log.Fatal("destination not set")
 	}
 
+	projectDir := path.Base(destination)
+
+	// Remove invalid characters from the string we will use
+	// as the project name in the template.
+	r := regexp.MustCompile("[^a-zA-Z0-9._-]");
+	projectName := r.ReplaceAllString(projectDir, "");
+	if (len(projectName) == 0){
+		projectName = "PROJ_NAME_PLACEHOLDER"
+	}
+
 	url := c.String("u")
 
 	err := utils.DownloadFromURLThenExtract(url, destination)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = utils.ReplaceInFiles(destination, "[PROJ_NAME_PLACEHOLDER]", projectName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -12,8 +12,8 @@
 package utils
 
 import (
-	"archive/zip"
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -272,24 +273,39 @@ func ReplaceInFiles(projectPath string, oldStr string, newStr string) error {
 
 	oldBytes := []byte(oldStr)
 	newBytes := []byte(newStr)
+
+	pathsToRename := []string{}
+
 	lastError := error(nil)
-	filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
+	filepath.Walk(projectPath, func(pathName string, info os.FileInfo, err error) error {
+
+		if strings.Contains(path.Base(pathName), oldStr) {
+			// Keep track of files we need to rename but don't rename
+			// them until the filepath.Walk is complete.
+			pathsToRename = append(pathsToRename, pathName);
+		}
+
 		if info.IsDir() {
 			return nil
 		}
 
-		content, err := ioutil.ReadFile(path)
+		content, err := ioutil.ReadFile(pathName)
 		if err != nil {
 			lastError = err
 			return nil
 		}
 		newContent := bytes.Replace(content, []byte(oldBytes), []byte(newBytes), -1)
-		if err = ioutil.WriteFile(path, newContent, info.Mode()); err != nil {
+		if err = ioutil.WriteFile(pathName, newContent, info.Mode()); err != nil {
 			lastError = err
 			return nil
 		}
 		return nil
 	})
+
+	for _, pathName := range pathsToRename {
+		newPath := strings.Replace(pathName, oldStr, newStr, -1)
+		os.Rename(pathName, newPath)
+	}
 
 	return lastError
 }

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -14,6 +14,7 @@ package utils
 import (
 	"archive/zip"
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"fmt"
@@ -265,4 +266,30 @@ func PathExists(path string) bool {
 		return true
 	}
 	return false
+}
+
+func ReplaceInFiles(projectPath string, oldStr string, newStr string) error {
+
+	oldBytes := []byte(oldStr)
+	newBytes := []byte(newStr)
+	lastError := error(nil)
+	filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			lastError = err
+			return nil
+		}
+		newContent := bytes.Replace(content, []byte(oldBytes), []byte(newBytes), -1)
+		if err = ioutil.WriteFile(path, newContent, info.Mode()); err != nil {
+			lastError = err
+			return nil
+		}
+		return nil
+	})
+
+	return lastError
 }


### PR DESCRIPTION
This makes the installer scan the downloaded source for a template project and replace the placeholder string "[PROJ_NAME_PLACEHOLDER]" with a generated name based on the project directory.

This is for eclipse/codewind#386