### PR TITLE
Rename codewind-installer -> cwctl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ spec:
     }
 
     environment {
-        CODE_DIRECTORY_FOR_GO = 'src/github.com/eclipse/cwctl'
+        CODE_DIRECTORY_FOR_GO = 'src/github.com/eclipse/codewind-installer'
         DEFAULT_WORKSPACE_DIR_FILE = 'temp_default_dir'
     }
 
@@ -92,29 +92,29 @@ spec:
                         # switch to the code go directory
                         cd ../../$CODE_DIRECTORY_FOR_GO
                         echo $(pwd)
-                        if [ -d cwctl ]; then
-                            rm -rf cwctl
+                        if [ -d codewind-installer ]; then
+                            rm -rf codewind-installer
                         fi
-                        mkdir cwctl
+                        mkdir codewind-installer
 
                         TIMESTAMP="$(date +%F-%H%M)"
                         # WINDOWS EXE: Submit Windows unsigned.exe and save signed output to signed.exe
 
                         # only sign windows exe if not a pull request
                         if [ -z $CHANGE_ID ]; then
-                            curl -o cwctl/cwctl-win-${TIMESTAMP}.exe  -F file=@cwctl-win.exe http://build.eclipse.org:31338/winsign.php
-                            rm cwctl-win.exe
+                            curl -o codewind-installer/cwctl-win-${TIMESTAMP}.exe  -F file=@cwctl-win.exe http://build.eclipse.org:31338/winsign.php
+                            rm codewind-installer-win.exe
                         fi
-                        # move other executable to cwctl directoryand add timestamp to the name
+                        # move other executable to codewind-installer directoryand add timestamp to the name
                         for fileid in cwctl-*; do
-                            mv -v $fileid cwctl/${fileid}-$TIMESTAMP
+                            mv -v $fileid codewind-installer/${fileid}-$TIMESTAMP
                         done
 
                         DEFAULT_WORKSPACE_DIR=$(cat $DEFAULT_WORKSPACE_DIR_FILE)
-                        cp -r cwctl $DEFAULT_WORKSPACE_DIR
+                        cp -r codewind-installer $DEFAULT_WORKSPACE_DIR
                     '''
                     // stash the executables so they are avaialable outside of this agent
-                    dir('cwctl') {
+                    dir('codewind-installer') {
                         stash includes: '**', name: 'EXECUTABLES'
                     }
                 }
@@ -132,19 +132,19 @@ spec:
             agent any
                steps {
                    sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-                println("Deploying cwctl to download area...")
+                println("Deploying codewind-installer to download area...")
                 sh '''
-                    if [ -d cwctl ]; then
-                        rm -rf cwctl
+                    if [ -d codewind-installer ]; then
+                        rm -rf codewind-installer
                     fi
-                    mkdir cwctl
+                    mkdir codewind-installer
                 '''
                 // get the stashed executables
-                 dir ('cwctl') {
+                 dir ('codewind-installer') {
                      unstash 'EXECUTABLES'
                  }
                 sh '''
-                    export REPO_NAME="cwctl"
+                    export REPO_NAME="codewind-installer"
                     export OUTPUT_DIR="$WORKSPACE/dev/ant_build/artifacts"
                     export DOWNLOAD_AREA_URL="https://download.eclipse.org/codewind/$REPO_NAME"
                     export LATEST_DIR="latest"

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -19,7 +19,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var tempFilePath = "docker-compose.yaml"
+var tempFilePath = "codewind-docker-compose.yaml"
 
 const versionNum = "x.x.dev"
 

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -19,17 +19,16 @@ import (
 	"github.com/urfave/cli"
 )
 
-var tempFilePath = "installer-docker-compose.yaml"
-
+var tempFilePath = "docker-compose.yaml"
 
 const versionNum = "x.x.dev"
 
 const healthEndpoint = "/api/v1/environment"
 
-//Commands for the installer
+//Commands for the controller
 func Commands() {
 	app := cli.NewApp()
-	app.Name = "codewind-installer"
+	app.Name = "cwctl"
 	app.Version = versionNum
 	app.Usage = "Start, Stop and Remove Codewind"
 

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -23,11 +23,11 @@ import (
 func RemoveCommand(c *cli.Context) {
 	tag := c.String("tag")
 	imageArr := []string{
-        "eclipse/codewind-pfe-amd64:" + tag,
-        "eclipse/codewind-performance-amd64:" + tag,
-        "eclipse/codewind-initialize-amd64:" + tag,
-        "cw-",
-    }
+		"eclipse/codewind-pfe-amd64:" + tag,
+		"eclipse/codewind-performance-amd64:" + tag,
+		"eclipse/codewind-initialize-amd64:" + tag,
+		"cw-",
+	}
 	networkName := "codewind"
 
 	images := utils.GetImageList()

--- a/actions/start.go
+++ b/actions/start.go
@@ -31,7 +31,7 @@ func StartCommand(c *cli.Context, tempFilePath string, healthEndpoint string) {
 		utils.CreateTempFile(tempFilePath)
 		utils.WriteToComposeFile(tempFilePath, debug)
 		utils.DockerCompose(tag)
-		utils.DeleteTempFile(tempFilePath) // Remove installer-docker-compose.yaml
+		utils.DeleteTempFile(tempFilePath) // Remove docker-compose.yaml
 		utils.PingHealth(healthEndpoint)
 	}
 }

--- a/actions/stop-all.go
+++ b/actions/stop-all.go
@@ -21,11 +21,11 @@ import (
 //StopAllCommand to stop codewind and project containers
 func StopAllCommand() {
 	containerArr := []string{
-		"codewind-pfe", 
+		"codewind-pfe",
 		"codewind-performance",
 		"cw-",
 		"appsody",
-		}
+	}
 
 	containers := utils.GetContainerList()
 

--- a/apiroutes/templates.go
+++ b/apiroutes/templates.go
@@ -42,7 +42,7 @@ type (
 // GetTemplates gets project templates from PFE's REST API.
 // Filter them using the function arguments
 func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
-	req, err := http.NewRequest("GET", config.PFEApiRoute() + "templates", nil)
+	req, err := http.NewRequest("GET", config.PFEApiRoute()+"templates", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func AddTemplateRepo(URL, description string) ([]TemplateRepo, error) {
 	jsonValue, _ := json.Marshal(values)
 
 	resp, err := http.Post(
-		config.PFEApiRoute() + "templates/repositories",
+		config.PFEApiRoute()+"templates/repositories",
 		"application/json",
 		bytes.NewBuffer(jsonValue),
 	)
@@ -164,7 +164,7 @@ func DeleteTemplateRepo(URL string) ([]TemplateRepo, error) {
 
 	req, err := http.NewRequest(
 		"DELETE",
-		config.PFEApiRoute() + "templates/repositories",
+		config.PFEApiRoute()+"templates/repositories",
 		bytes.NewBuffer(jsonValue),
 	)
 	req.Header.Set("Content-Type", "application/json")

--- a/integration.bats
+++ b/integration.bats
@@ -16,7 +16,7 @@
 }
 
 @test "invoke start command - Start dockerhub images (latest)" {
-  run go run main.go start
+  run go run main.go start -t latest
   echo "status = ${status}"
   echo "output trace = ${output}"
   [ "$status" -eq 0 ]

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -31,7 +31,7 @@ import (
 	"github.com/moby/moby/client"
 )
 
-// docker-compose yaml data
+// codewind-docker-compose.yaml data
 var data = `
 version: 2
 services:
@@ -129,12 +129,12 @@ func DockerCompose(tag string) {
 	}
 	os.Setenv("PFE_EXTERNAL_PORT", port)
 
-	cmd := exec.Command("docker-compose", "-f", "docker-compose.yaml", "up", "-d")
+	cmd := exec.Command("docker-compose", "-f", "codewind-docker-compose.yaml", "up", "-d")
 	output := new(bytes.Buffer)
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
-		DeleteTempFile("docker-compose.yaml")
+		DeleteTempFile("codewind-docker-compose.yaml")
 		errors.CheckErr(err, 101, "Is docker-compose installed?")
 	}
 	fmt.Printf("Please wait whilst containers initialize... %s \n", output.String())
@@ -142,12 +142,12 @@ func DockerCompose(tag string) {
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
-		DeleteTempFile("docker-compose.yaml")
+		DeleteTempFile("codewind-docker-compose.yaml")
 		os.Exit(1)
 	}
 
 	if strings.Contains(output.String(), "The image for the service you're trying to recreate has been removed") {
-		DeleteTempFile("docker-compose.yaml")
+		DeleteTempFile("codewind-docker-compose.yaml")
 		os.Exit(1)
 	}
 }

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -129,12 +129,12 @@ func DockerCompose(tag string) {
 	}
 	os.Setenv("PFE_EXTERNAL_PORT", port)
 
-	cmd := exec.Command("docker-compose", "-f", "installer-docker-compose.yaml", "up", "-d")
+	cmd := exec.Command("docker-compose", "-f", "docker-compose.yaml", "up", "-d")
 	output := new(bytes.Buffer)
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
-		DeleteTempFile("installer-docker-compose.yaml")
+		DeleteTempFile("docker-compose.yaml")
 		errors.CheckErr(err, 101, "Is docker-compose installed?")
 	}
 	fmt.Printf("Please wait whilst containers initialize... %s \n", output.String())
@@ -142,12 +142,12 @@ func DockerCompose(tag string) {
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
-		DeleteTempFile("installer-docker-compose.yaml")
+		DeleteTempFile("docker-compose.yaml")
 		os.Exit(1)
 	}
 
 	if strings.Contains(output.String(), "The image for the service you're trying to recreate has been removed") {
-		DeleteTempFile("installer-docker-compose.yaml")
+		DeleteTempFile("docker-compose.yaml")
 		os.Exit(1)
 	}
 }

--- a/utils/extensions.go
+++ b/utils/extensions.go
@@ -35,9 +35,9 @@ func RunCommand(projectPath string, command ExtensionCommand) error {
 		log.Println("There was a problem with locating the command directory")
 		return err
 	}
-	installerPath := filepath.Dir(cwd)
+	cwctlPath := filepath.Dir(cwd)
 	commandName := filepath.Base(command.Command) // prevent path traversal
-	commandBin := filepath.Join(installerPath, commandName)
+	commandBin := filepath.Join(cwctlPath, commandName)
 	cmd := exec.Command(commandBin, command.Args...)
 	cmd.Dir = projectPath
 	output := new(bytes.Buffer)

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -282,7 +282,7 @@ func ReplaceInFiles(projectPath string, oldStr string, newStr string) error {
 		if strings.Contains(path.Base(pathName), oldStr) {
 			// Keep track of files we need to rename but don't rename
 			// them until the filepath.Walk is complete.
-			pathsToRename = append(pathsToRename, pathName);
+			pathsToRename = append(pathsToRename, pathName)
 		}
 
 		if info.IsDir() {


### PR DESCRIPTION
**Problem (https://github.com/eclipse/codewind/issues/255):** Since the installer is more of a CLI now, it was deemed necessary to rename this from `codewind-installer` -> `cwctl`.

**Solution**
- produce a binary with the prefix `cwtl` instead of `codewind-installer`
- rename `codewind-installer` -> `cwctl` in the appropriate places across the code base
- linter fixed some format errors
- rename `installer-docker-compose.yaml` -> `docker-compose.yaml`

**Testing**
```
 ✓ invoke install command - install latest with --json
 ✓ invoke status -j command - output = '{status:stopped,installed-versions:[latest]}'
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images

5 tests, 0 failures
```
**Extra**
This is just MVP. See https://github.com/eclipse/codewind/issues/255 for what needs to be done next to complete this name change.
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>