### PR TITLE
Deployments schema update

### DIFF
--- a/actions/deployment_test.go
+++ b/actions/deployment_test.go
@@ -32,7 +32,10 @@ func Test_GetDeploymentsConfig(t *testing.T) {
 func Test_GetActiveDeployment(t *testing.T) {
 	t.Run("Asserts the initial deployment is local", func(t *testing.T) {
 		ResetDeploymentsFile()
-		result := FindTargetDeployment()
+		result, err := FindTargetDeployment()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, "local", result.ID)
 		assert.Equal(t, "Codewind local deployment", result.Label)
 		assert.Equal(t, "", result.URL)
@@ -65,7 +68,10 @@ func Test_SwitchTarget(t *testing.T) {
 	c := cli.NewContext(nil, set, nil)
 	t.Run("Assert target switches to remoteserver", func(t *testing.T) {
 		SetTargetDeployment(c)
-		result := FindTargetDeployment()
+		result, err := FindTargetDeployment()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, "remoteserver", result.ID)
 		assert.Equal(t, "MyRemoteServer", result.Label)
 		assert.Equal(t, "https://codewind.server.remote", result.URL)
@@ -87,7 +93,10 @@ func Test_RemoveDeploymentFromList(t *testing.T) {
 	})
 
 	t.Run("Check current target is 'remoteserver'", func(t *testing.T) {
-		result := FindTargetDeployment()
+		result, err := FindTargetDeployment()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, "remoteserver", result.ID)
 	})
 
@@ -98,7 +107,10 @@ func Test_RemoveDeploymentFromList(t *testing.T) {
 	})
 
 	t.Run("Check target reverts back to local", func(t *testing.T) {
-		result := FindTargetDeployment()
+		result, err := FindTargetDeployment()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, "local", result.ID)
 	})
 }

--- a/actions/status.go
+++ b/actions/status.go
@@ -25,7 +25,10 @@ import (
 
 // StatusCommand : to show the status
 func StatusCommand(c *cli.Context) {
-	targetDeployment := FindTargetDeployment()
+	targetDeployment, err := FindTargetDeployment()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 	if strings.EqualFold(targetDeployment.ID, "local") {
 		StatusCommandLocalDeployment(c)
 	} else {

--- a/errors/error.go
+++ b/errors/error.go
@@ -12,6 +12,7 @@
 package errors
 
 import (
+	"errors"
 	"log"
 )
 
@@ -72,4 +73,8 @@ func CheckErr(err error, code int, optMsg string) {
 			log.Fatal("UNKNOWN_ERROR", "[", code, "]: ", err, ". ", optMsg)
 		}
 	}
+}
+
+func newError(text string) error {
+	return errors.New(text)
 }

--- a/utils/deployments/deployment_utils.go
+++ b/utils/deployments/deployment_utils.go
@@ -1,0 +1,46 @@
+package deployments
+
+import "encoding/json"
+
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+// DepError : Deployment package errors
+type DepError struct {
+	Op   string
+	Err  error
+	Desc string
+}
+
+const (
+	// ErrOpSchema : Schema type errors
+	ErrOpSchema = "sec_schema"
+
+	// ErrOpTarget : Deployment target errors
+	ErrOpTarget = "sec_target"
+)
+
+const (
+	// TextTargetNotFound : missing target deployment text
+	TextTargetNotFound = "Target deployment not found"
+)
+
+// DepError : Error formatted in JSON containing an errorOp and a description from
+// either a fault condition in the CLI, or an error payload from a REST request
+func (se *DepError) Error() string {
+	type Output struct {
+		Operation   string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	tempOutput := &Output{Operation: se.Op, Description: se.Err.Error()}
+	jsonError, _ := json.Marshal(tempOutput)
+	return string(jsonError)
+}

--- a/utils/deployments/schema.go
+++ b/utils/deployments/schema.go
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+// File schema versions of the Deployments configuration file
+
+package deployments
+
+// DeploymentConfigV0 : DeploymentsConfig Schema Version 0
+type DeploymentConfigV0 struct {
+	Active      string         `json:"active"`
+	Deployments []DeploymentV0 `json:"deployments"`
+}
+
+// DeploymentConfigV1 : Deployments Schema Version 1
+type DeploymentConfigV1 struct {
+	SchemaVersion int            `json:"schemaversion"`
+	Active        string         `json:"active"`
+	Deployments   []DeploymentV1 `json:"deployments"`
+}
+
+// DeploymentV0 : Deployments Schema Version 0
+type DeploymentV0 struct {
+	Name     string `json:"name"`
+	Label    string `json:"label"`
+	URL      string `json:"url"`
+	AuthURL  string `json:"auth"`
+	Realm    string `json:"realm"`
+	ClientID string `json:"client_id"`
+}
+
+// DeploymentV1 : Deployments Schema Version 1
+type DeploymentV1 struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	URL      string `json:"url"`
+	AuthURL  string `json:"auth"`
+	Realm    string `json:"realm"`
+	ClientID string `json:"client_id"`
+}


### PR DESCRIPTION
## Problem

Fix crash in CLI after schema changes in the deployments.json file

## Solution

* adds a schema version field to the deployments json file
* upgrades any deployments to the latest schema
* includes tests

## Example of new schema : 

```
{
        "schemaversion": 1,
        "active": "local",
        "deployments": [
                {
                        "id": "local",
                        "label": "Codewind local deployment",
                        "url": "",
                        "auth": "",
                        "realm": "",
                        "clientid": ""
                }
        ]
}
```

## Test results (run manually) 

```
=== RUN   Test_GetDeploymentsConfig
=== RUN   Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment
--- PASS: Test_GetDeploymentsConfig (0.00s)
    --- PASS: Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment (0.00s)
=== RUN   Test_GetActiveDeployment
=== RUN   Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local
--- PASS: Test_GetActiveDeployment (0.00s)
    --- PASS: Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local (0.00s)
=== RUN   Test_CreateNewDeployment
=== RUN   Test_CreateNewDeployment/Adds_new_deployment_to_the_config
--- PASS: Test_CreateNewDeployment (0.00s)
    --- PASS: Test_CreateNewDeployment/Adds_new_deployment_to_the_config (0.00s)
=== RUN   Test_SwitchTarget
=== RUN   Test_SwitchTarget/Assert_target_switches_to_remoteserver
--- PASS: Test_SwitchTarget (0.00s)
    --- PASS: Test_SwitchTarget/Assert_target_switches_to_remoteserver (0.00s)
=== RUN   Test_RemoveDeploymentFromList
=== RUN   Test_RemoveDeploymentFromList/Check_we_have_2_deployments
=== RUN   Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver'
=== RUN   Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment
=== RUN   Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local
--- PASS: Test_RemoveDeploymentFromList (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_we_have_2_deployments (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver' (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/actions   0.018s
```


Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>