### PR TITLE
Add new seckeyring command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,14 @@
   version = "v1.4.2"
 
 [[projects]]
+  digest = "1:675c7e2e645d40363350159cfe1f719f61ce353a3859db939ca686d98aa85f16"
+  name = "github.com/danieljoos/wincred"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b892d337201d1400370ebf4fa919941c9ea222ee"
+  version = "v1.0.2"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -97,6 +105,14 @@
   pruneopts = "UT"
   revision = "519db1ee28dcc9fd2474ae59fca29a810482bfb1"
   version = "v0.4.0"
+
+[[projects]]
+  digest = "1:1f9fae0d86e56888d2e00c231d2a3958c321856ae585cff461b64929c66ce595"
+  name = "github.com/godbus/dbus"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "735b987ea3fc98b200348de1656e97f656ed4873"
+  version = "v5.0.2"
 
 [[projects]]
   digest = "1:525ebc5da920b1f2c76ae763c13f4decdc3c3bc541ff0fa18f2399d4e742177f"
@@ -172,6 +188,17 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:df5e82212238797c639de335e63a63e2eeddbacce39f3ab9a86405c3ea8b3a6c"
+  name = "github.com/zalando/go-keyring"
+  packages = [
+    ".",
+    "secret_service",
+  ]
+  pruneopts = "UT"
+  revision = "62750a1ff80d85940d011bc005f538647fe5d091"
+
+[[projects]]
+  branch = "master"
   digest = "1:50804d40964a0c59170e827824e79bbf810cc10ae57603d8facce8a1f48f9a83"
   name = "golang.org/x/crypto"
   packages = [
@@ -229,6 +256,7 @@
     "github.com/moby/moby/client",
     "github.com/stretchr/testify/assert",
     "github.com/urfave/cli",
+    "github.com/zalando/go-keyring",
     "gopkg.in/yaml.v3",
   ]
   solver-name = "gps-cdcl"

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Subcommands:</br>
 
 Subcommands:</br>
 
-`update/u` - Add new or updates existing Codewind credentials key in keyring
+`update/u` - Add new or update existing Codewind credentials key in keyring
 
 > --depid `<value>`                 Deployment ID (see the deployments cmd)
 > --username `<value>`              Username

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ $ brew upgrade dep
 |sectoken        |`st`          |'Authenticate with username and password to obtain an access_token' |
 |secrealm        |`sr`          |'Manage new or existing REALM configurations'                       |
 |secclient       |`sc`          |'Manage new or existing APPLICATION access configurations'          |
+|seckeyring      |`sk`          |'Manage Codewind keys in the desktop keyring'                       |
 |secuser         |`su`          |'Manage new or existing USER access configurations'                 |
 |deployments     |`dep`         |'Manage deployments configuration list'                             |
 |help            |`h`           |'Shows a list of commands or help for one command'                  |
@@ -196,6 +197,21 @@ Subcommands:</br>
 > --accesstoken value            Admin access_token
 > --username value               Admin Username
 > --password value               Admin Password
+
+## seckeyring
+
+Subcommands:</br>
+
+`update/u` - Add new or updates existing Codewind credentials key in keyring
+
+> --depid `<value>`                 Deployment ID (see the deployments cmd)
+> --username `<value>`              Username
+> --password `<value>`              Password
+
+`validate/v` - Checks if credentials key exist in the keyring
+
+> --depid `<value>`                 Deployment ID (see the deployments cmd)
+> --username `<value>`              Username
 
 ## secuser
 

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -272,6 +272,39 @@ func Commands() {
 			},
 		},
 		{
+			Name:    "seckeyring",
+			Aliases: []string{"sk"},
+			Usage:   "Manage the desktop keyring",
+			Subcommands: []cli.Command{
+				{
+					Name:    "update",
+					Aliases: []string{"u"},
+					Usage:   "Add new or update existing Codewind credentials in the keyring",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "depid,d", Usage: "Deployment ID (see the deployments cmd)", Required: true},
+						cli.StringFlag{Name: "username,u", Usage: "Username", Required: true},
+						cli.StringFlag{Name: "password,p", Usage: "New password", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityKeyUpdate(c)
+						return nil
+					},
+				}, {
+					Name:    "validate",
+					Aliases: []string{"v"},
+					Usage:   "Checks if Codewind credentials exist in the keyring",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "depid,d", Usage: "Keycloak login ID", Required: true},
+						cli.StringFlag{Name: "username,u", Usage: "Username", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityKeyValidate(c)
+						return nil
+					},
+				},
+			},
+		},
+		{
 			Name:    "secrealm",
 			Aliases: []string{"sr"},
 			Usage:   "Manage Realm configuration",

--- a/actions/security.go
+++ b/actions/security.go
@@ -12,6 +12,7 @@
 package actions
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -127,7 +128,8 @@ func SecurityKeyUpdate(c *cli.Context) {
 		fmt.Println(err.Error())
 		os.Exit(0)
 	}
-	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	response, _ := json.Marshal(security.Result{Status: "OK"})
+	fmt.Println(string(response))
 	os.Exit(0)
 }
 
@@ -138,6 +140,7 @@ func SecurityKeyValidate(c *cli.Context) {
 		fmt.Println(err.Error())
 		os.Exit(0)
 	}
-	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	response, _ := json.Marshal(security.Result{Status: "OK"})
+	fmt.Println(string(response))
 	os.Exit(0)
 }

--- a/actions/security.go
+++ b/actions/security.go
@@ -119,3 +119,25 @@ func SecurityUserSetPassword(c *cli.Context) {
 	utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	os.Exit(0)
 }
+
+// SecurityKeyUpdate : Creates or updates a key in the platforms keyring
+func SecurityKeyUpdate(c *cli.Context) {
+	err := security.SecKeyUpdate(c)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(0)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}
+
+// SecurityKeyValidate : Checks the key is available in the platform keyring
+func SecurityKeyValidate(c *cli.Context) {
+	_, err := security.SecKeyGetSecret(c)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(0)
+	}
+	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}

--- a/integration.bats
+++ b/integration.bats
@@ -111,3 +111,48 @@
    [ "$output" = '{"id":"local","label":"Codewind local deployment","url":"","auth":"","realm":"","clientid":""}' ]
    [ "$status" -eq 0 ]
 }
+
+#########################
+# Keyring command tests #
+#########################
+
+@test "invoke seckeyring update command - create a key" {
+  run go run main.go seckeyring update --depid local --username testuser --password secretphrase
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"status":"OK"}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke seckeyring update command - update a key" {
+  run go run main.go seckeyring update --depid local --username testuser --password new_secretphrase
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"status":"OK"}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke seckeyring validate command - validate a key" {
+  run go run main.go seckeyring validate --depid local --username testuser
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"status":"OK"}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke seckeyring validate command - key not found (incorrect deployment)" {
+  run go run main.go seckeyring validate --depid remoteNotKnown --username testuser
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke seckeyring validate command - key not found (incorrect username)"  {
+  run go run main.go seckeyring validate --depid local --username testuser_unknown
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
+  [ "$status" -eq 0 ]
+}
+

--- a/utils/security/keychain.go
+++ b/utils/security/keychain.go
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package security
+
+import (
+	"strings"
+
+	"github.com/urfave/cli"
+	"github.com/zalando/go-keyring"
+)
+
+// KeyringSecret : Secret
+type KeyringSecret struct {
+	ID       string `json:"id"`
+	ClientID string `json:"clientId"`
+}
+
+// SecKeyUpdate : Creates or updates a key in the platforms keyring
+func SecKeyUpdate(c *cli.Context) *SecError {
+	depid := strings.TrimSpace(strings.ToLower(c.String("depid")))
+	username := strings.TrimSpace(c.String("username"))
+	password := strings.TrimSpace(c.String("password"))
+	err := keyring.Set(KeyringServiceName+"."+depid, username, password)
+	if err != nil {
+		return &SecError{errOpKeyring, err, err.Error()}
+	}
+	return nil
+}
+
+// SecKeyGetSecret : retrieve secret / credentials from the keyring
+func SecKeyGetSecret(c *cli.Context) (string, *SecError) {
+	depid := strings.TrimSpace(c.String("depid"))
+	username := strings.TrimSpace(c.String("username"))
+	secret, err := keyring.Get(KeyringServiceName+"."+depid, username)
+	if err != nil {
+		return "", &SecError{errOpKeyring, err, err.Error()}
+	}
+	return secret, nil
+}

--- a/utils/security/security_utils.go
+++ b/utils/security/security_utils.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package security
 
 import (
@@ -16,6 +27,9 @@ const CodewindCliID string = "codewind-cli"
 // CodewindClientID : master realm name
 const CodewindClientID string = "codewind-backend"
 
+// KeyringServiceName : name
+const KeyringServiceName string = "org.eclipse.codewind"
+
 // SecError : Security package errors
 type SecError struct {
 	Op   string
@@ -31,6 +45,7 @@ const (
 	errOpCreate         = "sec_create"          // Create failed
 	errOpPassword       = "sec_passwordcontent" // Password formatting
 	errOpHostname       = "sec_badhostname"     // Bad hostname / url
+	errOpKeyring        = "sec_keyring"         // Keyring operations
 )
 
 const (


### PR DESCRIPTION
## Problem:

Provide a way to store credentials needed to drive the CLI when communicating with auth server to obtain an access_token. 

## Solution:  

1. adds a new `seckeyring --update` command  to add or update codewind credentials in a keyring 
2. adds a new `seckeyring --validate` command  to check if the credentials exist in a keyring

**Note:** The CLI does not print out the password.

## Example output

### Adding : 
> cwctl seckeyring update  --depid openshift --username admin --password somepassword
```{"status": "OK"}```

### Validate not exist (incorrect username) : 
> cwctl seckeyring validate --depid openshift --username admin12345        
```{"error":"sec_keyring","error_description":"secret not found in keyring"}```

### Validate exist : 
> seckeyring validate --depid openshift --username admin   
```{"status": "OK"}```

### Added bats tests : 
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect deployment)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

5 tests, 0 failures

Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>