### PR TITLE
re-indent .cw-settings

### DIFF
--- a/utils/project.go
+++ b/utils/project.go
@@ -91,7 +91,7 @@ func determineJavaBuildType(projectPath string) string {
 func WriteNewCwSettings(pathToCwSettings string, BuildType string) {
 	defaultCwSettings := getDefaultCwSettings()
 	cwSettings := addNonDefaultFieldsToCwSettings(defaultCwSettings, BuildType)
-	settings, err := json.MarshalIndent(cwSettings, "", "")
+	settings, err := json.MarshalIndent(cwSettings, "", "  ")
 	errors.CheckErr(err, 203, "")
 	// File permission 0644 grants read and write access to the owner
 	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)


### PR DESCRIPTION
Adds the indent to .cw-settings that was lost when we transferred to the CLI for building projects.