### PR TITLE
Allow installer to run when docker.sock unavailable.

### DIFF
--- a/apiroutes/templates.go
+++ b/apiroutes/templates.go
@@ -42,7 +42,7 @@ type (
 // GetTemplates gets project templates from PFE's REST API.
 // Filter them using the function arguments
 func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
-	req, err := http.NewRequest("GET", config.PFEApiRoute+"templates", nil)
+	req, err := http.NewRequest("GET", config.PFEApiRoute() + "templates", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, erro
 
 // GetTemplateStyles gets all template styles from PFE's REST API
 func GetTemplateStyles() ([]string, error) {
-	resp, err := http.Get(config.PFEApiRoute + "templates/styles")
+	resp, err := http.Get(config.PFEApiRoute() + "templates/styles")
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func GetTemplateStyles() ([]string, error) {
 
 // GetTemplateRepos gets all template repos from PFE's REST API
 func GetTemplateRepos() ([]TemplateRepo, error) {
-	resp, err := http.Get(config.PFEApiRoute + "templates/repositories")
+	resp, err := http.Get(config.PFEApiRoute() + "templates/repositories")
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func AddTemplateRepo(URL, description string) ([]TemplateRepo, error) {
 	jsonValue, _ := json.Marshal(values)
 
 	resp, err := http.Post(
-		config.PFEApiRoute+"templates/repositories",
+		config.PFEApiRoute() + "templates/repositories",
 		"application/json",
 		bytes.NewBuffer(jsonValue),
 	)
@@ -164,7 +164,7 @@ func DeleteTemplateRepo(URL string) ([]TemplateRepo, error) {
 
 	req, err := http.NewRequest(
 		"DELETE",
-		config.PFEApiRoute+"templates/repositories",
+		config.PFEApiRoute() + "templates/repositories",
 		bytes.NewBuffer(jsonValue),
 	)
 	req.Header.Set("Content-Type", "application/json")

--- a/config/config.go
+++ b/config/config.go
@@ -15,19 +15,18 @@ import (
 	"github.com/eclipse/codewind-installer/utils"
 )
 
-var hostname, port = utils.GetPFEHostAndPort()
-
-// PFEHostname is the hostname at which PFE is running, e.g. "127.0.0.1"
-var PFEHostname = hostname
-
-// PFEPort is the port on which PFE is running, e.g. "9090"
-var PFEPort = port
-
 // PFEHost is the host at which PFE is running, e.g. "127.0.0.1:9090"
-var PFEHost = hostname + ":" + port
+func PFEHost() string {
+	hostname, port := utils.GetPFEHostAndPort()
+	return hostname + ":" + port
+}
 
 // PFEOrigin is the origin from which PFE is running, e.g. "http://127.0.0.1:9090"
-var PFEOrigin = "http://" + PFEHost
+func PFEOrigin() string {
+	return "http://" + PFEHost()
+}
 
 // PFEApiRoute is the API route at which the PFE REST API can be accessed, e.g. "http://127.0.0.1:9090/api/v1/"
-var PFEApiRoute = PFEOrigin + "/api/v1/"
+func PFEApiRoute() string {
+	return PFEOrigin() + "/api/v1/"
+}

--- a/utils/download.go
+++ b/utils/download.go
@@ -71,7 +71,7 @@ func DownloadFromRepoURL(repoURL string, destination string) error {
 func DownloadAndExtractZip(zipURL string, destination string) error {
 	time := time.Now().Format(time.RFC3339)
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
-	pathToTempZipFile := os.TempDir() + "_" + time + ".zip"
+	pathToTempZipFile := path.Join(os.TempDir(), "_" + time + ".zip")
 
 	err := DownloadFile(zipURL, pathToTempZipFile)
 	if err != nil {


### PR DESCRIPTION
codewind-installer was failing to run on a Linux container without docker installed.
This was because `GetPFEHostAndPort()` which uses the docker libraries was always being called.
This PR changes the installer so that function is only called when necessary.
Also the path for the temporary file assumed `os.TempDir()` returned a string ending with the file separator character, which wasn't always true. `path.Join()` is now used to avoid this problem.

This was found when investigating eclipse/codewind#395

Signed-off-by: Howard Hellyer <hhellyer@uk.ibm.com>