### PR TITLE
Add security commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,21 @@ $ brew upgrade dep
 
 ## CLI Commands
 
-|Command         |Alias         |Usage                                                           |
-|----------------|--------------|----------------------------------------------------------------|
-|project         |              |'Manage Codewind projects'                                      |
-|install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'      |
-|start           |              |'Start the Codewind containers'                                 |
-|status          |              |'Print the installation status of Codewind'                     |
-|stop            |              |'Stop the running Codewind containers'                          |
-|stop-all        |              |'Stop all of the Codewind and project containers'               |
-|remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'|
-|templates       |              |'Manage project templates'                                      |
-|help            |`h`           |'Shows a list of commands or help for one command'              |
+|Command         |Alias         |Usage                                                               |
+|----------------|--------------|--------------------------------------------------------------------|
+|project         |              |'Manage Codewind projects'                                          |
+|install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'          |
+|sectoken        |`st`          |'Authenticate with username and password to obtain an access_token' |
+|secrealm        |`sr`          |'Manage new or existing REALM configurations'                       |
+|secclient       |`sc`          |'Manage new or existing APPLICATION access configurations'          |
+|secuser         |`su`          |'Manage new or existing USER access configurations'                 |
+|start           |              |'Start the Codewind containers'                                     |
+|status          |              |'Print the installation status of Codewind'                         |
+|stop            |              |'Stop the running Codewind containers'                              |
+|stop-all        |              |'Stop all of the Codewind and project containers'                   |
+|remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'    |
+|templates       |              |'Manage project templates'                                          |
+|help            |`h`           |'Shows a list of commands or help for one command'                  |
 
 ## CLI Command Options
 

--- a/README.md
+++ b/README.md
@@ -85,16 +85,16 @@ $ brew upgrade dep
 |----------------|--------------|--------------------------------------------------------------------|
 |project         |              |'Manage Codewind projects'                                          |
 |install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'          |
-|sectoken        |`st`          |'Authenticate with username and password to obtain an access_token' |
-|secrealm        |`sr`          |'Manage new or existing REALM configurations'                       |
-|secclient       |`sc`          |'Manage new or existing APPLICATION access configurations'          |
-|secuser         |`su`          |'Manage new or existing USER access configurations'                 |
 |start           |              |'Start the Codewind containers'                                     |
 |status          |              |'Print the installation status of Codewind'                         |
 |stop            |              |'Stop the running Codewind containers'                              |
 |stop-all        |              |'Stop all of the Codewind and project containers'                   |
 |remove          |`rm`          |'Remove Codewind/Project docker images and the codewind network'    |
 |templates       |              |'Manage project templates'                                          |
+|sectoken        |`st`          |'Authenticate with username and password to obtain an access_token' |
+|secrealm        |`sr`          |'Manage new or existing REALM configurations'                       |
+|secclient       |`sc`          |'Manage new or existing APPLICATION access configurations'          |
+|secuser         |`su`          |'Manage new or existing USER access configurations'                 |
 |help            |`h`           |'Shows a list of commands or help for one command'                  |
 
 ## CLI Command Options
@@ -137,6 +137,96 @@ $ brew upgrade dep
 Subcommands:</br>
 
 `list/ls` - List available templates
+
+## sectoken
+
+Subcommands:</br>
+
+`get/g` - Authenticate and obtain an access_token
+
+> **Flags:**
+> --host value                  URL or ingress to Keycloak service
+> --realm value                 Application realm
+> --username value              Account Username
+> --password value              Account Password
+> --client value                Client
+
+## secrealm
+
+Subcommands:</br>
+
+`create/c` - Create a new realm (requires either admin_token or username/password)
+
+> **Flags:**
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+
+## secclient
+
+Subcommands:</br>
+
+`create/c` - Create a new client in an existing Keycloak realm (requires either admin_token or username/password)
+
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --clientid value               New client ID to create
+> --redirect value               Allowed redirect callback URL eg: `http://127.0.0.1:9090/*`
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+
+`get/g` - Get client id (requires either admin_token or username/password)
+
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --clientid value               New client ID to create
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+
+`secret/s` - Get client secret (requires either admin_token or username/password)
+
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --clientid value               New client ID to create
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+
+## secuser
+
+Subcommands:</br>
+
+`create/c` - Create a new user in an existing Keycloak realm (requires either admin_token or username/password)
+
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+> --name value                   Username to add
+
+`get/g` - Gets an existing Keycloak user from an existing realm (requires either admin_token or username/password)
+
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+> --name value                   Username to query
+
+`setpw/p` - Reset an existing users password (requires either admin_token or username/password)
+
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+> --name value                   Username to query
+> --newpw value                  New replacement password
 
 ## help
 

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -236,6 +236,146 @@ func Commands() {
 			},
 		},
 
+		//  Security //
+		{
+			Name:  "sectoken",
+			Usage: "Authenticate and obtain an access_token",
+			Subcommands: []cli.Command{
+				{
+					Name:    "get",
+					Aliases: []string{"g"},
+					Usage:   "Login and retrieve access_token",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: true},
+						cli.StringFlag{Name: "realm,r", Usage: "Application realm", Required: true},
+						cli.StringFlag{Name: "username,u", Usage: "Account Username", Required: true},
+						cli.StringFlag{Name: "password,p", Usage: "Account Password", Required: true},
+						cli.StringFlag{Name: "client,c", Usage: "Client", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityTokenGet(c)
+						return nil
+					},
+				},
+			},
+		},
+		{
+			Name:  "secrealm",
+			Usage: "Manage Realm configuration",
+			Subcommands: []cli.Command{
+				{
+					Name:    "create",
+					Aliases: []string{"c"},
+					Usage:   "Create a new realm (requires either admin_token or username/password)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: true},
+						cli.StringFlag{Name: "realm,r", Usage: "Existing realm name", Required: true},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityCreateRealm(c)
+						return nil
+					},
+				},
+			},
+		}, {
+			Name:  "secclient",
+			Usage: "Manage client access configuration",
+			Subcommands: []cli.Command{
+				{
+					Name:    "create",
+					Aliases: []string{"c"},
+					Usage:   "Create a new client in a Keycloak realm (requires either admin_token or username/password)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: true},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "clientid,c", Usage: "New client ID to create", Required: true},
+						cli.StringFlag{Name: "redirect,l", Usage: "Redirect URL", Required: false},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityClientCreate(c)
+						return nil
+					},
+				},
+				{
+					Name:    "get",
+					Aliases: []string{"g"},
+					Usage:   "Get client id (requires either admin_token or username/password)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "clientid,c", Usage: "New client ID to create", Required: true},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityClientGet(c)
+						return nil
+					},
+				},
+			},
+		},
+		{
+			Name:  "secuser",
+			Usage: "Manage keycloak user account",
+			Subcommands: []cli.Command{
+				{
+					Name:    "create",
+					Aliases: []string{"c"},
+					Usage:   "Create a new user (requires either admin_token or username/password)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "name,n", Usage: "Username to add", Required: true},
+						cli.StringFlag{Name: "admintoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityUserCreate(c)
+						return nil
+					},
+				}, {
+					Name:    "get",
+					Aliases: []string{"g"},
+					Usage:   "Get details of a user (requires either admin_token or username/password)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "name,n", Usage: "Username to retrieve", Required: true},
+						cli.StringFlag{Name: "admintoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityUserGet(c)
+						return nil
+					},
+				}, {
+					Name:    "setpw",
+					Aliases: []string{"p"},
+					Usage:   "Sets the password of an existing user (requires either admin_token or username/password)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "name,n", Usage: "Account name to process", Required: true},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Access Token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Password", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityUserSetPW(c)
+						return nil
+					},
+				},
+			},
+		},
 		//  Deployment maintenance //
 		{
 			Name:    "deployments",

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -238,8 +238,9 @@ func Commands() {
 
 		//  Security //
 		{
-			Name:  "sectoken",
-			Usage: "Authenticate and obtain an access_token",
+			Name:    "sectoken",
+			Aliases: []string{"st"},
+			Usage:   "Authenticate and obtain an access_token",
 			Subcommands: []cli.Command{
 				{
 					Name:    "get",
@@ -260,8 +261,9 @@ func Commands() {
 			},
 		},
 		{
-			Name:  "secrealm",
-			Usage: "Manage Realm configuration",
+			Name:    "secrealm",
+			Aliases: []string{"sr"},
+			Usage:   "Manage Realm configuration",
 			Subcommands: []cli.Command{
 				{
 					Name:    "create",
@@ -281,8 +283,9 @@ func Commands() {
 				},
 			},
 		}, {
-			Name:  "secclient",
-			Usage: "Manage client access configuration",
+			Name:    "secclient",
+			Aliases: []string{"sc"},
+			Usage:   "Manage client access configuration",
 			Subcommands: []cli.Command{
 				{
 					Name:    "create",
@@ -339,8 +342,9 @@ func Commands() {
 			},
 		},
 		{
-			Name:  "secuser",
-			Usage: "Manage keycloak user account",
+			Name:    "secuser",
+			Aliases: []string{"su"},
+			Usage:   "Manage keycloak user account",
 			Subcommands: []cli.Command{
 				{
 					Name:    "create",

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -319,6 +319,23 @@ func Commands() {
 						return nil
 					},
 				},
+				{
+					Name:    "secret",
+					Aliases: []string{"s"},
+					Usage:   "Get client secret (requires either admin_token or username/password)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "clientid,c", Usage: "Client id", Required: true},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityClientGetSecret(c)
+						return nil
+					},
+				},
 			},
 		},
 		{
@@ -370,7 +387,7 @@ func Commands() {
 						cli.StringFlag{Name: "password,p", Usage: "Password", Required: false},
 					},
 					Action: func(c *cli.Context) error {
-						SecurityUserSetPW(c)
+						SecurityUserSetPassword(c)
 						return nil
 					},
 				},

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -349,10 +349,10 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
 						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "name,n", Usage: "Username to add", Required: true},
 						cli.StringFlag{Name: "admintoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
 						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+						cli.StringFlag{Name: "name,n", Usage: "Username to add", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						SecurityUserCreate(c)
@@ -365,10 +365,10 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
 						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "name,n", Usage: "Username to retrieve", Required: true},
 						cli.StringFlag{Name: "admintoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
 						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+						cli.StringFlag{Name: "name,n", Usage: "Username to retrieve", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						SecurityUserGet(c)
@@ -381,10 +381,11 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
 						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "name,n", Usage: "Account name to process", Required: true},
-						cli.StringFlag{Name: "accesstoken,t", Usage: "Access Token", Required: false},
-						cli.StringFlag{Name: "username,u", Usage: "Username", Required: false},
-						cli.StringFlag{Name: "password,p", Usage: "Password", Required: false},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin Access Token", Required: false},
+						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
+						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
+						cli.StringFlag{Name: "name,n", Usage: "Existing user account name to process", Required: true},
+						cli.StringFlag{Name: "newpw,w", Usage: "New password", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						SecurityUserSetPassword(c)

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -12,6 +12,8 @@
 package actions
 
 import (
+	"crypto/tls"
+	"net/http"
 	"os"
 
 	"github.com/eclipse/codewind-installer/errors"
@@ -468,6 +470,14 @@ func Commands() {
 				},
 			},
 		},
+	}
+
+	app.Before = func(c *cli.Context) error {
+		// Handle Global flag to disable certificate checking
+		if c.GlobalBool("insecure") {
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+		return nil
 	}
 
 	// Start application

--- a/actions/security.go
+++ b/actions/security.go
@@ -68,6 +68,21 @@ func SecurityClientGet(c *cli.Context) {
 	os.Exit(0)
 }
 
+// SecurityClientGetSecret : Retrieve a client secret from Keycloak
+func SecurityClientGetSecret(c *cli.Context) {
+	registredClientSecret, err := security.SecClientGetSecret(c)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(0)
+	}
+	if registredClientSecret != nil {
+		utils.PrettyPrintJSON(registredClientSecret)
+		os.Exit(0)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
+	os.Exit(0)
+}
+
 // SecurityUserCreate : Create a user in a Keycloak realm
 func SecurityUserCreate(c *cli.Context) {
 	err := security.SecUserCreate(c)
@@ -94,8 +109,8 @@ func SecurityUserGet(c *cli.Context) {
 	os.Exit(0)
 }
 
-// SecurityUserSetPW : Set a users password in Keycloak
-func SecurityUserSetPW(c *cli.Context) {
+// SecurityUserSetPassword : Set a users password in Keycloak
+func SecurityUserSetPassword(c *cli.Context) {
 	err := security.SecUserSetPW(c)
 	if err != nil {
 		fmt.Println(err.Error())

--- a/actions/security.go
+++ b/actions/security.go
@@ -55,13 +55,13 @@ func SecurityClientCreate(c *cli.Context) {
 
 // SecurityClientGet : Retrieve a client configuration from Keycloak
 func SecurityClientGet(c *cli.Context) {
-	registredClient, err := security.SecClientGet(c)
+	registeredClient, err := security.SecClientGet(c)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(0)
 	}
-	if registredClient != nil {
-		utils.PrettyPrintJSON(registredClient)
+	if registeredClient != nil {
+		utils.PrettyPrintJSON(registeredClient)
 		os.Exit(0)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
@@ -70,13 +70,13 @@ func SecurityClientGet(c *cli.Context) {
 
 // SecurityClientGetSecret : Retrieve a client secret from Keycloak
 func SecurityClientGetSecret(c *cli.Context) {
-	registredClientSecret, err := security.SecClientGetSecret(c)
+	registeredClientSecret, err := security.SecClientGetSecret(c)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(0)
 	}
-	if registredClientSecret != nil {
-		utils.PrettyPrintJSON(registredClientSecret)
+	if registeredClientSecret != nil {
+		utils.PrettyPrintJSON(registeredClientSecret)
 		os.Exit(0)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
@@ -96,13 +96,13 @@ func SecurityUserCreate(c *cli.Context) {
 
 // SecurityUserGet : Retrieve the user detail from Keycloak
 func SecurityUserGet(c *cli.Context) {
-	registredUser, err := security.SecUserGet(c)
+	registeredUser, err := security.SecUserGet(c)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(0)
 	}
-	if registredUser != nil {
-		utils.PrettyPrintJSON(registredUser)
+	if registeredUser != nil {
+		utils.PrettyPrintJSON(registeredUser)
 		os.Exit(0)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "Not found"})

--- a/actions/security.go
+++ b/actions/security.go
@@ -12,7 +12,7 @@
 package actions
 
 import (
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/eclipse/codewind-installer/utils"
@@ -25,18 +25,20 @@ func SecurityTokenGet(c *cli.Context) {
 	auth, err := security.SecAuthenticate(c, "", "")
 	if err == nil && auth != nil {
 		utils.PrettyPrintJSON(auth)
-		os.Exit(0)
+	} else {
+		fmt.Println(err.Error())
 	}
-	log.Fatal(err)
+	os.Exit(0)
 }
 
 // SecurityCreateRealm : Create a realm in Keycloak
 func SecurityCreateRealm(c *cli.Context) {
 	err := security.SecRealmCreate(c)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err.Error())
+	} else {
+		utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	}
-	utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	os.Exit(0)
 }
 
@@ -44,9 +46,10 @@ func SecurityCreateRealm(c *cli.Context) {
 func SecurityClientCreate(c *cli.Context) {
 	err := security.SecClientCreate(c)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err.Error())
+	} else {
+		utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	}
-	utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	os.Exit(0)
 }
 
@@ -54,7 +57,8 @@ func SecurityClientCreate(c *cli.Context) {
 func SecurityClientGet(c *cli.Context) {
 	registredClient, err := security.SecClientGet(c)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err.Error())
+		os.Exit(0)
 	}
 	if registredClient != nil {
 		utils.PrettyPrintJSON(registredClient)
@@ -68,19 +72,25 @@ func SecurityClientGet(c *cli.Context) {
 func SecurityUserCreate(c *cli.Context) {
 	err := security.SecUserCreate(c)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err.Error())
+	} else {
+		utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	}
-	utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	os.Exit(0)
 }
 
 // SecurityUserGet : Retrieve the user detail from Keycloak
 func SecurityUserGet(c *cli.Context) {
-	err := security.SecUserGet(c)
+	registredUser, err := security.SecUserGet(c)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err.Error())
+		os.Exit(0)
 	}
-	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	if registredUser != nil {
+		utils.PrettyPrintJSON(registredUser)
+		os.Exit(0)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
 	os.Exit(0)
 }
 
@@ -88,7 +98,8 @@ func SecurityUserGet(c *cli.Context) {
 func SecurityUserSetPW(c *cli.Context) {
 	err := security.SecUserSetPW(c)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err.Error())
+		os.Exit(0)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	os.Exit(0)

--- a/actions/security.go
+++ b/actions/security.go
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"log"
+	"os"
+
+	"github.com/eclipse/codewind-installer/utils"
+	"github.com/eclipse/codewind-installer/utils/security"
+	"github.com/urfave/cli"
+)
+
+// SecurityTokenGet : Authenticate and retrieve an access_token
+func SecurityTokenGet(c *cli.Context) {
+	auth, err := security.SecAuthenticate(c, "", "")
+	if err == nil && auth != nil {
+		utils.PrettyPrintJSON(auth)
+		os.Exit(0)
+	}
+	log.Fatal(err)
+}
+
+// SecurityCreateRealm : Create a realm in Keycloak
+func SecurityCreateRealm(c *cli.Context) {
+	err := security.SecRealmCreate(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}
+
+// SecurityClientCreate : Create a new client in Keycloak
+func SecurityClientCreate(c *cli.Context) {
+	err := security.SecClientCreate(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}
+
+// SecurityClientGet : Retrieve a client configuration from Keycloak
+func SecurityClientGet(c *cli.Context) {
+	registredClient, err := security.SecClientGet(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if registredClient != nil {
+		utils.PrettyPrintJSON(registredClient)
+		os.Exit(0)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
+	os.Exit(0)
+}
+
+// SecurityUserCreate : Create a user in a Keycloak realm
+func SecurityUserCreate(c *cli.Context) {
+	err := security.SecUserCreate(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}
+
+// SecurityUserGet : Retrieve the user detail from Keycloak
+func SecurityUserGet(c *cli.Context) {
+	err := security.SecUserGet(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}
+
+// SecurityUserSetPW : Set a users password in Keycloak
+func SecurityUserSetPW(c *cli.Context) {
+	err := security.SecUserSetPW(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}

--- a/utils/security/authenticate.go
+++ b/utils/security/authenticate.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -25,9 +24,7 @@ type AuthToken struct {
 // SecAuthenticate - sends credentials to the auth server for a specific realm and returns an AuthToken
 // connectionRealm can be used to override the supplied context arguments
 func SecAuthenticate(c *cli.Context, connectionRealm string, connectionClient string) (*AuthToken, *SecError) {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
+
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	username := strings.TrimSpace(strings.ToLower(c.String("username")))
 	password := strings.TrimSpace(strings.ToLower(c.String("password")))

--- a/utils/security/authenticate.go
+++ b/utils/security/authenticate.go
@@ -1,0 +1,80 @@
+package security
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+// AuthToken from the keycloak server after successfully authenticating
+type AuthToken struct {
+	AccessToken     string `json:"access_token"`
+	ExpiresIn       int    `json:"expires_in"`
+	RefreshToken    string `json:"refresh_token"`
+	TokenType       string `json:"token_type"`
+	NotBeforePolicy int    `json:"not-before-policy"`
+	SessionState    string `json:"session_state"`
+	Scope           string `json:"scope"`
+}
+
+// SecAuthenticate - sends credentials to the auth server for a specific realm and returns an AuthToken
+// connectionRealm can be used to override the supplied context arguments
+func SecAuthenticate(c *cli.Context, connectionRealm string, connectionClient string) (*AuthToken, *SecError) {
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
+	username := strings.TrimSpace(strings.ToLower(c.String("username")))
+	password := strings.TrimSpace(strings.ToLower(c.String("password")))
+	realm := strings.TrimSpace(strings.ToLower(c.String("realm")))
+	client := strings.TrimSpace(strings.ToLower(c.String("client")))
+
+	// If a connection realm was supplied, use that instead of the command line Context flags
+	if connectionRealm != "" {
+		realm = connectionRealm
+	}
+
+	if connectionClient != "" {
+		client = connectionClient
+	}
+
+	// build REST request
+	url := hostname + "/auth/realms/" + realm + "/protocol/openid-connect/token"
+	payload := strings.NewReader("grant_type=password&client_id=" + client + "&username=" + username + "&password=" + password)
+	req, _ := http.NewRequest("POST", url, payload)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Cache-Control", "no-cache")
+	req.Header.Add("cache-control", "no-cache")
+
+	// send request
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, &SecError{errOpConnection, err, err.Error()}
+	}
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+
+	// Handle special case http status codes
+	switch httpCode := res.StatusCode; {
+	case httpCode == 400, httpCode == 401:
+		keycloakAPIError := parseKeycloakError(string(body), res.StatusCode)
+		kcError := errors.New(string(keycloakAPIError.ErrorDescription))
+		return nil, &SecError{keycloakAPIError.Error, kcError, kcError.Error()}
+	case httpCode != 200:
+		err = errors.New(string(body))
+		return nil, &SecError{errOpResponse, err, err.Error()}
+	}
+
+	// Parse and return authtoken
+	authToken := AuthToken{}
+	err = json.Unmarshal([]byte(body), &authToken)
+	if err != nil {
+		return nil, &SecError{errOpResponseFormat, err, "Unable to parse Keycloak response"}
+	}
+	return &authToken, nil
+}

--- a/utils/security/authenticate.go
+++ b/utils/security/authenticate.go
@@ -46,7 +46,10 @@ func SecAuthenticate(c *cli.Context, connectionRealm string, connectionClient st
 	// build REST request
 	url := hostname + "/auth/realms/" + realm + "/protocol/openid-connect/token"
 	payload := strings.NewReader("grant_type=password&client_id=" + client + "&username=" + username + "&password=" + password)
-	req, _ := http.NewRequest("POST", url, payload)
+	req, err := http.NewRequest("POST", url, payload)
+	if err != nil {
+		return nil, &SecError{errOpConnection, err, err.Error()}
+	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Cache-Control", "no-cache")
 	req.Header.Add("cache-control", "no-cache")

--- a/utils/security/authenticate.go
+++ b/utils/security/authenticate.go
@@ -77,7 +77,7 @@ func SecAuthenticate(c *cli.Context, connectionRealm string, connectionClient st
 	authToken := AuthToken{}
 	err = json.Unmarshal([]byte(body), &authToken)
 	if err != nil {
-		return nil, &SecError{errOpResponseFormat, err, "Unable to parse Keycloak response"}
+		return nil, &SecError{errOpResponseFormat, err, textUnableToParse}
 	}
 	return &authToken, nil
 }

--- a/utils/security/client.go
+++ b/utils/security/client.go
@@ -1,0 +1,116 @@
+package security
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+// SecClientCreate : Create a new client in Keycloak
+func SecClientCreate(c *cli.Context) *SecError {
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
+	realm := strings.TrimSpace(c.String("realm"))
+	accesstoken := strings.TrimSpace(c.String("accesstoken"))
+	clientid := strings.TrimSpace(c.String("clientid"))
+	redirect := strings.TrimSpace(c.String("redirect"))
+
+	// Authenticate if needed
+	if accesstoken == "" {
+		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
+		if err != nil || authToken == nil {
+			return err
+		}
+		accesstoken = authToken.AccessToken
+	}
+
+	// build REST request
+	url := hostname + "/auth/admin/realms/" + realm + "/clients"
+	callbackRedirect := ""
+	if redirect != "" {
+		callbackRedirect = ",\"redirectUris\":[\"" + redirect + "\"]"
+	}
+	payload := strings.NewReader("{\"clientId\":\"" + clientid + "\",\"name\":\"" + clientid + "\"" + callbackRedirect + "}")
+	req, _ := http.NewRequest("POST", url, payload)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Cache-Control", "no-cache")
+	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Authorization", "Bearer "+accesstoken)
+
+	// send request
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return &SecError{errOpConnection, err, err.Error()}
+	}
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+	if string(body) != "" {
+		keycloakAPIError := parseKeycloakError(string(body), res.StatusCode)
+		keycloakAPIError.Error = errOpResponseFormat
+		kcError := errors.New(string(keycloakAPIError.ErrorDescription))
+		return &SecError{keycloakAPIError.Error, kcError, kcError.Error()}
+	}
+	return nil
+}
+
+// SecClientGet : Retrieve Client information
+func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
+	realm := strings.TrimSpace(c.String("realm"))
+	accesstoken := strings.TrimSpace(c.String("accesstoken"))
+	clientid := strings.TrimSpace(c.String("clientid"))
+
+	// Authenticate if needed
+	if accesstoken == "" {
+		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
+		if err != nil || authToken == nil {
+			return nil, err
+		}
+		accesstoken = authToken.AccessToken
+	}
+
+	// Built REST request
+	url := hostname + "/auth/admin/realms/" + realm + "/clients?clientId=" + clientid
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Authorization", "Bearer "+accesstoken)
+	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("cache-control", "no-cache")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, &SecError{errOpConnection, err, err.Error()}
+	}
+
+	// Handle HTTP status codes
+	if res.StatusCode != 200 {
+		body, _ := ioutil.ReadAll(res.Body)
+		err = errors.New(string(body))
+		return nil, &SecError{errOpResponse, err, err.Error()}
+	}
+
+	registeredClients := RegisteredClients{}
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	err = json.Unmarshal([]byte(body), &registeredClients.Collection)
+	if err != nil {
+		return nil, &SecError{errOpResponseFormat, err, err.Error()}
+	}
+
+	registredClient := RegisteredClient{}
+	if len(registeredClients.Collection) > 0 {
+		registredClient = registeredClients.Collection[0]
+		return &registredClient, nil
+	}
+
+	return nil, nil
+}

--- a/utils/security/client.go
+++ b/utils/security/client.go
@@ -182,7 +182,7 @@ func SecClientGetSecret(c *cli.Context) (*RegisteredClientSecret, *SecError) {
 
 	req.Header.Add("Authorization", "Bearer "+accesstoken)
 	req.Header.Add("cache-control", "no-cache")
-	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Cache-Control", "no-cache")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, &SecError{errOpConnection, err, err.Error()}

--- a/utils/security/client.go
+++ b/utils/security/client.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -31,9 +30,6 @@ type RegisteredClientSecret struct {
 
 // SecClientCreate : Create a new client in Keycloak
 func SecClientCreate(c *cli.Context) *SecError {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
 
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	realm := strings.TrimSpace(c.String("realm"))
@@ -99,9 +95,7 @@ func SecClientCreate(c *cli.Context) *SecError {
 
 // SecClientGet : Retrieve Client information
 func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
+
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	realm := strings.TrimSpace(c.String("realm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
@@ -123,7 +117,7 @@ func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
 		return nil, &SecError{errOpConnection, err, err.Error()}
 	}
 	req.Header.Add("Authorization", "Bearer "+accesstoken)
-	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Cache-Control", "no-cache")
 	req.Header.Add("cache-control", "no-cache")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -157,9 +151,6 @@ func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
 // SecClientGetSecret : Retrieve the client secret for the supplied clientID
 func SecClientGetSecret(c *cli.Context) (*RegisteredClientSecret, *SecError) {
 
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	realm := strings.TrimSpace(c.String("realm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))

--- a/utils/security/client.go
+++ b/utils/security/client.go
@@ -11,19 +11,19 @@ import (
 	"github.com/urfave/cli"
 )
 
-// RegisteredClients A collection of registered clients
+// RegisteredClients : A collection of registered clients
 type RegisteredClients struct {
 	Collection []RegisteredClient
 }
 
-// RegisteredClient details of a registered client
+// RegisteredClient : Registered client
 type RegisteredClient struct {
 	ID       string `json:"id"`
 	ClientID string `json:"clientId"`
 	Name     string `json:"name"`
 }
 
-// RegisteredClientSecret - Client secret
+// RegisteredClientSecret : Client secret
 type RegisteredClientSecret struct {
 	Type   string `json:"type"`
 	Secret string `json:"value"`
@@ -41,7 +41,7 @@ func SecClientCreate(c *cli.Context) *SecError {
 	clientid := strings.TrimSpace(c.String("clientid"))
 	redirect := strings.TrimSpace(c.String("redirect"))
 
-	// Authenticate if needed
+	// authenticate if needed
 	if accesstoken == "" {
 		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
 		if err != nil || authToken == nil {
@@ -56,7 +56,7 @@ func SecClientCreate(c *cli.Context) *SecError {
 	if redirect != "" {
 		callbackRedirect = ",\"redirectUris\":[\"" + redirect + "\"]"
 	}
-	payload := strings.NewReader("{\"clientId\":\"" + clientid + "\",\"name\":\"" + clientid + "\"" + callbackRedirect + "}")
+	payload := strings.NewReader("{\"directAccessGrantsEnabled\":true, \"publicClient\":true, \"clientId\":\"" + clientid + "\",\"name\":\"" + clientid + "\"" + callbackRedirect + "}")
 	req, err := http.NewRequest("POST", url, payload)
 	if err != nil {
 		return &SecError{errOpConnection, err, err.Error()}
@@ -92,7 +92,7 @@ func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 	clientid := strings.TrimSpace(c.String("clientid"))
 
-	// Authenticate if needed
+	// authenticate if needed
 	if accesstoken == "" {
 		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
 		if err != nil || authToken == nil {
@@ -101,7 +101,7 @@ func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
 		accesstoken = authToken.AccessToken
 	}
 
-	// Built REST request
+	// build REST request
 	url := hostname + "/auth/admin/realms/" + realm + "/clients?clientId=" + clientid
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -116,7 +116,7 @@ func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
 	}
 	defer res.Body.Close()
 
-	// Handle HTTP status codes
+	// handle HTTP status codes
 	if res.StatusCode != 200 {
 		body, _ := ioutil.ReadAll(res.Body)
 		err = errors.New(string(body))
@@ -130,16 +130,16 @@ func SecClientGet(c *cli.Context) (*RegisteredClient, *SecError) {
 		return nil, &SecError{errOpResponseFormat, err, err.Error()}
 	}
 
-	registredClient := RegisteredClient{}
+	registeredClient := RegisteredClient{}
 	if len(registeredClients.Collection) > 0 {
-		registredClient = registeredClients.Collection[0]
-		return &registredClient, nil
+		registeredClient = registeredClients.Collection[0]
+		return &registeredClient, nil
 	}
 
 	return nil, nil
 }
 
-// SecClientGetSecret retrieve the client secret for the supplied clientID
+// SecClientGetSecret : Retrieve the client secret for the supplied clientID
 func SecClientGetSecret(c *cli.Context) (*RegisteredClientSecret, *SecError) {
 
 	if c.GlobalBool("insecure") {
@@ -149,7 +149,7 @@ func SecClientGetSecret(c *cli.Context) (*RegisteredClientSecret, *SecError) {
 	realm := strings.TrimSpace(c.String("realm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 
-	// Authenticate if needed
+	// authenticate if needed
 	if accesstoken == "" {
 		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
 		if err != nil || authToken == nil {
@@ -167,7 +167,7 @@ func SecClientGetSecret(c *cli.Context) (*RegisteredClientSecret, *SecError) {
 		return nil, nil
 	}
 
-	// Built REST request
+	// build REST request
 	url := hostname + "/auth/admin/realms/" + realm + "/clients/" + registeredClient.ID + "/client-secret"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -183,7 +183,7 @@ func SecClientGetSecret(c *cli.Context) (*RegisteredClientSecret, *SecError) {
 	}
 	defer res.Body.Close()
 
-	// Handle HTTP status codes
+	// handle HTTP status codes
 	if res.StatusCode != 200 {
 		body, _ := ioutil.ReadAll(res.Body)
 		err = errors.New(string(body))

--- a/utils/security/realm.go
+++ b/utils/security/realm.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -31,7 +32,25 @@ func SecRealmCreate(c *cli.Context) *SecError {
 
 	// build REST request
 	url := hostname + "/auth/admin/realms"
-	payload := strings.NewReader("{\"realm\":\"" + realm + "\",\"displayName\":\"" + realm + "\",\"enabled\":true,\"loginTheme\":\"codewind\",\"accessTokenLifespan\":86400}")
+
+	// build the payload (JSON)
+	type PayloadRealm struct {
+		Realm               string `json:"realm"`
+		DisplayName         string `json:"displayName"`
+		Enabled             bool   `json:"enabled"`
+		LoginTheme          string `json:"loginTheme"`
+		AccessTokenLifespan int    `json:"accessTokenLifespan"`
+	}
+	tempRealm := &PayloadRealm{
+		Realm:               realm,
+		DisplayName:         realm,
+		Enabled:             true,
+		LoginTheme:          "codewind",
+		AccessTokenLifespan: 86400,
+	}
+
+	jsonRealm, err := json.Marshal(tempRealm)
+	payload := strings.NewReader(string(jsonRealm))
 	req, err := http.NewRequest("POST", url, payload)
 	if err != nil {
 		return &SecError{errOpConnection, err, err.Error()}

--- a/utils/security/realm.go
+++ b/utils/security/realm.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -13,9 +12,6 @@ import (
 
 // SecRealmCreate : Create a new realm in Keycloak
 func SecRealmCreate(c *cli.Context) *SecError {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
 
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	realm := strings.TrimSpace(c.String("realm"))

--- a/utils/security/realm.go
+++ b/utils/security/realm.go
@@ -1,0 +1,55 @@
+package security
+
+import (
+	"crypto/tls"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+// SecRealmCreate : Create a new realm in Keycloak
+func SecRealmCreate(c *cli.Context) *SecError {
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
+	realm := strings.TrimSpace(c.String("realm"))
+	accesstoken := strings.TrimSpace(c.String("accesstoken"))
+
+	// Authenticate if needed
+	if accesstoken == "" {
+		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
+		if err != nil || authToken == nil {
+			return err
+		}
+		accesstoken = authToken.AccessToken
+	}
+
+	// build REST request
+	url := hostname + "/auth/admin/realms"
+	payload := strings.NewReader("{\"realm\":\"" + realm + "\",\"displayName\":\"" + realm + "\",\"enabled\":true,\"loginTheme\":\"codewind\",\"accessTokenLifespan\":86400}")
+	req, _ := http.NewRequest("POST", url, payload)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Cache-Control", "no-cache")
+	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Authorization", "Bearer "+accesstoken)
+
+	// send request
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return &SecError{errOpConnection, err, err.Error()}
+	}
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if string(body) != "" {
+		keycloakAPIError := parseKeycloakError(string(body), res.StatusCode)
+		keycloakAPIError.Error = errOpResponseFormat
+		kcError := errors.New(keycloakAPIError.ErrorDescription)
+		return &SecError{keycloakAPIError.Error, kcError, kcError.Error()}
+	}
+	return nil
+}

--- a/utils/security/realm.go
+++ b/utils/security/realm.go
@@ -32,7 +32,10 @@ func SecRealmCreate(c *cli.Context) *SecError {
 	// build REST request
 	url := hostname + "/auth/admin/realms"
 	payload := strings.NewReader("{\"realm\":\"" + realm + "\",\"displayName\":\"" + realm + "\",\"enabled\":true,\"loginTheme\":\"codewind\",\"accessTokenLifespan\":86400}")
-	req, _ := http.NewRequest("POST", url, payload)
+	req, err := http.NewRequest("POST", url, payload)
+	if err != nil {
+		return &SecError{errOpConnection, err, err.Error()}
+	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Cache-Control", "no-cache")
 	req.Header.Add("cache-control", "no-cache")

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -29,6 +29,7 @@ const (
 	errOpResponseFormat = "sec_bodyparser" // Parse errors
 	errOpNotFound       = "sec_notfound"   // No matching search results
 	errOpCreate         = "sec_create"     // Create failed
+	errBadPassword      = "sec_password"   // Password formatting
 )
 
 // SecError : Error formatted in JSON containing an errorOp and a description from

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -4,19 +4,19 @@ import (
 	"encoding/json"
 )
 
-// KeycloakMasterRealm master realm name
+// KeycloakMasterRealm : master realm name
 const KeycloakMasterRealm string = "master"
 
-// KeycloakAdminClientID master realm name
+// KeycloakAdminClientID : master realm name
 const KeycloakAdminClientID string = "admin-cli"
 
-// CodewindCliID master realm name
+// CodewindCliID : master realm name
 const CodewindCliID string = "codewind-cli"
 
-// CodewindClientID master realm name
+// CodewindClientID : master realm name
 const CodewindClientID string = "codewind-backend"
 
-// SecError - Security package errors
+// SecError : Security package errors
 type SecError struct {
 	Op   string
 	Err  error
@@ -24,12 +24,13 @@ type SecError struct {
 }
 
 const (
-	errOpConnection     = "sec_connection" // Connection failed
-	errOpResponse       = "sec_response"   // Bad response
-	errOpResponseFormat = "sec_bodyparser" // Parse errors
-	errOpNotFound       = "sec_notfound"   // No matching search results
-	errOpCreate         = "sec_create"     // Create failed
-	errOpPassword       = "sec_password"   // Password formatting
+	errOpConnection     = "sec_connection"      // Connection failed
+	errOpResponse       = "sec_response"        // Bad response
+	errOpResponseFormat = "sec_bodyparser"      // Parse errors
+	errOpNotFound       = "sec_notfound"        // No matching search results
+	errOpCreate         = "sec_create"          // Create failed
+	errOpPassword       = "sec_passwordcontent" // Password formatting
+	errOpHostname       = "sec_badhostname"     // Bad hostname / url
 )
 
 const (
@@ -44,7 +45,7 @@ func (se *SecError) Error() string {
 	return "{\"error\", \"" + se.Op + "\", \"error_description\": \"" + se.Err.Error() + "\"}"
 }
 
-// KeycloakAPIError Error responses from Keycloak
+// KeycloakAPIError : Error responses from Keycloak
 type KeycloakAPIError struct {
 	HTTPStatus       int
 	Error            string `json:"error"`

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -1,0 +1,102 @@
+package security
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+
+	"github.com/urfave/cli"
+)
+
+// KeycloakMasterRealm master realm name
+const KeycloakMasterRealm string = "master"
+
+// KeycloakAdminClientID master realm name
+const KeycloakAdminClientID string = "admin-cli"
+
+// CodewindCliID master realm name
+const CodewindCliID string = "codewind-cli"
+
+// CodewindClientID master realm name
+const CodewindClientID string = "codewind-backend"
+
+// SecError - Security package errors
+type SecError struct {
+	Op   string
+	Err  error
+	Desc string
+}
+
+const (
+	errOpConnection     = "sec_connection" // Connection failed
+	errOpResponse       = "sec_response"   // Bad response
+	errOpResponseFormat = "sec_bodyparser" // Parse errors
+	errOpNotFound       = "sec_notfound"   // No matching search results
+)
+
+// SecError : Error formatted in JSON containing an errorOp and a description from
+// either a fault condition in the CLI, or an error payload from a REST request
+func (se *SecError) Error() string {
+	return "{\"error\", \"" + se.Op + "\", \"error_description\": \"" + se.Err.Error() + "\"}"
+}
+
+// RegisteredClients A collection of registered clients
+type RegisteredClients struct {
+	Collection []RegisteredClient
+}
+
+// RegisteredClient details of a registered client
+type RegisteredClient struct {
+	ID       string `json:"id"`
+	ClientID string `json:"clientId"`
+	Name     string `json:"name"`
+}
+
+// KeycloakAPIError Error responses from Keycloak
+type KeycloakAPIError struct {
+	HTTPStatus       int
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	ErrorMessage     string `json:"errorMessage"`
+}
+
+// Result : status messaqe
+type Result struct {
+	Status string `json:"status"`
+}
+
+// parseKeycloakError : parse the JSON response from Keycloak
+func parseKeycloakError(body string, httpCode int) *KeycloakAPIError {
+	keycloakAPIError := KeycloakAPIError{}
+	keycloakAPIError.HTTPStatus = httpCode
+	json.Unmarshal([]byte(body), &keycloakAPIError)
+	// copy message into description if one is not set
+	if keycloakAPIError.ErrorMessage != "" && keycloakAPIError.ErrorDescription == "" {
+		keycloakAPIError.ErrorDescription = keycloakAPIError.ErrorMessage
+	}
+	return &keycloakAPIError
+}
+
+// SecUserCreate : Create a new user in Keycloak
+func SecUserCreate(c *cli.Context) error {
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return nil
+}
+
+// SecUserGet : Retrieve user info from keycloak
+func SecUserGet(c *cli.Context) error {
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return nil
+}
+
+// SecUserSetPW : Set a users password
+func SecUserSetPW(c *cli.Context) error {
+	if c.GlobalBool("insecure") {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return nil
+}

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -1,11 +1,7 @@
 package security
 
 import (
-	"crypto/tls"
 	"encoding/json"
-	"net/http"
-
-	"github.com/urfave/cli"
 )
 
 // KeycloakMasterRealm master realm name
@@ -32,6 +28,7 @@ const (
 	errOpResponse       = "sec_response"   // Bad response
 	errOpResponseFormat = "sec_bodyparser" // Parse errors
 	errOpNotFound       = "sec_notfound"   // No matching search results
+	errOpCreate         = "sec_create"     // Create failed
 )
 
 // SecError : Error formatted in JSON containing an errorOp and a description from
@@ -50,6 +47,17 @@ type RegisteredClient struct {
 	ID       string `json:"id"`
 	ClientID string `json:"clientId"`
 	Name     string `json:"name"`
+}
+
+// RegisteredUsers A collection of registered users
+type RegisteredUsers struct {
+	Collection []RegisteredUser
+}
+
+// RegisteredUser details of a registered user
+type RegisteredUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
 }
 
 // KeycloakAPIError Error responses from Keycloak
@@ -75,28 +83,4 @@ func parseKeycloakError(body string, httpCode int) *KeycloakAPIError {
 		keycloakAPIError.ErrorDescription = keycloakAPIError.ErrorMessage
 	}
 	return &keycloakAPIError
-}
-
-// SecUserCreate : Create a new user in Keycloak
-func SecUserCreate(c *cli.Context) error {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-	return nil
-}
-
-// SecUserGet : Retrieve user info from keycloak
-func SecUserGet(c *cli.Context) error {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-	return nil
-}
-
-// SecUserSetPW : Set a users password
-func SecUserSetPW(c *cli.Context) error {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-	return nil
 }

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -42,7 +42,13 @@ const (
 // SecError : Error formatted in JSON containing an errorOp and a description from
 // either a fault condition in the CLI, or an error payload from a REST request
 func (se *SecError) Error() string {
-	return "{\"error\", \"" + se.Op + "\", \"error_description\": \"" + se.Err.Error() + "\"}"
+	type Output struct {
+		Operation   string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	tempOutput := &Output{Operation: se.Op, Description: se.Err.Error()}
+	jsonError, _ := json.Marshal(tempOutput)
+	return string(jsonError)
 }
 
 // KeycloakAPIError : Error responses from Keycloak

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -37,29 +37,6 @@ func (se *SecError) Error() string {
 	return "{\"error\", \"" + se.Op + "\", \"error_description\": \"" + se.Err.Error() + "\"}"
 }
 
-// RegisteredClients A collection of registered clients
-type RegisteredClients struct {
-	Collection []RegisteredClient
-}
-
-// RegisteredClient details of a registered client
-type RegisteredClient struct {
-	ID       string `json:"id"`
-	ClientID string `json:"clientId"`
-	Name     string `json:"name"`
-}
-
-// RegisteredUsers A collection of registered users
-type RegisteredUsers struct {
-	Collection []RegisteredUser
-}
-
-// RegisteredUser details of a registered user
-type RegisteredUser struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
-}
-
 // KeycloakAPIError Error responses from Keycloak
 type KeycloakAPIError struct {
 	HTTPStatus       int

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -29,7 +29,13 @@ const (
 	errOpResponseFormat = "sec_bodyparser" // Parse errors
 	errOpNotFound       = "sec_notfound"   // No matching search results
 	errOpCreate         = "sec_create"     // Create failed
-	errBadPassword      = "sec_password"   // Password formatting
+	errOpPassword       = "sec_password"   // Password formatting
+)
+
+const (
+	textBadPassword   = "Passwords must not contains quoted characters"
+	textUserNotFound  = "Registered User not found"
+	textUnableToParse = "Unable to parse Keycloak response"
 )
 
 // SecError : Error formatted in JSON containing an errorOp and a description from

--- a/utils/security/user.go
+++ b/utils/security/user.go
@@ -11,6 +11,17 @@ import (
 	"github.com/urfave/cli"
 )
 
+// RegisteredUsers A collection of registered users
+type RegisteredUsers struct {
+	Collection []RegisteredUser
+}
+
+// RegisteredUser details of a registered user
+type RegisteredUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
 // SecUserSetPW : Set a users password
 func SecUserSetPW(c *cli.Context) error {
 	if c.GlobalBool("insecure") {

--- a/utils/security/user.go
+++ b/utils/security/user.go
@@ -111,7 +111,7 @@ func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
 	}
 	req.Header.Add("Authorization", "Bearer "+accesstoken)
 	req.Header.Add("cache-control", "no-cache")
-	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Cache-Control", "no-cache")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, &SecError{errOpConnection, err, err.Error()}
@@ -188,7 +188,7 @@ func SecUserSetPW(c *cli.Context) *SecError {
 	req.Header.Add("Authorization", "Bearer "+accesstoken)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
-	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Cache-Control", "no-cache")
 	res, err := http.DefaultClient.Do(req)
 
 	if err != nil {

--- a/utils/security/user.go
+++ b/utils/security/user.go
@@ -143,6 +143,12 @@ func SecUserSetPW(c *cli.Context) *SecError {
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 	newPassword := strings.TrimSpace(c.String("newpw"))
 
+	// validate password characters
+	if strings.Contains(newPassword, "'") || strings.Contains(newPassword, "\"") {
+		err := errors.New("Passwords must not contains quoted characters")
+		return &SecError{errBadPassword, err, err.Error()}
+	}
+
 	// Authenticate if needed
 	if accesstoken == "" {
 		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)

--- a/utils/security/user.go
+++ b/utils/security/user.go
@@ -88,9 +88,7 @@ func SecUserCreate(c *cli.Context) *SecError {
 
 // SecUserGet : Get user from Keycloak
 func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
+
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	realm := strings.TrimSpace(c.String("realm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
@@ -150,19 +148,11 @@ func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
 
 // SecUserSetPW : Resets the users password in keycloak to a new one supplied
 func SecUserSetPW(c *cli.Context) *SecError {
-	if c.GlobalBool("insecure") {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
+
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	realm := strings.TrimSpace(c.String("realm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 	newPassword := strings.TrimSpace(c.String("newpw"))
-
-	// validate password characters
-	if strings.Contains(newPassword, "'") || strings.Contains(newPassword, "\"") {
-		err := errors.New(textBadPassword)
-		return &SecError{errOpPassword, err, err.Error()}
-	}
 
 	// authenticate if needed
 	if accesstoken == "" {

--- a/utils/security/user.go
+++ b/utils/security/user.go
@@ -44,8 +44,23 @@ func SecUserCreate(c *cli.Context) *SecError {
 
 	// build REST request
 	url := hostname + "/auth/admin/realms/" + realm + "/users"
-	//    '{"username":"developer","firstName":"codewind","lastName":"developer","enabled":true}'
-	payload := strings.NewReader("{\"enabled\":true,\"username\":\"" + targetUsername + "\",\"firstName\":\"\",\"lastName\":\"" + targetUsername + "\"}")
+
+	// build the payload (JSON)
+	type PayloadUser struct {
+		Enabled   bool   `json:"enabled"`
+		Username  string `json:"username"`
+		FirstName string `json:"firstName"`
+		LastName  string `json:"lastName"`
+	}
+	tempUser := &PayloadUser{
+		Enabled:   true,
+		Username:  targetUsername,
+		FirstName: "",
+		LastName:  "",
+	}
+
+	jsonUser, err := json.Marshal(tempUser)
+	payload := strings.NewReader(string(jsonUser))
 	req, err := http.NewRequest("POST", url, payload)
 	if err != nil {
 		return &SecError{errOpConnection, err, err.Error()}
@@ -165,7 +180,16 @@ func SecUserSetPW(c *cli.Context) *SecError {
 
 	// build REST request
 	url := hostname + "/auth/admin/realms/" + realm + "/users/" + registeredUser.ID + "/reset-password"
-	payload := strings.NewReader("{\"type\":\"password\",\"value\":\"" + newPassword + "\",\"temporary\":false}")
+
+	// build the payload (JSON)
+	type PayloadPasswordChange struct {
+		Type      string `json:"type"`
+		Value     string `json:"value"`
+		Temporary bool   `json:"temporary"`
+	}
+	tempPasswordChange := &PayloadPasswordChange{Type: "password", Value: newPassword, Temporary: false}
+	jsonPasswordChange, err := json.Marshal(tempPasswordChange)
+	payload := strings.NewReader(string(jsonPasswordChange))
 	req, err := http.NewRequest("PUT", url, payload)
 	if err != nil {
 		return &SecError{errOpConnection, err, err.Error()}

--- a/utils/security/user.go
+++ b/utils/security/user.go
@@ -11,12 +11,12 @@ import (
 	"github.com/urfave/cli"
 )
 
-// RegisteredUsers A collection of registered users
+// RegisteredUsers : A collection of registered users
 type RegisteredUsers struct {
 	Collection []RegisteredUser
 }
 
-// RegisteredUser details of a registered user
+// RegisteredUser : details of a registered user
 type RegisteredUser struct {
 	ID       string `json:"id"`
 	Username string `json:"username"`
@@ -33,7 +33,7 @@ func SecUserCreate(c *cli.Context) *SecError {
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 	targetUsername := strings.TrimSpace(c.String("name"))
 
-	// Authenticate if needed
+	// authenticate if needed
 	if accesstoken == "" {
 		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
 		if err != nil || authToken == nil {
@@ -81,7 +81,7 @@ func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 	searchName := strings.TrimSpace(c.String("name"))
 
-	// Authenticate if needed
+	// authenticate if needed
 	if accesstoken == "" {
 		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
 		if err != nil || authToken == nil {
@@ -90,7 +90,7 @@ func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
 		accesstoken = authToken.AccessToken
 	}
 
-	// Built REST request
+	// build REST request
 	url := hostname + "/auth/admin/realms/" + realm + "/users?username=" + searchName
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -106,7 +106,7 @@ func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
 
 	defer res.Body.Close()
 
-	// Handle HTTP status codes
+	// handle HTTP status codes
 	if res.StatusCode != 200 {
 		body, _ := ioutil.ReadAll(res.Body)
 		err = errors.New(string(body))
@@ -120,14 +120,14 @@ func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
 		return nil, &SecError{errOpResponseFormat, err, err.Error()}
 	}
 
-	registredUser := RegisteredUser{}
+	registeredUser := RegisteredUser{}
 
 	if len(registeredUsers.Collection) > 0 {
-		registredUser = registeredUsers.Collection[0]
-		return &registredUser, nil
+		registeredUser = registeredUsers.Collection[0]
+		return &registeredUser, nil
 	}
 
-	// not found
+	// user not found
 	errNotFound := errors.New(textUserNotFound)
 	return nil, &SecError{errOpNotFound, errNotFound, errNotFound.Error()}
 
@@ -149,7 +149,7 @@ func SecUserSetPW(c *cli.Context) *SecError {
 		return &SecError{errOpPassword, err, err.Error()}
 	}
 
-	// Authenticate if needed
+	// authenticate if needed
 	if accesstoken == "" {
 		authToken, err := SecAuthenticate(c, KeycloakMasterRealm, KeycloakAdminClientID)
 		if err != nil || authToken == nil {
@@ -163,7 +163,7 @@ func SecUserSetPW(c *cli.Context) *SecError {
 		return secError
 	}
 
-	// Built REST request
+	// build REST request
 	url := hostname + "/auth/admin/realms/" + realm + "/users/" + registeredUser.ID + "/reset-password"
 	payload := strings.NewReader("{\"type\":\"password\",\"value\":\"" + newPassword + "\",\"temporary\":false}")
 	req, err := http.NewRequest("PUT", url, payload)
@@ -183,7 +183,7 @@ func SecUserSetPW(c *cli.Context) *SecError {
 
 	defer res.Body.Close()
 
-	// Handle HTTP status codes
+	// handle HTTP status codes
 	if res.StatusCode != 204 {
 		errNotFound := errors.New(res.Status)
 		return &SecError{errOpNotFound, errNotFound, errNotFound.Error()}

--- a/utils/security/user.go
+++ b/utils/security/user.go
@@ -128,7 +128,7 @@ func SecUserGet(c *cli.Context) (*RegisteredUser, *SecError) {
 	}
 
 	// not found
-	errNotFound := errors.New("Registered User not found")
+	errNotFound := errors.New(textUserNotFound)
 	return nil, &SecError{errOpNotFound, errNotFound, errNotFound.Error()}
 
 }
@@ -145,8 +145,8 @@ func SecUserSetPW(c *cli.Context) *SecError {
 
 	// validate password characters
 	if strings.Contains(newPassword, "'") || strings.Contains(newPassword, "\"") {
-		err := errors.New("Passwords must not contains quoted characters")
-		return &SecError{errBadPassword, err, err.Error()}
+		err := errors.New(textBadPassword)
+		return &SecError{errOpPassword, err, err.Error()}
 	}
 
 	// Authenticate if needed


### PR DESCRIPTION
## Problem

- Configuration of a Keycloak container can be complicated and should be simplified. 
- IDEs should call Codewind APIs in a way that does not require them to manage the users credentials

## Solution

Introduce a new set of security commands to the Codewind CLI to : 

1. Create and manage a Keycloak realm for Codewind users in an existing Keycloak container
2. Create the Codewind client IDs and secrets needed for apps to authenticate
3. Create an initial developer user account for the application developer 
4. Provide a password change capability to change default passwords to something unique
5. Adds documentation explaining the use of the commands

## Commands added : 

```
   sectoken - Authenticate and obtain an access_token
   secrealm - Manage Realm configuration
   secclient - Manage client access configuration
   secuser  - Manage keycloak user account
```

## To follow : 

1. Tests
2. Keychain storage of user credentials
3. Enable Integration with Portal APIs





