### PR TITLE
add quotes around json in stuct

### DIFF
--- a/apiroutes/templates.go
+++ b/apiroutes/templates.go
@@ -36,7 +36,7 @@ type (
 	TemplateRepo struct {
 		Description string `json:"description"`
 		URL         string `json:"url"`
-		Name        string `json:name`
+		Name        string `json:"name"`
 	}
 )
 


### PR DESCRIPTION
**Problem**
Bad syntax in a struct. Currently is `json:name`

**Solution**
Fix the syntax to be `json:"name"`

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>