### PR TITLE
add flag from to name to POST /templates

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -211,6 +211,11 @@ func Commands() {
 									Value: "",
 									Usage: "Description of the template repo",
 								},
+								cli.StringFlag{
+									Name:  "name",
+									Value: "",
+									Usage: "Name of the template repo",
+								},
 							},
 							Action: func(c *cli.Context) error {
 								AddTemplateRepo(c)

--- a/actions/templates.go
+++ b/actions/templates.go
@@ -76,6 +76,7 @@ func AddTemplateRepo(c *cli.Context) {
 	repos, err := apiroutes.AddTemplateRepo(
 		c.String("URL"),
 		c.String("description"),
+		c.String("name"),
 	)
 	if err != nil {
 		log.Printf("Error adding template repo: %q", err)

--- a/apiroutes/templates.go
+++ b/apiroutes/templates.go
@@ -27,6 +27,7 @@ type (
 	Template struct {
 		Label       string `json:"label"`
 		Description string `json:"description"`
+		Name        string `json:"name"`
 		Language    string `json:"language"`
 		URL         string `json:"url"`
 		ProjectType string `json:"projectType"`
@@ -36,13 +37,14 @@ type (
 	TemplateRepo struct {
 		Description string `json:"description"`
 		URL         string `json:"url"`
+		Name        string `json:name`
 	}
 )
 
 // GetTemplates gets project templates from PFE's REST API.
 // Filter them using the function arguments
 func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
-	req, err := http.NewRequest("GET", config.PFEApiRoute() + "templates", nil)
+	req, err := http.NewRequest("GET", config.PFEApiRoute()+"templates", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +118,7 @@ func GetTemplateRepos() ([]TemplateRepo, error) {
 
 // AddTemplateRepo adds a template repo to PFE and
 // returns the new list of existing repos
-func AddTemplateRepo(URL, description string) ([]TemplateRepo, error) {
+func AddTemplateRepo(URL, description string, name string) ([]TemplateRepo, error) {
 	if _, err := url.ParseRequestURI(URL); err != nil {
 		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
 	}
@@ -124,6 +126,7 @@ func AddTemplateRepo(URL, description string) ([]TemplateRepo, error) {
 	values := map[string]string{
 		"url":         URL,
 		"description": description,
+		"name":        name,
 	}
 	jsonValue, _ := json.Marshal(values)
 
@@ -164,7 +167,7 @@ func DeleteTemplateRepo(URL string) ([]TemplateRepo, error) {
 
 	req, err := http.NewRequest(
 		"DELETE",
-		config.PFEApiRoute() + "templates/repositories",
+		config.PFEApiRoute()+"templates/repositories",
 		bytes.NewBuffer(jsonValue),
 	)
 	req.Header.Set("Content-Type", "application/json")

--- a/apiroutes/templates.go
+++ b/apiroutes/templates.go
@@ -27,7 +27,6 @@ type (
 	Template struct {
 		Label       string `json:"label"`
 		Description string `json:"description"`
-		Name        string `json:"name"`
 		Language    string `json:"language"`
 		URL         string `json:"url"`
 		ProjectType string `json:"projectType"`
@@ -44,7 +43,7 @@ type (
 // GetTemplates gets project templates from PFE's REST API.
 // Filter them using the function arguments
 func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
-	req, err := http.NewRequest("GET", config.PFEApiRoute()+"templates", nil)
+	req, err := http.NewRequest("GET", config.PFEApiRoute() + "templates", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +166,7 @@ func DeleteTemplateRepo(URL string) ([]TemplateRepo, error) {
 
 	req, err := http.NewRequest(
 		"DELETE",
-		config.PFEApiRoute()+"templates/repositories",
+		config.PFEApiRoute() + "templates/repositories",
 		bytes.NewBuffer(jsonValue),
 	)
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
To go with https://github.com/eclipse/codewind/pull/602/files for https://github.com/eclipse/codewind/issues/586, allows a name flag to be added when invoking `templates repo add` and then calls the PFE endpoint with that name.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>