### PR TITLE
Remove GPL package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,12 +24,12 @@
   version = "v0.4.13"
 
 [[projects]]
-  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
+  digest = "1:771809465d2d81b1e2631f0e062b7458647135b2eca9e1cc577e58d1db0d987f"
+  name = "github.com/containerd/containerd"
+  packages = ["errdefs"]
   pruneopts = "UT"
-  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
-  version = "v1.4.2"
+  revision = "36cf5b690dcc00ff0f34ff7799209050c3d0c59a"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:675c7e2e645d40363350159cfe1f719f61ce353a3859db939ca686d98aa85f16"
@@ -48,43 +48,47 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:4ddc17aeaa82cb18c5f0a25d7c253a10682f518f4b2558a82869506eec223d76"
+  digest = "1:5d7f88f9487f370e3ae52155465156370fc5798102d811d2d4448d2385ccaf67"
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
     "reference",
+    "registry/api/errcode",
   ]
   pruneopts = "UT"
   revision = "2461543d988979529609e8cb6fca9ca190dc48da"
   version = "v2.7.1"
 
 [[projects]]
-  digest = "1:096c02ecb59ad7cba169748105b8000620e1fc4648c106e4b8b1f032bedf9269"
+  digest = "1:8ec76bacd3a3f522fed4da9dd0570720a7afa13471974fb50515a1c89f589655"
   name = "github.com/docker/docker"
   packages = [
+    "api",
     "api/types",
     "api/types/blkiodev",
     "api/types/container",
     "api/types/events",
     "api/types/filters",
+    "api/types/image",
     "api/types/mount",
     "api/types/network",
-    "api/types/reference",
     "api/types/registry",
     "api/types/strslice",
     "api/types/swarm",
+    "api/types/swarm/runtime",
     "api/types/time",
     "api/types/versions",
     "api/types/volume",
-    "pkg/jsonlog",
+    "client",
+    "errdefs",
     "pkg/jsonmessage",
     "pkg/term",
     "pkg/term/windows",
-    "pkg/tlsconfig",
   ]
   pruneopts = "UT"
-  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
-  version = "v1.13.1"
+  revision = "3e077fc8667a24c854a7f693a685f2c1ed5b2c9c"
+  source = "https://github.com/docker/engine"
+  version = "v19.03.3"
 
 [[projects]]
   digest = "1:811c86996b1ca46729bad2724d4499014c4b9effd05ef8c71b852aad90deb0ce"
@@ -115,6 +119,28 @@
   version = "v5.0.2"
 
 [[projects]]
+  digest = "1:4882ca4e50712f367a52a467a277dcd8ef877b82acaa5973baea92fe7443f2eb"
+  name = "github.com/gogo/protobuf"
+  packages = ["proto"]
+  pruneopts = "UT"
+  revision = "0ca988a254f991240804bf9821f3450d87ccbb1b"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:f5ce1529abc1204444ec73779f44f94e2fa8fcdb7aca3c355b0c95947e4005c6"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = "UT"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
+
+[[projects]]
   digest = "1:525ebc5da920b1f2c76ae763c13f4decdc3c3bc541ff0fa18f2399d4e742177f"
   name = "github.com/google/go-github"
   packages = ["github"]
@@ -139,12 +165,12 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:4b17b21e0f462ee50ca92f81cadabf531f7c4a2d3590cc55b0a9d081059ca61e"
-  name = "github.com/moby/moby"
-  packages = ["client"]
+  digest = "1:906eb1ca3c8455e447b99a45237b2b9615b665608fd07ad12cce847dd9a1ec43"
+  name = "github.com/morikuni/aec"
+  packages = ["."]
   pruneopts = "UT"
-  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
-  version = "v1.13.1"
+  revision = "39771216ff4c63d11f5e604076f9c45e8be1067b"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
@@ -153,6 +179,17 @@
   pruneopts = "UT"
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
+
+[[projects]]
+  digest = "1:11db38d694c130c800d0aefb502fb02519e514dc53d9804ce51d1ad25ec27db6"
+  name = "github.com/opencontainers/image-spec"
+  packages = [
+    "specs-go",
+    "specs-go/v1",
+  ]
+  pruneopts = "UT"
+  revision = "d60099175f88c47cd379c4738d158884749ed235"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
@@ -169,6 +206,14 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
 
 [[projects]]
   digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
@@ -215,11 +260,9 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2954b3699dc7d134a2ad3710f170b912bd979c5513cc13d869a57a1d2e753d8b"
+  digest = "1:3e0062766e6b0bcfe1ba1ed1d3f08a8e1e99cd5831426e2596dc9537d28f2adb"
   name = "golang.org/x/net"
   packages = [
-    "context",
-    "context/ctxhttp",
     "internal/socks",
     "proxy",
   ]
@@ -238,6 +281,28 @@
   revision = "51ab0e2deafac1f46c46ad59cf0921be2f180c3d"
 
 [[projects]]
+  branch = "master"
+  digest = "1:583a0c80f5e3a9343d33aea4aead1e1afcc0043db66fdf961ddd1fe8cd3a4faf"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/rpc/status"]
+  pruneopts = "UT"
+  revision = "548a555dbc03994223efbaba0090152849259498"
+
+[[projects]]
+  digest = "1:dd9e017df31acd9cf78ad0df2c8a1132fb3f724ec9287240ee7306364130bafc"
+  name = "google.golang.org/grpc"
+  packages = [
+    "codes",
+    "connectivity",
+    "grpclog",
+    "internal",
+    "status",
+  ]
+  pruneopts = "UT"
+  revision = "f6d0f9ee430895e87ef1ceb5ac8f39725bafceef"
+  version = "v1.24.0"
+
+[[projects]]
   branch = "v3"
   digest = "1:46754188622566b86271d7526cb643b88c2b9589ee224c2d55e282f0f35a0df8"
   name = "gopkg.in/yaml.v3"
@@ -250,10 +315,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/docker/docker/api/types",
+    "github.com/docker/docker/client",
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/term",
     "github.com/google/go-github/github",
-    "github.com/moby/moby/client",
     "github.com/stretchr/testify/assert",
     "github.com/urfave/cli",
     "github.com/zalando/go-keyring",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,6 +22,10 @@
 #   go-tests = true
 #   unused-packages = true
 
+[[override]]
+  name = "github.com/docker/docker"
+  source = "https://github.com/docker/engine"
+  version = "19.03.3"
 
 [prune]
   go-tests = true

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -25,10 +25,10 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
 	"github.com/eclipse/codewind-installer/errors"
-	"github.com/moby/moby/client"
 )
 
 // codewind-docker-compose.yaml data

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/moby/moby/client"
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind-installer/issues/142**
GPL licenses found. An out of date release for `docker/docker` contained this and so did `moby/moby`.

**Solution**
- Use an `override` to specify the set version of `docker/docker`. This now pulls from a difrerent source, `docker/engine`. This version of the `docker/engine` repository should not contain the GPL licensing
- The above in turn removes the need for `moby/moby` dependancy and therefore has been removed and replaced with the updated `docker/docker`

**Testing**
BATS Output:
```
➜  codewind-installer git:(fix-GPL-lic) ✗ bats integration.bats    
 ✓ invoke install command - install latest with --json
 ✓ invoke status -j command - output = '{status:stopped,installed-versions:[latest]}'
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✓ invoke dep reset command - reset deployments file
 ✓ invoke dep list command - contains just 1 local deployment
 ✓ invoke dep add command - add new deployment to the list
 ✓ invoke dep list command - ensure both deployments exist 
 ✓ invoke dep target command - set a target to something unknown
 ✓ invoke dep target command - set the target to kube
 ✓ invoke dep target command - check the target is now kube
 ✓ invoke dep remove command - delete target kube
 ✓ invoke dep target command - check target returns to local
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect deployment)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

19 tests, 0 failures
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>