### PR TITLE
Statically compile the linux binary so it can run on Alpine.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ spec:
                         export GOARCH=amd64
                         GOOS=darwin go build -ldflags="-s -w" -o codewind-installer-macos
                         GOOS=windows go build -ldflags="-s -w" -o codewind-installer-win.exe
-                        GOOS=linux go build -ldflags="-s -w" -o codewind-installer-linux
+                        CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o codewind-installer-linux
                         chmod -v +x codewind-installer-*
 
                     '''


### PR DESCRIPTION
This adds the `CGO_ENABLED=0` flag to produce a binary that can run on Alpine linux as well as normal Linux.

I've tested on a local Linux box that this produces a binary that runs inside the theia container but I've marked this WIP so I can download the binary Jenkins builds for this PR and verify that is good as well before this is merged. This PR is ready for review.