### PR TITLE
Refactor deployments command

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -428,7 +428,7 @@ func Commands() {
 						cli.StringFlag{Name: "clientid", Usage: "Security client_id to connect as eg: codewind_ctl or che-public", Required: false},
 					},
 					Action: func(c *cli.Context) error {
-						AddDeploymentToList(c)
+						DeploymentAddToList(c)
 						return nil
 					},
 				},
@@ -442,7 +442,7 @@ func Commands() {
 					Action: func(c *cli.Context) error {
 						if c.NumFlags() != 1 {
 						} else {
-							RemoveDeploymentFromList(c)
+							DeploymentRemoveFromList(c)
 						}
 						return nil
 					},
@@ -456,9 +456,9 @@ func Commands() {
 					},
 					Action: func(c *cli.Context) error {
 						if c.NumFlags() == 0 {
-							ListTargetDeployment()
+							DeploymentGetTarget()
 						} else {
-							SetTargetDeployment(c)
+							DeploymentSetTarget(c)
 						}
 						return nil
 					},
@@ -468,7 +468,7 @@ func Commands() {
 					Aliases: []string{"ls"},
 					Usage:   "List known deployments",
 					Action: func(c *cli.Context) error {
-						ListDeployments()
+						DeploymentListAll()
 						return nil
 					},
 				},
@@ -476,7 +476,7 @@ func Commands() {
 					Name:  "reset",
 					Usage: "Resets the deployments list",
 					Action: func(c *cli.Context) error {
-						ResetDeploymentsFile()
+						DeploymentResetList()
 						return nil
 					},
 				},

--- a/actions/deployment.go
+++ b/actions/deployment.go
@@ -13,304 +13,81 @@ package actions
 
 import (
 	"encoding/json"
-	"errors"
-	"io/ioutil"
-	"log"
+	"fmt"
 	"os"
-	"path"
-	"runtime"
-	"strings"
 
-	codewindErrors "github.com/eclipse/codewind-installer/errors"
-	"github.com/eclipse/codewind-installer/utils"
 	"github.com/eclipse/codewind-installer/utils/deployments"
 	"github.com/urfave/cli"
 )
 
-// deploymentsSchemaVersion must be incremented when changing the Deployment Config or Deployment Entry
-const deploymentsSchemaVersion = 1
-
-// DeploymentConfig state and possible deployments
-type DeploymentConfig struct {
-	SchemaVersion int          `json:"schemaversion"`
-	Active        string       `json:"active"`
-	Deployments   []Deployment `json:"deployments"`
-}
-
-// Deployment entry
-type Deployment struct {
-	ID       string `json:"id"`
-	Label    string `json:"label"`
-	URL      string `json:"url"`
-	AuthURL  string `json:"auth"`
-	Realm    string `json:"realm"`
-	ClientID string `json:"clientid"`
-}
-
-// InitDeploymentConfigIfRequired : Check the config file exist, if it does not then create a new default configuration
-func InitDeploymentConfigIfRequired() {
-	_, err := os.Stat(getDeploymentConfigFilename())
-	if os.IsNotExist(err) {
-		os.MkdirAll(getDeploymentConfigPath(), 0777)
-		ResetDeploymentsFile()
-	} else {
-		err = applySchemaUpdates()
-	}
-}
-
-// ResetDeploymentsFile : Creates a new / overwrites deployment config file with a default single local Codewind deployment
-func ResetDeploymentsFile() {
-	// create the default local deployment
-	initialConfig := DeploymentConfig{
-		Active:        "local",
-		SchemaVersion: deploymentsSchemaVersion,
-		Deployments: []Deployment{
-			Deployment{
-				ID:       "local",
-				Label:    "Codewind local deployment",
-				URL:      "",
-				AuthURL:  "",
-				Realm:    "",
-				ClientID: "",
-			},
-		},
-	}
-	body, err := json.MarshalIndent(initialConfig, "", "\t")
-	codewindErrors.CheckErr(err, 208, "Unable to format deployments file")
-	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
-	codewindErrors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
-}
-
-// FindTargetDeployment : Returns the single active deployment
-func FindTargetDeployment() (*Deployment, error) {
-	data, errCode, err := loadDeploymentsConfigFile()
-	codewindErrors.CheckErr(err, errCode, "Unable to process the deployments config file")
-	activeID := data.Active
-	for i := 0; i < len(data.Deployments); i++ {
-		if strings.EqualFold(activeID, data.Deployments[i].ID) {
-			targetDeployment := data.Deployments[i]
-			targetDeployment.URL = strings.TrimSuffix(targetDeployment.URL, "/")
-			targetDeployment.AuthURL = strings.TrimSuffix(targetDeployment.AuthURL, "/")
-			return &targetDeployment, nil
-		}
-	}
-	depError := errors.New(deployments.TextTargetNotFound)
-	return nil, &deployments.DepError{deployments.ErrOpSchema, depError, depError.Error()}
-}
-
-// GetDeploymentsConfig : Retrieves and returns the entire Deployment configuration contents
-func GetDeploymentsConfig() *DeploymentConfig {
-	data, errCode, err := loadDeploymentsConfigFile()
-	codewindErrors.CheckErr(err, errCode, "Unable to process the deployments config file")
-	return data
-}
-
-// SetTargetDeployment : If the deployment is unknown the command will return an error message
-func SetTargetDeployment(c *cli.Context) {
-	newTargetName := c.String("id")
-	data, errCode, err := loadDeploymentsConfigFile()
-	codewindErrors.CheckErr(err, errCode, "Unable to process the deployments config file")
-	foundID := ""
-
-	for i := 0; i < len(data.Deployments); i++ {
-		if strings.EqualFold(newTargetName, data.Deployments[i].ID) {
-			foundID = data.Deployments[i].ID
-			break
-		}
-	}
-	if foundID == "" {
-		log.Fatal("Unable to change deployment. '" + newTargetName + "' has no matching configuration")
-	}
-
-	data.Active = foundID
-	body, err := json.MarshalIndent(data, "", "\t")
-	codewindErrors.CheckErr(err, 208, "Unable to format deployments file")
-	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
-	codewindErrors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
-}
-
-// AddDeploymentToList : adds a new deployment to the deployment config
-func AddDeploymentToList(c *cli.Context) {
-	id := strings.TrimSpace(strings.ToLower(c.String("id")))
-	label := strings.TrimSpace(c.String("label"))
-	url := c.String("url")
-	if url != "" && len(strings.TrimSpace(url)) > 0 {
-		url = strings.TrimSuffix(url, "/")
-	}
-	auth := c.String("auth")
-	if auth != "" && len(strings.TrimSpace(auth)) > 0 {
-		auth = strings.TrimSuffix(auth, "/")
-	}
-
-	realm := strings.TrimSpace(c.String("realm"))
-	clientID := strings.TrimSpace(c.String("clientid"))
-
-	data, errCode, err := loadDeploymentsConfigFile()
-	codewindErrors.CheckErr(err, errCode, "Unable to process the deployments config file")
-
-	// check the name is not already in use
-	for i := 0; i < len(data.Deployments); i++ {
-		if strings.EqualFold(id, data.Deployments[i].ID) {
-			log.Fatal("Deployment '" + id + "' already exists, to update:  first remove, then add")
-		}
-	}
-
-	// create the new deployment
-	newDeployment := Deployment{
-		ID:       id,
-		Label:    label,
-		URL:      url,
-		AuthURL:  auth,
-		Realm:    realm,
-		ClientID: clientID,
-	}
-
-	// append it to the list
-	data.Deployments = append(data.Deployments, newDeployment)
-	body, err := json.MarshalIndent(data, "", "\t")
-	codewindErrors.CheckErr(err, 208, "Unable to format deployments file")
-	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
-	codewindErrors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
-}
-
-// RemoveDeploymentFromList : Removes the stored entry
-func RemoveDeploymentFromList(c *cli.Context) {
-	id := c.String("id")
-	if strings.EqualFold(id, "local") {
-		log.Fatal("Local is a required deployment and can not be removed")
-	}
-	data, errCode, err := loadDeploymentsConfigFile()
-	codewindErrors.CheckErr(err, errCode, "Unable to process the deployments config file")
-	for i := 0; i < len(data.Deployments); i++ {
-		if strings.EqualFold(id, data.Deployments[i].ID) {
-			copy(data.Deployments[i:], data.Deployments[i+1:])
-			data.Deployments = data.Deployments[:len(data.Deployments)-1]
-		}
-	}
-	data.Active = "local"
-	body, err := json.MarshalIndent(data, "", "\t")
-	codewindErrors.CheckErr(err, 208, "Unable to format deployments file")
-	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
-	codewindErrors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
-}
-
-// ListTargetDeployment : Display the deployment details for the current target deployment
-func ListTargetDeployment() {
-	targetDeployment, _ := FindTargetDeployment()
-	if targetDeployment != nil {
-		utils.PrettyPrintJSON(targetDeployment)
-	} else {
-		log.Fatal("Unable to find a matching target - set one now using the target command")
-	}
-}
-
-// ListDeployments : Output all saved deployments
-func ListDeployments() {
-	deploymentConfig := GetDeploymentsConfig()
-	if deploymentConfig != nil && deploymentConfig.Deployments != nil && len(deploymentConfig.Deployments) > 0 {
-		utils.PrettyPrintJSON(deploymentConfig)
-	} else {
-		log.Fatal("Unable to any deployments - please run the reset command")
-	}
-}
-
-// loadDeploymentsConfigFile : Load the deployments configuration file from disk
-// and returns the contents of the file or an error
-func loadDeploymentsConfigFile() (*DeploymentConfig, int, error) {
-	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+// DeploymentAddToList : Add new deployment to the deployments config file
+func DeploymentAddToList(c *cli.Context) {
+	err := deployments.AddDeploymentToList(c)
 	if err != nil {
-		return nil, 207, err
+		fmt.Println(err.Error())
+		os.Exit(0)
 	}
-	data := DeploymentConfig{}
-	err = json.Unmarshal([]byte(file), &data)
+	response, _ := json.Marshal(deployments.Result{Status: "OK", StatusMessage: "Deployment added"})
+	fmt.Println(string(response))
+	os.Exit(0)
+}
+
+// DeploymentRemoveFromList : Removes a deployment from the deployments config file
+func DeploymentRemoveFromList(c *cli.Context) {
+	err := deployments.RemoveDeploymentFromList(c)
 	if err != nil {
-		return nil, 208, err
+		fmt.Println(err.Error())
+		os.Exit(0)
 	}
-	return &data, 0, nil
+	response, _ := json.Marshal(deployments.Result{Status: "OK", StatusMessage: "Deployment removed"})
+	fmt.Println(string(response))
+	os.Exit(0)
 }
 
-// saveDeploymentsConfigFile : Save the deployments configuration file to disk
-// returns an error, and error code
-func saveDeploymentsConfigFile(deploymentConfig *DeploymentConfig) (int, error) {
-	body, err := json.MarshalIndent(deploymentConfig, "", "\t")
-	codewindErrors.CheckErr(err, 208, "Unable to format deployments file")
-	saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
-	codewindErrors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
-	return 0, nil
-}
-
-func getDeploymentConfigPath() string {
-	const GOOS string = runtime.GOOS
-	homeDir := ""
-	if GOOS == "windows" {
-		homeDir = os.Getenv("USERPROFILE")
-	} else {
-		homeDir = os.Getenv("HOME")
-	}
-	return path.Join(homeDir, ".codewind", "config")
-}
-
-func getDeploymentConfigFilename() string {
-	return path.Join(getDeploymentConfigPath(), "deployments.json")
-}
-
-func loadRawDeploymentsFile() ([]byte, int, error) {
-	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+// DeploymentGetTarget : Fetch the target deployment
+func DeploymentGetTarget() {
+	targetDeployment, err := deployments.GetTargetDeployment()
 	if err != nil {
-		return nil, 207, err
+		fmt.Println(err.Error())
+		os.Exit(0)
 	}
-	return file, 0, nil
+	response, _ := json.Marshal(targetDeployment)
+	fmt.Println(string(response))
+	os.Exit(0)
 }
 
-// update any existing entries to use the new schema design
-func applySchemaUpdates() error {
-
-	loadedFile, errCode, err := loadDeploymentsConfigFile()
-	codewindErrors.CheckErr(err, errCode, "Unable to load the deployments config file")
-	savedSchemaVersion := loadedFile.SchemaVersion
-
-	// upgrade the schema if needed
-	if savedSchemaVersion < deploymentsSchemaVersion {
-		file, errCode, err := loadRawDeploymentsFile()
-		codewindErrors.CheckErr(err, errCode, "Unable to read the deployments config file")
-
-		// apply schama updates from version 0 to version 1
-		if savedSchemaVersion == 0 {
-
-			// current config file
-			deploymentConfig := deployments.DeploymentConfigV0{}
-
-			// create new config structure
-			newDeploymentConfig := deployments.DeploymentConfigV1{}
-
-			err = json.Unmarshal([]byte(file), &deploymentConfig)
-			if err != nil {
-				return err
-			}
-
-			newDeploymentConfig.Active = deploymentConfig.Active
-			newDeploymentConfig.SchemaVersion = 1
-
-			// copy deployments from old to new config
-			originalDeploymentsV0 := deploymentConfig.Deployments
-			for i := 0; i < len(originalDeploymentsV0); i++ {
-				originalDeployment := originalDeploymentsV0[i]
-				deploymentJSON, _ := json.Marshal(originalDeployment)
-				var upgradedDeployment deployments.DeploymentV1
-				json.Unmarshal(deploymentJSON, &upgradedDeployment)
-
-				// rename 'name' field to 'id'
-				upgradedDeployment.ID = originalDeployment.Name
-				newDeploymentConfig.Deployments = append(newDeploymentConfig.Deployments, upgradedDeployment)
-			}
-
-			// schema has been updated
-			body, err := json.MarshalIndent(newDeploymentConfig, "", "\t")
-			codewindErrors.CheckErr(err, 208, "Unable to format deployments file")
-			saveErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
-			codewindErrors.CheckErr(saveErr, 203, "Unable to save the deployments config file")
-		}
-
+// DeploymentSetTarget : Set a new deployment by ID
+func DeploymentSetTarget(c *cli.Context) {
+	err := deployments.SetTargetDeployment(c)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(0)
 	}
-	return nil
+	response, _ := json.Marshal(deployments.Result{Status: "OK", StatusMessage: "New target set"})
+	fmt.Println(string(response))
+	os.Exit(0)
+}
+
+// DeploymentListAll : Fetch all deployments
+func DeploymentListAll() {
+	allDeployments, err := deployments.GetAllDeployments()
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(0)
+	}
+	response, _ := json.Marshal(allDeployments)
+	fmt.Println(string(response))
+	os.Exit(0)
+}
+
+// DeploymentResetList : Reset to a single default local deployment
+func DeploymentResetList() {
+	err := deployments.ResetDeploymentsFile()
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(0)
+	}
+	response, _ := json.Marshal(deployments.Result{Status: "OK", StatusMessage: "Deployment list reset"})
+	fmt.Println(string(response))
+	os.Exit(0)
 }

--- a/actions/status.go
+++ b/actions/status.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/eclipse/codewind-installer/apiroutes"
 	"github.com/eclipse/codewind-installer/utils"
+	"github.com/eclipse/codewind-installer/utils/deployments"
 	"github.com/urfave/cli"
 )
 
 // StatusCommand : to show the status
 func StatusCommand(c *cli.Context) {
-	targetDeployment, err := FindTargetDeployment()
+	targetDeployment, err := deployments.GetTargetDeployment()
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -37,7 +38,7 @@ func StatusCommand(c *cli.Context) {
 }
 
 // StatusCommandRemoteDeployment : Output remote deployment details
-func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
+func StatusCommandRemoteDeployment(c *cli.Context, d *deployments.Deployment) {
 	jsonOutput := c.Bool("json")
 	apiResponse, err := apiroutes.GetAPIEnvironment(c, d.URL)
 	if err != nil {
@@ -50,7 +51,10 @@ func StatusCommandRemoteDeployment(c *cli.Context, d *Deployment) {
 				Status:   "stopped",
 				Versions: []string{},
 			}
-			output, _ := json.Marshal(respStatus)
+			output, err := json.Marshal(respStatus)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 			fmt.Println(string(output))
 		} else {
 			fmt.Println("Codewind remote deployment did not respond on " + d.URL)

--- a/integration.bats
+++ b/integration.bats
@@ -35,3 +35,79 @@
   echo "output trace = ${output}"
   [ "$status" -eq 0 ]
 }
+
+############################
+# Deployment command tests #
+############################
+
+@test "invoke dep reset command - reset deployments file" {
+  run go run main.go dep reset
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"status":"OK","status_message":"Deployment list reset"}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep list command - contains just 1 local deployment" {
+  run go run main.go dep list
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"schemaversion":1,"active":"local","deployments":[{"id":"local","label":"Codewind local deployment","url":"","auth":"","realm":"","clientid":""}]}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep add command - add new deployment to the list" {
+  run go run main.go dep add -id kube --label "kube-cluster" --url http://mykube:12345 --auth http://myauth:12345 --realm codewind-cloud --clientid codewind
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"status":"OK","status_message":"Deployment added"}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep list command - ensure both deployments exist " {
+  run go run main.go dep list
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"schemaversion":1,"active":"local","deployments":[{"id":"local","label":"Codewind local deployment","url":"","auth":"","realm":"","clientid":""},{"id":"kube","label":"kube-cluster","url":"http://mykube:12345","auth":"http://myauth:12345","realm":"codewind-cloud","clientid":"codewind"}]}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep target command - set a target to something unknown" {
+  run go run main.go dep target -id noname
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"error":"dep_not_found","error_description":"Target deployment not found"}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep target command - set the target to kube" {
+  run go run main.go dep target --id kube
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"status":"OK","status_message":"New target set"}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep target command - check the target is now kube" {
+  run go run main.go dep target
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"id":"kube","label":"kube-cluster","url":"http://mykube:12345","auth":"http://myauth:12345","realm":"codewind-cloud","clientid":"codewind"}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep remove command - delete target kube" {
+  run go run main.go dep remove --id kube
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"status":"OK","status_message":"Deployment removed"}' ]
+   [ "$status" -eq 0 ]
+}
+
+@test "invoke dep target command - check target returns to local" {
+  run go run main.go dep target
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+   [ "$output" = '{"id":"local","label":"Codewind local deployment","url":"","auth":"","realm":"","clientid":""}' ]
+   [ "$status" -eq 0 ]
+}

--- a/main.go
+++ b/main.go
@@ -11,9 +11,12 @@
 
 package main
 
-import "github.com/eclipse/codewind-installer/actions"
+import (
+	"github.com/eclipse/codewind-installer/actions"
+	"github.com/eclipse/codewind-installer/utils/deployments"
+)
 
 func main() {
-	actions.InitDeploymentConfigIfRequired()
+	deployments.InitConfigFileIfRequired()
 	actions.Commands()
 }

--- a/utils/deployments/deployment.go
+++ b/utils/deployments/deployment.go
@@ -1,0 +1,356 @@
+package deployments
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+// deploymentsSchemaVersion must be incremented when changing the Deployment Config or Deployment Entry
+const deploymentsSchemaVersion = 1
+
+// DeploymentConfig state and possible deployments
+type DeploymentConfig struct {
+	SchemaVersion int          `json:"schemaversion"`
+	Active        string       `json:"active"`
+	Deployments   []Deployment `json:"deployments"`
+}
+
+// Deployment entry
+type Deployment struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	URL      string `json:"url"`
+	AuthURL  string `json:"auth"`
+	Realm    string `json:"realm"`
+	ClientID string `json:"clientid"`
+}
+
+// InitConfigFileIfRequired : Check the config file exist, if it does not then create a new default configuration
+func InitConfigFileIfRequired() *DepError {
+	_, err := os.Stat(getDeploymentConfigFilename())
+	if os.IsNotExist(err) {
+		os.MkdirAll(getDeploymentConfigDir(), 0777)
+		return ResetDeploymentsFile()
+	}
+	return applySchemaUpdates()
+}
+
+// ResetDeploymentsFile : Creates a new / overwrites deployment config file with a default single local Codewind deployment
+func ResetDeploymentsFile() *DepError {
+	// create the default local deployment
+	initialConfig := DeploymentConfig{
+		Active:        "local",
+		SchemaVersion: deploymentsSchemaVersion,
+		Deployments: []Deployment{
+			Deployment{
+				ID:       "local",
+				Label:    "Codewind local deployment",
+				URL:      "",
+				AuthURL:  "",
+				Realm:    "",
+				ClientID: "",
+			},
+		},
+	}
+	body, err := json.MarshalIndent(initialConfig, "", "\t")
+	if err != nil {
+		return &DepError{errOpFileParse, err, err.Error()}
+	}
+
+	err = ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	if err != nil {
+		return &DepError{errOpFileWrite, err, err.Error()}
+	}
+	return nil
+}
+
+// FindTargetDeployment : Returns the single active deployment
+func FindTargetDeployment() (*Deployment, *DepError) {
+	data, depError := loadDeploymentsConfigFile()
+	if depError != nil {
+		return nil, depError
+	}
+
+	activeID := data.Active
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(activeID, data.Deployments[i].ID) {
+			targetDeployment := data.Deployments[i]
+			targetDeployment.URL = strings.TrimSuffix(targetDeployment.URL, "/")
+			targetDeployment.AuthURL = strings.TrimSuffix(targetDeployment.AuthURL, "/")
+			return &targetDeployment, nil
+		}
+	}
+
+	err := errors.New(errTargetNotFound)
+	return nil, &DepError{errOpNotFound, err, err.Error()}
+}
+
+// GetDeploymentsConfig : Retrieves and returns the entire Deployment configuration contents
+func GetDeploymentsConfig() (*DeploymentConfig, *DepError) {
+	data, depErr := loadDeploymentsConfigFile()
+	if depErr != nil {
+		return nil, depErr
+	}
+	return data, nil
+}
+
+// SetTargetDeployment : If the deployment is unknown return an error
+func SetTargetDeployment(c *cli.Context) *DepError {
+	newTargetName := c.String("id")
+	data, depErr := loadDeploymentsConfigFile()
+	if depErr != nil {
+		return depErr
+	}
+	foundID := ""
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(newTargetName, data.Deployments[i].ID) {
+			foundID = data.Deployments[i].ID
+			break
+		}
+	}
+	if foundID == "" {
+		err := errors.New(errTargetNotFound)
+		return &DepError{errOpNotFound, err, err.Error()}
+	}
+	data.Active = foundID
+	body, err := json.MarshalIndent(data, "", "\t")
+	if err != nil {
+		return &DepError{errOpFileParse, err, err.Error()}
+	}
+	err = ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	if err != nil {
+		return &DepError{errOpFileWrite, err, err.Error()}
+	}
+	return nil
+}
+
+// AddDeploymentToList : adds a new deployment to the deployment config
+func AddDeploymentToList(c *cli.Context) *DepError {
+	id := strings.TrimSpace(strings.ToLower(c.String("id")))
+	label := strings.TrimSpace(c.String("label"))
+	url := c.String("url")
+	if url != "" && len(strings.TrimSpace(url)) > 0 {
+		url = strings.TrimSuffix(url, "/")
+	}
+	auth := c.String("auth")
+	if auth != "" && len(strings.TrimSpace(auth)) > 0 {
+		auth = strings.TrimSuffix(auth, "/")
+	}
+
+	realm := strings.TrimSpace(c.String("realm"))
+	clientID := strings.TrimSpace(c.String("clientid"))
+
+	data, depErr := loadDeploymentsConfigFile()
+	if depErr != nil {
+		return depErr
+	}
+
+	// check the name is not already in use
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(id, data.Deployments[i].ID) {
+			depError := errors.New("Deployment '" + id + "' already exists, to update:  first remove, then add")
+			return &DepError{errOpConflict, depError, depError.Error()}
+		}
+	}
+
+	// create the new deployment
+	newDeployment := Deployment{
+		ID:       id,
+		Label:    label,
+		URL:      url,
+		AuthURL:  auth,
+		Realm:    realm,
+		ClientID: clientID,
+	}
+
+	// append it to the list
+	data.Deployments = append(data.Deployments, newDeployment)
+	body, err := json.MarshalIndent(data, "", "\t")
+	if err != nil {
+		return &DepError{errOpFileParse, err, err.Error()}
+	}
+
+	err = ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	if err != nil {
+		return &DepError{errOpFileWrite, err, err.Error()}
+	}
+	return nil
+}
+
+// RemoveDeploymentFromList : Removes the stored entry
+func RemoveDeploymentFromList(c *cli.Context) *DepError {
+	id := c.String("id")
+	if strings.EqualFold(id, "local") {
+		depError := errors.New("Local is a required deployment and must not be removed")
+		return &DepError{errOpProtected, depError, depError.Error()}
+	}
+	data, depErr := loadDeploymentsConfigFile()
+	if depErr != nil {
+		return depErr
+	}
+
+	for i := 0; i < len(data.Deployments); i++ {
+		if strings.EqualFold(id, data.Deployments[i].ID) {
+			copy(data.Deployments[i:], data.Deployments[i+1:])
+			data.Deployments = data.Deployments[:len(data.Deployments)-1]
+		}
+	}
+	data.Active = "local"
+	body, err := json.MarshalIndent(data, "", "\t")
+	if err != nil {
+		return &DepError{errOpFileParse, err, err.Error()}
+	}
+
+	err = ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	if err != nil {
+		return &DepError{errOpFileWrite, err, err.Error()}
+	}
+	return nil
+}
+
+// GetTargetDeployment : Retrieve the deployment details for the current target deployment
+func GetTargetDeployment() (*Deployment, *DepError) {
+	targetDeployment, depErr := FindTargetDeployment()
+	if depErr != nil {
+		return nil, depErr
+	}
+	if targetDeployment != nil {
+		return targetDeployment, nil
+	}
+	depError := errors.New("Unable to find a matching target - set one now using the target command")
+	return nil, &DepError{errOpNotFound, depError, depError.Error()}
+}
+
+// GetAllDeployments : Retrieve all saved deployments
+func GetAllDeployments() (*DeploymentConfig, *DepError) {
+	deploymentConfig, depErr := GetDeploymentsConfig()
+	if depErr != nil {
+		return nil, depErr
+	}
+	if deploymentConfig != nil && deploymentConfig.Deployments != nil && len(deploymentConfig.Deployments) > 0 {
+		return deploymentConfig, nil
+	}
+	depError := errors.New("No Deployments found")
+	return nil, &DepError{errOpNotFound, depError, depError.Error()}
+}
+
+// loadDeploymentsConfigFile : Load the deployments configuration file from disk
+// and returns the contents of the file or an error
+func loadDeploymentsConfigFile() (*DeploymentConfig, *DepError) {
+	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+	if err != nil {
+		return nil, &DepError{errOpFileLoad, err, err.Error()}
+	}
+	data := DeploymentConfig{}
+	err = json.Unmarshal([]byte(file), &data)
+	if err != nil {
+		return nil, &DepError{errOpFileParse, err, err.Error()}
+	}
+	return &data, nil
+}
+
+// saveDeploymentsConfigFile : Save the deployments configuration file to disk
+// returns an error, and error code
+func saveDeploymentsConfigFile(deploymentConfig *DeploymentConfig) *DepError {
+	body, err := json.MarshalIndent(deploymentConfig, "", "\t")
+	if err != nil {
+		return &DepError{errOpFileParse, err, err.Error()}
+	}
+	depErr := ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+	if depErr != nil {
+		return &DepError{errOpFileWrite, depErr, depErr.Error()}
+	}
+	return nil
+}
+
+// getDeploymentConfigDir : get directory path to the deployments file
+func getDeploymentConfigDir() string {
+	const GOOS string = runtime.GOOS
+	homeDir := ""
+	if GOOS == "windows" {
+		homeDir = os.Getenv("USERPROFILE")
+	} else {
+		homeDir = os.Getenv("HOME")
+	}
+	return path.Join(homeDir, ".codewind", "config")
+}
+
+// getDeploymentConfigFilename  : get full file path of deployments file
+func getDeploymentConfigFilename() string {
+	return path.Join(getDeploymentConfigDir(), "deployments.json")
+}
+
+func loadRawDeploymentsFile() ([]byte, *DepError) {
+	file, err := ioutil.ReadFile(getDeploymentConfigFilename())
+	if err != nil {
+		return nil, &DepError{errOpFileLoad, err, err.Error()}
+	}
+	return file, nil
+}
+
+// applySchemaUpdates : update any existing entries to use the new schema design
+func applySchemaUpdates() *DepError {
+
+	loadedFile, depErr := loadDeploymentsConfigFile()
+	if depErr != nil {
+		return depErr
+	}
+	savedSchemaVersion := loadedFile.SchemaVersion
+
+	// upgrade the schema if needed
+	if savedSchemaVersion < deploymentsSchemaVersion {
+		file, depErr := loadRawDeploymentsFile()
+		if depErr != nil {
+			return depErr
+		}
+
+		// apply schama updates from version 0 to version 1
+		if savedSchemaVersion == 0 {
+
+			// current config file
+			deploymentConfig := DeploymentConfigV0{}
+
+			// create new config structure
+			newDeploymentConfig := DeploymentConfigV1{}
+
+			err := json.Unmarshal([]byte(file), &deploymentConfig)
+			if err != nil {
+				return &DepError{errOpFileParse, err, err.Error()}
+			}
+
+			newDeploymentConfig.Active = deploymentConfig.Active
+			newDeploymentConfig.SchemaVersion = 1
+
+			// copy deployments from old to new config
+			originalDeploymentsV0 := deploymentConfig.Deployments
+			for i := 0; i < len(originalDeploymentsV0); i++ {
+				originalDeployment := originalDeploymentsV0[i]
+				deploymentJSON, _ := json.Marshal(originalDeployment)
+				var upgradedDeployment DeploymentV1
+				json.Unmarshal(deploymentJSON, &upgradedDeployment)
+
+				// rename 'name' field to 'id'
+				upgradedDeployment.ID = originalDeployment.Name
+				newDeploymentConfig.Deployments = append(newDeploymentConfig.Deployments, upgradedDeployment)
+			}
+
+			// schema has been updated
+			body, err := json.MarshalIndent(newDeploymentConfig, "", "\t")
+			if err != nil {
+				return &DepError{errOpFileParse, err, err.Error()}
+			}
+			err = ioutil.WriteFile(getDeploymentConfigFilename(), body, 0644)
+			if err != nil {
+				return &DepError{errOpFileWrite, err, err.Error()}
+			}
+		}
+	}
+	return nil
+}

--- a/utils/deployments/deployment_test.go
+++ b/utils/deployments/deployment_test.go
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package actions
+package deployments
 
 import (
 	"flag"
@@ -20,10 +20,13 @@ import (
 )
 
 func Test_GetDeploymentsConfig(t *testing.T) {
-	InitDeploymentConfigIfRequired()
+	InitConfigFileIfRequired()
 	t.Run("Asserts there is only one deployment", func(t *testing.T) {
 		ResetDeploymentsFile()
-		result := GetDeploymentsConfig()
+		result, err := GetDeploymentsConfig()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Equal(t, "local", result.Active)
 		assert.Len(t, result.Deployments, 1)
 	})
@@ -50,13 +53,16 @@ func Test_CreateNewDeployment(t *testing.T) {
 	set.String("url", "https://codewind.server.remote", "Codewind URL")
 	set.String("auth", "https://auth.server.remote:8443", "Auth URL")
 	set.String("realm", "codewind", "Security realm")
-	set.String("clientid", "cwctl", "ID of client")
+	set.String("clientid", "cw-ctl", "ID of client")
 
 	c := cli.NewContext(nil, set, nil)
 	ResetDeploymentsFile()
 	t.Run("Adds new deployment to the config", func(t *testing.T) {
 		AddDeploymentToList(c)
-		result := GetDeploymentsConfig()
+		result, err := GetDeploymentsConfig()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Len(t, result.Deployments, 2)
 	})
 }
@@ -77,7 +83,7 @@ func Test_SwitchTarget(t *testing.T) {
 		assert.Equal(t, "https://codewind.server.remote", result.URL)
 		assert.Equal(t, "https://auth.server.remote:8443", result.AuthURL)
 		assert.Equal(t, "codewind", result.Realm)
-		assert.Equal(t, "cwctl", result.ClientID)
+		assert.Equal(t, "cw-ctl", result.ClientID)
 	})
 }
 
@@ -88,7 +94,10 @@ func Test_RemoveDeploymentFromList(t *testing.T) {
 	c := cli.NewContext(nil, set, nil)
 
 	t.Run("Check we have 2 deployments", func(t *testing.T) {
-		result := GetDeploymentsConfig()
+		result, err := GetDeploymentsConfig()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Len(t, result.Deployments, 2)
 	})
 
@@ -102,7 +111,10 @@ func Test_RemoveDeploymentFromList(t *testing.T) {
 
 	t.Run("Remove the remoteserver deployment", func(t *testing.T) {
 		RemoveDeploymentFromList(c)
-		result := GetDeploymentsConfig()
+		result, err := GetDeploymentsConfig()
+		if err != nil {
+			t.Fail()
+		}
 		assert.Len(t, result.Deployments, 1)
 	})
 

--- a/utils/deployments/deployment_test.go
+++ b/utils/deployments/deployment_test.go
@@ -13,14 +13,32 @@ package deployments
 
 import (
 	"flag"
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
 
+// Test_SchemaUpgrade01 :  Upgrade schema tests from Version 0 to Version 1
+func Test_SchemaUpgrade0to1(t *testing.T) {
+	// create a v1 file :
+	v1File := "{\"active\": \"testlocal\",\"deployments\": [{\"name\":\"testlocal\",\"label\": \"Codewind local test deployment\",\"url\": \"\"}]}"
+	ioutil.WriteFile(getDeploymentConfigFilename(), []byte(v1File), 0644)
+	t.Run("Asserts schema updated to v1 with a local target", func(t *testing.T) {
+		InitConfigFileIfRequired() // perform upgrade
+		result, err := GetDeploymentsConfig()
+		if err != nil {
+			t.Fail()
+		}
+		assert.Equal(t, 1, result.SchemaVersion)
+		assert.Equal(t, "testlocal", result.Active)
+		assert.Len(t, result.Deployments, 1)
+		assert.Equal(t, "testlocal", result.Deployments[0].ID)
+	})
+}
+
 func Test_GetDeploymentsConfig(t *testing.T) {
-	InitConfigFileIfRequired()
 	t.Run("Asserts there is only one deployment", func(t *testing.T) {
 		ResetDeploymentsFile()
 		result, err := GetDeploymentsConfig()

--- a/utils/deployments/deployment_utils.go
+++ b/utils/deployments/deployment_utils.go
@@ -1,6 +1,8 @@
 package deployments
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 /*******************************************************************************
  * Copyright (c) 2019 IBM Corporation and others.
@@ -21,16 +23,17 @@ type DepError struct {
 }
 
 const (
-	// ErrOpSchema : Schema type errors
-	ErrOpSchema = "sec_schema"
-
-	// ErrOpTarget : Deployment target errors
-	ErrOpTarget = "sec_target"
+	errOpFileParse    = "dep_parse"
+	errOpFileLoad     = "dep_load"
+	errOpFileWrite    = "dep_write"
+	errOpSchemaUpdate = "dep_schema_update"
+	errOpConflict     = "dep_conflict"
+	errOpNotFound     = "dep_not_found"
+	errOpProtected    = "dep_protected"
 )
 
 const (
-	// TextTargetNotFound : missing target deployment text
-	TextTargetNotFound = "Target deployment not found"
+	errTargetNotFound = "Target deployment not found"
 )
 
 // DepError : Error formatted in JSON containing an errorOp and a description from
@@ -43,4 +46,10 @@ func (se *DepError) Error() string {
 	tempOutput := &Output{Operation: se.Op, Description: se.Err.Error()}
 	jsonError, _ := json.Marshal(tempOutput)
 	return string(jsonError)
+}
+
+// Result : status message
+type Result struct {
+	Status        string `json:"status"`
+	StatusMessage string `json:"status_message"`
 }


### PR DESCRIPTION
## Problem:

Deployments command returns output messages in different formats using the original  CLI error handler.  This makes it difficult to locate root cause configuration problems and over-complicates the code. 

## Solution:

* This PR uses a Deployment error type
* all output is single line JSON making it easier for the IDEs to consume
* low level errors are passed upstream to callers
* Refactoring - moved majority of code out of "actions" and into utility functions in a "deployment" package. 
* Add additional unit and functional tests
* output error messages are in the form :  

```
{"error":"dep_protected","error_description":"Local is a required deployment and must not be removed"}
```

## Testing:

### Added new integration tests : 

 ✓ invoke dep reset command - reset deployments file
 ✓ invoke dep list command - contains just 1 local deployment
 ✓ invoke dep add command - add new deployment to the list
 ✓ invoke dep list command - ensure both deployments exist 
 ✓ invoke dep target command - set a target to something unknown
 ✓ invoke dep target command - set the target to kube
 ✓ invoke dep target command - check the target is now kube
 ✓ invoke dep target command - delete target kube
 ✓ invoke dep target command - check target returns to local

### Updated unit tests :

=== RUN   Test_SchemaUpgrade0to1
=== RUN   Test_SchemaUpgrade0to1/Asserts_schema_updated_to_v1_with_a_local_target
--- PASS: Test_SchemaUpgrade0to1 (0.00s)
    --- PASS: Test_SchemaUpgrade0to1/Asserts_schema_updated_to_v1_with_a_local_target (0.00s)
=== RUN   Test_GetDeploymentsConfig
=== RUN   Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment
--- PASS: Test_GetDeploymentsConfig (0.00s)
    --- PASS: Test_GetDeploymentsConfig/Asserts_there_is_only_one_deployment (0.00s)
=== RUN   Test_GetActiveDeployment
=== RUN   Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local
--- PASS: Test_GetActiveDeployment (0.00s)
    --- PASS: Test_GetActiveDeployment/Asserts_the_initial_deployment_is_local (0.00s)
=== RUN   Test_CreateNewDeployment
=== RUN   Test_CreateNewDeployment/Adds_new_deployment_to_the_config
--- PASS: Test_CreateNewDeployment (0.00s)
    --- PASS: Test_CreateNewDeployment/Adds_new_deployment_to_the_config (0.00s)
=== RUN   Test_SwitchTarget
=== RUN   Test_SwitchTarget/Assert_target_switches_to_remoteserver
--- PASS: Test_SwitchTarget (0.00s)
    --- PASS: Test_SwitchTarget/Assert_target_switches_to_remoteserver (0.00s)
=== RUN   Test_RemoveDeploymentFromList
=== RUN   Test_RemoveDeploymentFromList/Check_we_have_2_deployments
=== RUN   Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver'
=== RUN   Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment
=== RUN   Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local
--- PASS: Test_RemoveDeploymentFromList (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_we_have_2_deployments (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_current_target_is_'remoteserver' (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Remove_the_remoteserver_deployment (0.00s)
    --- PASS: Test_RemoveDeploymentFromList/Check_target_reverts_back_to_local (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/utils/deployments 0.085s





 