### PR TITLE
Allow mixed case passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Subcommands:</br>
 
 > **Flags:**
 > --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
+> --newrealm value               Application realm to be created
 > --accesstoken value            Admin access_token
 > --username value               Admin Username
 > --password value               Admin Password
@@ -173,8 +173,8 @@ Subcommands:</br>
 `create/c` - Create a new client in an existing Keycloak realm (requires either admin_token or username/password)
 
 > --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
-> --clientid value               New client ID to create
+> --realm value                  Application realm where client should be created
+> --newclient value              New client ID to create
 > --redirect value               Allowed redirect callback URL eg: `http://127.0.0.1:9090/*`
 > --accesstoken value            Admin access_token
 > --username value               Admin Username
@@ -184,7 +184,7 @@ Subcommands:</br>
 
 > --host value                   URL or ingress to Keycloak service
 > --realm value                  Application realm
-> --clientid value               New client ID to create
+> --clientid value               Client ID to retrieve
 > --accesstoken value            Admin access_token
 > --username value               Admin Username
 > --password value               Admin Password
@@ -193,7 +193,7 @@ Subcommands:</br>
 
 > --host value                   URL or ingress to Keycloak service
 > --realm value                  Application realm
-> --clientid value               New client ID to create
+> --clientid value               Client ID to retrieve
 > --accesstoken value            Admin access_token
 > --username value               Admin Username
 > --password value               Admin Password
@@ -244,7 +244,7 @@ Subcommands:</br>
 > --password value               Admin Password
 > --name value                   Username to query
 > --newpw value                  New replacement password
- 
+
 ## deployments
 
 Subcommands:</br>
@@ -257,7 +257,7 @@ Subcommands:</br>
 > --url value    The ingress URL of the PFE instance
 > --auth value   URL of Keycloak service eg: `https://mykeycloak.test:8443`
 > --realm value  Security realm eg:  codewind or che
-> --clientid value  Security client id eg:  codewind or che-public
+> --clientid value  Security client id eg: codewind or che-public
 
 `remove/rm` - Remove a deployment from the list
 

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -315,7 +315,7 @@ func Commands() {
 					Usage:   "Create a new realm (requires either admin_token or username/password)",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: true},
-						cli.StringFlag{Name: "realm,r", Usage: "Existing realm name", Required: true},
+						cli.StringFlag{Name: "newrealm,r", Usage: "New realm name", Required: true},
 						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
 						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
@@ -337,8 +337,8 @@ func Commands() {
 					Usage:   "Create a new client in a Keycloak realm (requires either admin_token or username/password)",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: true},
-						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "clientid,c", Usage: "New client ID to create", Required: true},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm where client should be created", Required: true},
+						cli.StringFlag{Name: "newclient,c", Usage: "New client ID to create", Required: true},
 						cli.StringFlag{Name: "redirect,l", Usage: "Redirect URL", Required: false},
 						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
@@ -356,7 +356,7 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
 						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "clientid,c", Usage: "New client ID to create", Required: true},
+						cli.StringFlag{Name: "clientid,c", Usage: "Client ID to retrieve", Required: true},
 						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
 						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
@@ -373,7 +373,7 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
 						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "clientid,c", Usage: "Client id", Required: true},
+						cli.StringFlag{Name: "clientid,c", Usage: "Client ID to retrieve", Required: true},
 						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
 						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
@@ -397,7 +397,7 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
 						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "admintoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
 						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
 						cli.StringFlag{Name: "name,n", Usage: "Username to add", Required: true},
@@ -413,7 +413,7 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
 						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
-						cli.StringFlag{Name: "admintoken,t", Usage: "Admin access_token", Required: false},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: false},
 						cli.StringFlag{Name: "username,u", Usage: "Admin Username", Required: false},
 						cli.StringFlag{Name: "password,p", Usage: "Admin Password", Required: false},
 						cli.StringFlag{Name: "name,n", Usage: "Username to retrieve", Required: true},

--- a/actions/security.go
+++ b/actions/security.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/eclipse/codewind-installer/utils"
 	"github.com/eclipse/codewind-installer/utils/security"
@@ -123,7 +124,10 @@ func SecurityUserSetPassword(c *cli.Context) {
 
 // SecurityKeyUpdate : Creates or updates a key in the platforms keyring
 func SecurityKeyUpdate(c *cli.Context) {
-	err := security.SecKeyUpdate(c)
+	deploymentID := strings.TrimSpace(strings.ToLower(c.String("depid")))
+	username := strings.TrimSpace(strings.ToLower(c.String("username")))
+	password := strings.TrimSpace(c.String("password"))
+	err := security.SecKeyUpdate(deploymentID, username, password)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(0)
@@ -135,7 +139,9 @@ func SecurityKeyUpdate(c *cli.Context) {
 
 // SecurityKeyValidate : Checks the key is available in the platform keyring
 func SecurityKeyValidate(c *cli.Context) {
-	_, err := security.SecKeyGetSecret(c)
+	deploymentID := strings.TrimSpace(strings.ToLower(c.String("depid")))
+	username := strings.TrimSpace(strings.ToLower(c.String("username")))
+	_, err := security.SecKeyGetSecret(deploymentID, username)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(0)

--- a/integration.bats
+++ b/integration.bats
@@ -117,7 +117,7 @@
 #########################
 
 @test "invoke seckeyring update command - create a key" {
-  run go run main.go seckeyring update --depid local --username testuser --password secretphrase
+  run go run main.go seckeyring update --depid local --username testuser --password seCretphrase
   echo "status = ${status}"
   echo "output trace = ${output}"
   [ "$output" = '{"status":"OK"}' ]
@@ -125,7 +125,7 @@
 }
 
 @test "invoke seckeyring update command - update a key" {
-  run go run main.go seckeyring update --depid local --username testuser --password new_secretphrase
+  run go run main.go seckeyring update --depid local --username testuser --password new_secretPhrase
   echo "status = ${status}"
   echo "output trace = ${output}"
   [ "$output" = '{"status":"OK"}' ]

--- a/utils/security/authenticate.go
+++ b/utils/security/authenticate.go
@@ -27,7 +27,7 @@ func SecAuthenticate(c *cli.Context, connectionRealm string, connectionClient st
 
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	username := strings.TrimSpace(strings.ToLower(c.String("username")))
-	password := strings.TrimSpace(strings.ToLower(c.String("password")))
+	password := strings.TrimSpace(c.String("password"))
 	realm := strings.TrimSpace(strings.ToLower(c.String("realm")))
 	client := strings.TrimSpace(strings.ToLower(c.String("client")))
 

--- a/utils/security/client.go
+++ b/utils/security/client.go
@@ -34,7 +34,7 @@ func SecClientCreate(c *cli.Context) *SecError {
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
 	realm := strings.TrimSpace(c.String("realm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
-	clientid := strings.TrimSpace(c.String("clientid"))
+	newclient := strings.TrimSpace(c.String("newclient"))
 	redirectURL := strings.TrimSpace(c.String("redirect"))
 
 	// authenticate if needed
@@ -60,8 +60,8 @@ func SecClientCreate(c *cli.Context) *SecError {
 	tempClient := &PayloadClient{
 		DirectAccessGrantsEnabled: true,
 		PublicClient:              true,
-		ClientID:                  clientid,
-		Name:                      clientid,
+		ClientID:                  newclient,
+		Name:                      newclient,
 	}
 
 	tempClient.RedirectUris = [...]string{redirectURL}

--- a/utils/security/keychain.go
+++ b/utils/security/keychain.go
@@ -14,7 +14,6 @@ package security
 import (
 	"strings"
 
-	"github.com/urfave/cli"
 	"github.com/zalando/go-keyring"
 )
 
@@ -25,11 +24,13 @@ type KeyringSecret struct {
 }
 
 // SecKeyUpdate : Creates or updates a key in the platforms keyring
-func SecKeyUpdate(c *cli.Context) *SecError {
-	depid := strings.TrimSpace(strings.ToLower(c.String("depid")))
-	username := strings.TrimSpace(c.String("username"))
-	password := strings.TrimSpace(c.String("password"))
-	err := keyring.Set(KeyringServiceName+"."+depid, username, password)
+func SecKeyUpdate(deploymentID string, username string, password string) *SecError {
+
+	depID := strings.TrimSpace(strings.ToLower(deploymentID))
+	uName := strings.TrimSpace(strings.ToLower(username))
+	pass := strings.TrimSpace(password)
+
+	err := keyring.Set(KeyringServiceName+"."+depID, uName, pass)
 	if err != nil {
 		return &SecError{errOpKeyring, err, err.Error()}
 	}
@@ -37,10 +38,12 @@ func SecKeyUpdate(c *cli.Context) *SecError {
 }
 
 // SecKeyGetSecret : retrieve secret / credentials from the keyring
-func SecKeyGetSecret(c *cli.Context) (string, *SecError) {
-	depid := strings.TrimSpace(c.String("depid"))
-	username := strings.TrimSpace(c.String("username"))
-	secret, err := keyring.Get(KeyringServiceName+"."+depid, username)
+func SecKeyGetSecret(deploymentID string, username string) (string, *SecError) {
+
+	depID := strings.TrimSpace(strings.ToLower(deploymentID))
+	uName := strings.TrimSpace(strings.ToLower(username))
+
+	secret, err := keyring.Get(KeyringServiceName+"."+depID, uName)
 	if err != nil {
 		return "", &SecError{errOpKeyring, err, err.Error()}
 	}

--- a/utils/security/keychain_test.go
+++ b/utils/security/keychain_test.go
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package security
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zalando/go-keyring"
+)
+
+const testDeployment = "unittest-dev"
+const testUsername = "unit_test_user"
+const testPassword = "pAss%-w0rd-&'cha*s"
+const testPasswordUpdated = "pAss%-w0rd-&'cha*s-with_more_chars"
+
+func Test_Keychain(t *testing.T) {
+
+	// remove test key if one exists
+	keyring.Delete(KeyringServiceName+"."+testDeployment, testUsername)
+
+	t.Run("Secret can not be retrieved for an unknown account", func(t *testing.T) {
+		retrievedSecret, err := SecKeyGetSecret(testDeployment, testUsername)
+		if err == nil {
+			t.Fail()
+		}
+		assert.Equal(t, "", retrievedSecret)
+	})
+
+	t.Run("A new key can be created in the platform keychain", func(t *testing.T) {
+		err := SecKeyUpdate(testDeployment, testUsername, testPassword)
+		if err != nil {
+			t.Fail()
+		}
+	})
+
+	t.Run("The secret can be retrieved from the keychain", func(t *testing.T) {
+		storedSecret, err := SecKeyGetSecret(testDeployment, testUsername)
+		if err != nil {
+			t.Fail()
+		}
+		assert.Equal(t, testPassword, storedSecret)
+	})
+
+	t.Run("An existing key in the keychain can be updated", func(t *testing.T) {
+		err := SecKeyUpdate(testDeployment, testUsername, testPasswordUpdated)
+		if err != nil {
+			t.Fail()
+		}
+	})
+
+	t.Run("Retrieved secret matches the saved secret", func(t *testing.T) {
+		storedSecret, err := SecKeyGetSecret(testDeployment, testUsername)
+		if err != nil {
+			t.Fail()
+		}
+		assert.Equal(t, testPasswordUpdated, storedSecret)
+	})
+
+	// remove test key
+	keyring.Delete(KeyringServiceName+"."+testDeployment, testUsername)
+}

--- a/utils/security/realm.go
+++ b/utils/security/realm.go
@@ -14,7 +14,7 @@ import (
 func SecRealmCreate(c *cli.Context) *SecError {
 
 	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
-	realm := strings.TrimSpace(c.String("realm"))
+	newRealm := strings.TrimSpace(c.String("newrealm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 
 	// Authenticate if needed
@@ -38,8 +38,8 @@ func SecRealmCreate(c *cli.Context) *SecError {
 		AccessTokenLifespan int    `json:"accessTokenLifespan"`
 	}
 	tempRealm := &PayloadRealm{
-		Realm:               realm,
-		DisplayName:         realm,
+		Realm:               newRealm,
+		DisplayName:         newRealm,
 		Enabled:             true,
 		LoginTheme:          "codewind",
 		AccessTokenLifespan: 86400,


### PR DESCRIPTION
## Problem: 

User passwords with uppercase characters are mangled and not stored in keyring correctly

## Solution

1. Uppercase characters are valid characters in Keycloak.  Changing the user password to all lowercase is not required.
2. Updated texts to use mixed case passwords and clean-up test key after use
3. Changed accesstoken name to be consistent with other command line options 
4. Updated Readme

## Tests

Updated tests to handle mixed case : 

### Integration tests : 

 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect deployment)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

### unit tests : 

=== RUN   Test_Keychain
=== RUN   Test_Keychain/Secret_can_not_be_retrieved_for_an_unknown_account
=== RUN   Test_Keychain/A_new_key_can_be_created_in_the_platform_keychain
=== RUN   Test_Keychain/The_secret_can_be_retrieved_from_the_keychain
=== RUN   Test_Keychain/An_existing_key_in_the_keychain_can_be_updated
=== RUN   Test_Keychain/Retrieved_secret_matches_the_saved_secret
--- PASS: Test_Keychain (0.24s)
    --- PASS: Test_Keychain/Secret_can_not_be_retrieved_for_an_unknown_account (0.03s)
    --- PASS: Test_Keychain/A_new_key_can_be_created_in_the_platform_keychain (0.05s)
    --- PASS: Test_Keychain/The_secret_can_be_retrieved_from_the_keychain (0.03s)
    --- PASS: Test_Keychain/An_existing_key_in_the_keychain_can_be_updated (0.04s)
    --- PASS: Test_Keychain/Retrieved_secret_matches_the_saved_secret (0.03s)
PASS
ok      github.com/eclipse/codewind-installer/utils/security    0.503s

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>