### PR TITLE
Add auth URL to Deployments command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ $ brew upgrade dep
 |secrealm        |`sr`          |'Manage new or existing REALM configurations'                       |
 |secclient       |`sc`          |'Manage new or existing APPLICATION access configurations'          |
 |secuser         |`su`          |'Manage new or existing USER access configurations'                 |
+|deployments     |`dep`         |'Manage deployments configuration list'                             |
 |help            |`h`           |'Shows a list of commands or help for one command'                  |
 
 ## CLI Command Options
@@ -227,6 +228,36 @@ Subcommands:</br>
 > --password value               Admin Password
 > --name value                   Username to query
 > --newpw value                  New replacement password
+## deployments
+
+Subcommands:</br>
+
+`add/a` - Add a new deployment to the list
+
+> **Flags:**
+> --id value     A deployment reference id
+> --label value  A displayable name
+> --url value    The ingress URL of the PFE instance
+> --auth value   URL of Keycloak service eg: `https://mykeycloak.test:8443`
+
+`remove/rm` - Remove a deployment from the list
+
+> **Flags:**
+> --id value     A deployment reference id
+
+`target/t` - Show/Change the current target deployment
+
+> *Note:* Not supplying any flag will return the current selected target
+> --id value  The deployment id of the target to switch to
+
+
+`list/ls` - List known deployments
+
+>**Note:** No additional flags
+
+`reset` - Resets the deployments list to a single local deployment
+
+>**Note:** No additional flags
 
 ## help
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Subcommands:</br>
 > --password value               Admin Password
 > --name value                   Username to query
 > --newpw value                  New replacement password
+ 
 ## deployments
 
 Subcommands:</br>
@@ -239,6 +240,8 @@ Subcommands:</br>
 > --label value  A displayable name
 > --url value    The ingress URL of the PFE instance
 > --auth value   URL of Keycloak service eg: `https://mykeycloak.test:8443`
+> --realm value  Security realm eg:  codewind or che
+> --clientid value  Security client id eg:  codewind or che-public
 
 `remove/rm` - Remove a deployment from the list
 

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -415,6 +415,8 @@ func Commands() {
 						cli.StringFlag{Name: "label", Usage: "A displayable name", Required: false},
 						cli.StringFlag{Name: "url", Usage: "The ingress URL of the PFE instance", Required: true},
 						cli.StringFlag{Name: "auth", Usage: "URL of Keycloak service eg: https://mykeycloak.test:8443", Required: false},
+						cli.StringFlag{Name: "realm", Usage: "Security realm eg: codewind or che", Required: false},
+						cli.StringFlag{Name: "clientid", Usage: "Security client_id to connect as eg: codewind_ctl or che-public", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						AddDeploymentToList(c)

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -404,16 +404,17 @@ func Commands() {
 		{
 			Name:    "deployments",
 			Aliases: []string{"dep"},
-			Usage:   "Maintain local deployments list",
+			Usage:   "Manage deployments list",
 			Subcommands: []cli.Command{
 				{
 					Name:    "add",
 					Aliases: []string{"a"},
-					Usage:   "Add a new deployment to the list",
+					Usage:   "Add a new deployment to the configuration file",
 					Flags: []cli.Flag{
-						cli.StringFlag{Name: "name", Usage: "A reference name", Required: true},
+						cli.StringFlag{Name: "id", Usage: "A reference name", Required: true},
 						cli.StringFlag{Name: "label", Usage: "A displayable name", Required: false},
-						cli.StringFlag{Name: "url", Usage: "The ingress url of the PFE instance", Required: true},
+						cli.StringFlag{Name: "url", Usage: "The ingress URL of the PFE instance", Required: true},
+						cli.StringFlag{Name: "auth", Usage: "URL of Keycloak service eg: https://mykeycloak.test:8443", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						AddDeploymentToList(c)
@@ -423,9 +424,9 @@ func Commands() {
 				{
 					Name:    "remove",
 					Aliases: []string{"rm"},
-					Usage:   "Remove a deployment from the list",
+					Usage:   "Remove a deployment from the configuration file",
 					Flags: []cli.Flag{
-						cli.StringFlag{Name: "name", Usage: "The reference name of the deployment to be removed", Required: true},
+						cli.StringFlag{Name: "id", Usage: "The reference ID of the deployment to be removed", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						if c.NumFlags() != 1 {
@@ -440,7 +441,7 @@ func Commands() {
 					Aliases: []string{"t"},
 					Usage:   "Show/Change the current target deployment",
 					Flags: []cli.Flag{
-						cli.StringFlag{Name: "name", Usage: "The deployment name of a new target"},
+						cli.StringFlag{Name: "id", Usage: "The deployment id of the target to switch to"},
 					},
 					Action: func(c *cli.Context) error {
 						if c.NumFlags() == 0 {

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -33,10 +33,12 @@ type DeploymentConfig struct {
 
 // Deployment entry
 type Deployment struct {
-	ID      string `json:"id"`
-	Label   string `json:"label"`
-	URL     string `json:"url"`
-	AuthURL string `json:"auth"`
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	URL      string `json:"url"`
+	AuthURL  string `json:"auth"`
+	Realm    string `json:"realm"`
+	ClientID string `json:"clientid"`
 }
 
 // InitDeploymentConfigIfRequired : Check the config file exist, if it does not then create a new default configuration
@@ -55,10 +57,12 @@ func ResetDeploymentsFile() {
 		Active: "local",
 		Deployments: []Deployment{
 			Deployment{
-				ID:      "local",
-				Label:   "Codewind local deployment",
-				URL:     "",
-				AuthURL: "",
+				ID:       "local",
+				Label:    "Codewind local deployment",
+				URL:      "",
+				AuthURL:  "",
+				Realm:    "",
+				ClientID: "",
 			},
 		},
 	}
@@ -128,6 +132,9 @@ func AddDeploymentToList(c *cli.Context) {
 		auth = strings.TrimSuffix(auth, "/")
 	}
 
+	realm := strings.TrimSpace(c.String("realm"))
+	clientID := strings.TrimSpace(c.String("clientid"))
+
 	data, errCode, err := loadDeploymentsConfigFile()
 	errors.CheckErr(err, errCode, "Unable to process the deployments config file")
 
@@ -140,10 +147,12 @@ func AddDeploymentToList(c *cli.Context) {
 
 	// create the new deployment
 	newDeployment := Deployment{
-		ID:      id,
-		Label:   label,
-		URL:     url,
-		AuthURL: auth,
+		ID:       id,
+		Label:    label,
+		URL:      url,
+		AuthURL:  auth,
+		Realm:    realm,
+		ClientID: clientID,
 	}
 
 	// append it to the list

--- a/actions/deployment_test.go
+++ b/actions/deployment_test.go
@@ -45,7 +45,10 @@ func Test_CreateNewDeployment(t *testing.T) {
 	set.String("id", "remoteserver", "just an id")
 	set.String("label", "MyRemoteServer", "just a label")
 	set.String("url", "https://codewind.server.remote", "Codewind URL")
-	set.String("auth", "https://auth.server.remote", "Auth URL")
+	set.String("auth", "https://auth.server.remote:8443", "Auth URL")
+	set.String("realm", "codewind", "Security realm")
+	set.String("clientid", "cwctl", "ID of client")
+
 	c := cli.NewContext(nil, set, nil)
 	ResetDeploymentsFile()
 	t.Run("Adds new deployment to the config", func(t *testing.T) {
@@ -66,7 +69,9 @@ func Test_SwitchTarget(t *testing.T) {
 		assert.Equal(t, "remoteserver", result.ID)
 		assert.Equal(t, "MyRemoteServer", result.Label)
 		assert.Equal(t, "https://codewind.server.remote", result.URL)
-		assert.Equal(t, "https://auth.server.remote", result.AuthURL)
+		assert.Equal(t, "https://auth.server.remote:8443", result.AuthURL)
+		assert.Equal(t, "codewind", result.Realm)
+		assert.Equal(t, "cwctl", result.ClientID)
 	})
 }
 

--- a/actions/deployment_test.go
+++ b/actions/deployment_test.go
@@ -24,7 +24,7 @@ func Test_GetActiveDeployment(t *testing.T) {
 		result := FindTargetDeployment()
 		assert.Equal(t, "local", result.Name)
 		assert.Equal(t, "Codewind local deployment", result.Label)
-		assert.Equal(t, "tbd", result.Url)
+		assert.Equal(t, "", result.URL)
 	})
 }
 

--- a/actions/deployment_test.go
+++ b/actions/deployment_test.go
@@ -12,24 +12,16 @@
 package actions
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
 )
 
-func Test_GetActiveDeployment(t *testing.T) {
-	InitDeploymentConfigIfRequired()
-	t.Run("ActiveDeployment", func(t *testing.T) {
-		ResetDeploymentsFile()
-		result := FindTargetDeployment()
-		assert.Equal(t, "local", result.Name)
-		assert.Equal(t, "Codewind local deployment", result.Label)
-		assert.Equal(t, "", result.URL)
-	})
-}
-
 func Test_GetDeploymentsConfig(t *testing.T) {
-	t.Run("GetDeploymentsConfig", func(t *testing.T) {
+	InitDeploymentConfigIfRequired()
+	t.Run("Asserts there is only one deployment", func(t *testing.T) {
 		ResetDeploymentsFile()
 		result := GetDeploymentsConfig()
 		assert.Equal(t, "local", result.Active)
@@ -37,4 +29,71 @@ func Test_GetDeploymentsConfig(t *testing.T) {
 	})
 }
 
-//TODO:  add coverage
+func Test_GetActiveDeployment(t *testing.T) {
+	t.Run("Asserts the initial deployment is local", func(t *testing.T) {
+		ResetDeploymentsFile()
+		result := FindTargetDeployment()
+		assert.Equal(t, "local", result.ID)
+		assert.Equal(t, "Codewind local deployment", result.Label)
+		assert.Equal(t, "", result.URL)
+	})
+}
+
+// Test_CreateNewDeployment :  Adds a new deployment to the list called remoteserver
+func Test_CreateNewDeployment(t *testing.T) {
+	set := flag.NewFlagSet("tests", 0)
+	set.String("id", "remoteserver", "just an id")
+	set.String("label", "MyRemoteServer", "just a label")
+	set.String("url", "https://codewind.server.remote", "Codewind URL")
+	set.String("auth", "https://auth.server.remote", "Auth URL")
+	c := cli.NewContext(nil, set, nil)
+	ResetDeploymentsFile()
+	t.Run("Adds new deployment to the config", func(t *testing.T) {
+		AddDeploymentToList(c)
+		result := GetDeploymentsConfig()
+		assert.Len(t, result.Deployments, 2)
+	})
+}
+
+// Test_SwitchTarget : Switches the target from one deployment to one called remoteserver
+func Test_SwitchTarget(t *testing.T) {
+	set := flag.NewFlagSet("tests", 0)
+	set.String("id", "remoteserver", "doc")
+	c := cli.NewContext(nil, set, nil)
+	t.Run("Assert target switches to remoteserver", func(t *testing.T) {
+		SetTargetDeployment(c)
+		result := FindTargetDeployment()
+		assert.Equal(t, "remoteserver", result.ID)
+		assert.Equal(t, "MyRemoteServer", result.Label)
+		assert.Equal(t, "https://codewind.server.remote", result.URL)
+		assert.Equal(t, "https://auth.server.remote", result.AuthURL)
+	})
+}
+
+// Test_RemoveDeploymentFromList : Adds a new deployment to the stored list
+func Test_RemoveDeploymentFromList(t *testing.T) {
+	set := flag.NewFlagSet("tests", 0)
+	set.String("id", "remoteserver", "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	t.Run("Check we have 2 deployments", func(t *testing.T) {
+		result := GetDeploymentsConfig()
+		assert.Len(t, result.Deployments, 2)
+	})
+
+	t.Run("Check current target is 'remoteserver'", func(t *testing.T) {
+		result := FindTargetDeployment()
+		assert.Equal(t, "remoteserver", result.ID)
+	})
+
+	t.Run("Remove the remoteserver deployment", func(t *testing.T) {
+		RemoveDeploymentFromList(c)
+		result := GetDeploymentsConfig()
+		assert.Len(t, result.Deployments, 1)
+	})
+
+	t.Run("Check target reverts back to local", func(t *testing.T) {
+		result := FindTargetDeployment()
+		assert.Equal(t, "local", result.ID)
+	})
+}

--- a/actions/status.go
+++ b/actions/status.go
@@ -23,7 +23,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-//StatusCommand to show the status
+// StatusCommand to show the status
 func StatusCommand(c *cli.Context) {
 	targetDeployment := FindTargetDeployment()
 	if strings.EqualFold(targetDeployment.Name, "local") {
@@ -33,9 +33,10 @@ func StatusCommand(c *cli.Context) {
 	}
 }
 
+// StatusCommandRemoteDeployment - Output remote deployment details
 func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 	jsonOutput := c.Bool("json")
-	apiResponse, err := apiroutes.GetAPIEnvironment(c, d.Url)
+	apiResponse, err := apiroutes.GetAPIEnvironment(c, d.URL)
 	if err != nil {
 		if jsonOutput {
 			type status struct {
@@ -49,7 +50,7 @@ func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 			output, _ := json.Marshal(respStatus)
 			fmt.Println(string(output))
 		} else {
-			fmt.Println("Codewind remote deployment did not respond on " + d.Url)
+			fmt.Println("Codewind remote deployment did not respond on " + d.URL)
 			log.Println(err)
 		}
 		os.Exit(0)
@@ -68,21 +69,22 @@ func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 			Status:   "started",
 			Versions: append(versions, apiResponse.Version),
 			Started:  append(versions, apiResponse.Version),
-			URL:      d.Url,
+			URL:      d.URL,
 		}
 		output, _ := json.Marshal(resp)
 		fmt.Println(string(output))
 	} else {
-		fmt.Println("Codewind is installed and running on: " + d.Url)
+		fmt.Println("Codewind is installed and running on: " + d.URL)
 	}
 	os.Exit(0)
 
 }
 
+// StatusCommandLocalDeployment - Output local deployment details
 func StatusCommandLocalDeployment(c *cli.Context) {
 	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {
-		// STARTED
+		// Started
 		hostname, port := utils.GetPFEHostAndPort()
 		if jsonOutput {
 
@@ -112,7 +114,7 @@ func StatusCommandLocalDeployment(c *cli.Context) {
 	}
 
 	if utils.CheckImageStatus() {
-		// INSTALLED BUT NOT STARTED
+		// Installed but not started
 		if jsonOutput {
 
 			imageTagArr := utils.GetImageTags()
@@ -134,7 +136,7 @@ func StatusCommandLocalDeployment(c *cli.Context) {
 		}
 		os.Exit(0)
 	} else {
-		// NOT INSTALLED
+		// Not installed
 		if jsonOutput {
 			output, _ := json.Marshal(map[string]string{"status": "uninstalled"})
 			fmt.Println(string(output))

--- a/actions/status.go
+++ b/actions/status.go
@@ -23,17 +23,17 @@ import (
 	"github.com/urfave/cli"
 )
 
-// StatusCommand to show the status
+// StatusCommand : to show the status
 func StatusCommand(c *cli.Context) {
 	targetDeployment := FindTargetDeployment()
-	if strings.EqualFold(targetDeployment.Name, "local") {
+	if strings.EqualFold(targetDeployment.ID, "local") {
 		StatusCommandLocalDeployment(c)
 	} else {
 		StatusCommandRemoteDeployment(c, targetDeployment)
 	}
 }
 
-// StatusCommandRemoteDeployment - Output remote deployment details
+// StatusCommandRemoteDeployment : Output remote deployment details
 func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 	jsonOutput := c.Bool("json")
 	apiResponse, err := apiroutes.GetAPIEnvironment(c, d.URL)
@@ -80,7 +80,7 @@ func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 
 }
 
-// StatusCommandLocalDeployment - Output local deployment details
+// StatusCommandLocalDeployment : Output local deployment details
 func StatusCommandLocalDeployment(c *cli.Context) {
 	jsonOutput := c.Bool("json")
 	if utils.CheckContainerStatus() {


### PR DESCRIPTION
## Problem 

The existing Codewind CLI deployments command needs to store an AUTH server endpoint for remote cloud deployments where authentication is required. 

## Solution

This PR adds :

1. Adds new optional `--auth` `--realm` `--clientid`  flags to the `add` command
2. Adds the auth URL, realm and clientid output to the `target` command
3. Updates README usage notes
4. Rename the deployment `name` field to deployment `id`
5. Adds additional unit tests for the deployment command 
6. Fix old linter warnings

## Example deployment : 

```javascript
{
        "active": "local",
        "deployments": [
                {
                        "id": "local",
                        "label": "Codewind local deployment",
                        "url": "",
                        "auth": "",
                        "realm": "",
                        "clientid": ""
                },
                {
                        "id": "someremote",
                        "label": "My Cloud Deployment",
                        "url": "https://mycloudserver.example.com",
                        "auth": "https://authentication.example.com",
                        "realm": "codewind",
                        "clientid": "codewind-cli"
                }
        ]
}
```

## Test output 

```
=== RUN   Test_GetDeploymentsConfig
=== RUN   Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment
--- PASS: Test_GetDeploymentsConfig (0.00s)
    --- PASS: Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment (0.00s)
=== RUN   Test_GetActiveDeployment
=== RUN   Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local
--- PASS: Test_GetActiveDeployment (0.00s)
    --- PASS: Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local (0.00s)
=== RUN   Test_CreateNewDeployment
=== RUN   Test_CreateNewDeployment/Adds_new_deployment_to_the_config
--- PASS: Test_CreateNewDeployment (0.00s)
    --- PASS: Test_CreateNewDeployment/Adds_new_deployment_to_the_config (0.00s)
=== RUN   Test_SwitchTarget
=== RUN   Test_SwitchTarget/Assert_target_switches_to_remoteserver
--- PASS: Test_SwitchTarget (0.00s)
    --- PASS: Test_SwitchTarget/Assert_target_switches_to_remoteserver (0.00s)
=== RUN   Test_RemoveDeploymentFromList
=== RUN   Test_RemoveDeploymentFromList/Check_we_have_2_deployments
=== RUN   Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver'
=== RUN   Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment
=== RUN   Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local
--- PASS: Test_RemoveDeploymentFromList (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_we_have_2_deployments (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver' (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/actions   0.020s
```