### PR TITLE
Copy target after dep schema update

### DIFF
--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -282,13 +282,14 @@ func applySchemaUpdates() error {
 
 			// create new config structure
 			newDeploymentConfig := deployments.DeploymentConfigV1{}
-			newDeploymentConfig.Active = deploymentConfig.Active
-			newDeploymentConfig.SchemaVersion = 1
 
 			err = json.Unmarshal([]byte(file), &deploymentConfig)
 			if err != nil {
 				return err
 			}
+
+			newDeploymentConfig.Active = deploymentConfig.Active
+			newDeploymentConfig.SchemaVersion = 1
 
 			// copy deployments from old to new config
 			originalDeploymentsV0 := deploymentConfig.Deployments


### PR DESCRIPTION
# Problem 

Deployment target name resets after schema update

# Solution

This PR copies over the original target after loading the original file.

# Tests
```
=== RUN   Test_GetDeploymentsConfig
=== RUN   Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment
--- PASS: Test_GetDeploymentsConfig (0.00s)
    --- PASS: Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment (0.00s)
=== RUN   Test_GetActiveDeployment
=== RUN   Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local
--- PASS: Test_GetActiveDeployment (0.00s)
    --- PASS: Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local (0.00s)
=== RUN   Test_CreateNewDeployment
=== RUN   Test_CreateNewDeployment/Adds_new_deployment_to_the_config
--- PASS: Test_CreateNewDeployment (0.00s)
    --- PASS: Test_CreateNewDeployment/Adds_new_deployment_to_the_config (0.00s)
=== RUN   Test_SwitchTarget
=== RUN   Test_SwitchTarget/Assert_target_switches_to_remoteserver
--- PASS: Test_SwitchTarget (0.00s)
    --- PASS: Test_SwitchTarget/Assert_target_switches_to_remoteserver (0.00s)
=== RUN   Test_RemoveDeploymentFromList
=== RUN   Test_RemoveDeploymentFromList/Check_we_have_2_deployments
=== RUN   Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver'
=== RUN   Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment
=== RUN   Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local
--- PASS: Test_RemoveDeploymentFromList (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_we_have_2_deployments (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver' (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/actions   0.017s

```

Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>