### PR TITLE
Init deployment.json on first use

### DIFF
--- a/actions/deployment_test.go
+++ b/actions/deployment_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func Test_GetActiveDeployment(t *testing.T) {
+	InitDeploymentConfigIfRequired()
 	t.Run("ActiveDeployment", func(t *testing.T) {
 		ResetDeploymentsFile()
 		result := FindTargetDeployment()


### PR DESCRIPTION
# Problem

When running tests for the first time the deployment.json file may not exist causing tests to fail. 

# Solution 

This pr checks if the config file exists.  If not,  it creates a new path and file ready for use.

# Re-ran tests manually:

```
=== RUN   Test_GetActiveDeployment
=== RUN   Test_GetActiveDeployment/ActiveDeployment
--- PASS: Test_GetActiveDeployment (0.00s)
    --- PASS: Test_GetActiveDeployment/ActiveDeployment (0.00s)
=== RUN   Test_GetDeploymentsConfig
=== RUN   Test_GetDeploymentsConfig/GetDeploymentsConfig
--- PASS: Test_GetDeploymentsConfig (0.00s)
    --- PASS: Test_GetDeploymentsConfig/GetDeploymentsConfig (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/actions   0.015s
```

Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>