### PR TITLE
Liberty recognition now uses Dockerfile

### DIFF
--- a/resources/test/liberty-project/Dockerfile
+++ b/resources/test/liberty-project/Dockerfile
@@ -1,0 +1,1 @@
+FROM websphere-liberty

--- a/utils/project.go
+++ b/utils/project.go
@@ -80,7 +80,10 @@ func determineJavaBuildType(projectPath string) string {
 	if strings.Contains(pomXMLString, "<groupId>org.springframework.boot</groupId>") {
 		return "spring"
 	}
-	if strings.Contains(pomXMLString, "<groupId>org.eclipse.microprofile</groupId>") {
+	pathToDockerfile := path.Join(projectPath, "Dockerfile")
+	dockerfileContents, err := ioutil.ReadFile(pathToDockerfile)
+	dockerfileString := string(dockerfileContents)
+	if strings.Contains(dockerfileString, "FROM websphere-liberty") {
 		return "liberty"
 	}
 	return "docker"


### PR DESCRIPTION
As per the PR on the [Codewind repo](https://github.com/eclipse/codewind/pull/374)

Changing Liberty project recognition to use the Dockerfile rather than the pom.xml:
- The `pom.xml` contents were not unique to Liberty and were also used in Open Liberty
- This means Open Liberty projects that are imported will correctly fall through and be classed as `docker` type instead of being treated as Liberty

See [issue](https://github.com/eclipse/codewind/issues/243) on Codewind repo for details
