### PR TITLE
update README.md from codewind-installer -> cwctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Codewind Installer
+# Codewind Command Line Interface (CLI)
+
 Install Codewind on MacOS or Windows.
 Prebuilt binary files are available for download [on Eclipse](https://download.eclipse.org/codewind/codewind-installer/).
 
@@ -13,22 +14,22 @@ Ensure that you are logged in to Docker. Type `docker login` into a command line
 
 1. Download the release binary file to a folder on your system.
 2. Use the `cd` command to go to the location of the downloaded file in the command line window.
-3. If the binary file has the `.dms` extension, remove the extension so that the file is named `codewind-installer-macos`.
-4. Enter the `chmod +x codewind-installer-macos` command to give yourself execution permissions for the binary.
-5. If you already have a `codewind-workspace` with your projects in it, copy it into your `/Users/<username>` home directory. If you do not already have a workspace, the installer creates an empty workspace for you in this directory.
-6. Type `./codewind-installer-macos` in the command line window to run the installer.
-7. To run a command, enter `./codewind-installer-macos <command>`.
+3. If the binary file has the `.dms` extension, remove the extension so that the file is named `cwctl-macos`.
+4. Enter the `chmod +x cwctl-macos` command to give yourself execution permissions for the binary.
+5. If you already have a `codewind-workspace` with your projects in it, copy it into your `/Users/<username>` home directory. If you do not already have a workspace, the CLI creates an empty workspace for you in this directory.
+6. Type `./cwctl-macos` in the command line window to run the CLI.
+7. To run a command, enter `./cwctl-macos <command>`.
 
 ## Downloading the release binary for Linux
 
 1. Download the release binary file to a folder on your system.
 2. Use the `cd` command to go to the location of the downloaded file in the command line window.
-3. If necessary, remove any file extensions so that the file is named `codewind-installer-linux`.
-4. Enter the `chmod +x codewind-installer-linux` command to give yourself execution permissions for the binary.
-5. If you already have a `codewind-workspace` with your projects in it, copy the workspace into your `$HOME` home directory. If you do not already have a workspace, the installer creates an empty workspace for you in this directory.
+3. If necessary, remove any file extensions so that the file is named `cwctl-linux`.
+4. Enter the `chmod +x cwctl-linux` command to give yourself execution permissions for the binary.
+5. If you already have a `codewind-workspace` with your projects in it, copy the workspace into your `$HOME` home directory. If you do not already have a workspace, the CLI creates an empty workspace for you in this directory.
 6. Install `docker-compose` with [Install Docker Compose](https://docs.docker.com/compose/install/).
-7. To run the installer, enter `./codewind-installer-linux` in the command line window.
-8. To run a command, enter `./codewind-installer-linux <command>`.
+7. To run the CLI, enter `./cwctl-linux` in the command line window.
+8. To run a command, enter `./cwctl-linux <command>`.
 
 ## Downloading the release binary for Windows
 
@@ -36,9 +37,9 @@ Ensure that you are logged in to Docker. Type `docker login` into a command line
 2. Use the `cd` command to go to the location of the downloaded file in the command prompt.
 3. Ensure that the binary file has an `.exe` extension. If it doesn't, add the extension to the file name.
 4. Ensure that your `C:\` drive is shared with Docker Desktop for Windows. To check, go to **Settings**>**Shared drives** and make sure the `C:\` drive check box is selected.
-5. If you already have a `codewind-workspace` with your projects in it, copy the `codewind-workspace` into your `C:\` directory. If you do not already have a workspace, the installer creates an empty one for you in this directory.
-6. To get started and see the commands that are available, type the `.\codewind-installer-win.exe` command in the command prompt.
-7. To run a command, enter `.\codewind-installer-win.exe <command>`.
+5. If you already have a `codewind-workspace` with your projects in it, copy the `codewind-workspace` into your `C:\` directory. If you do not already have a workspace, the CLI creates an empty one for you in this directory.
+6. To get started and see the commands that are available, type the `.\cwctl-win.exe` command in the command prompt.
+7. To run a command, enter `.\cwctl-win.exe <command>`.
 
 ## Building and deploying locally on MacOS
 
@@ -56,7 +57,7 @@ $ brew upgrade dep
 6. Use the `cd` command to go to the project directory and install the vendor packages with the `dep ensure -v` command.
 7. Build the binary and give it a name with the `go build -o <binary-name>` command. To build a binary without the debug symbols, use the `go build -ldflags="-s -w" -o <binary-name>` command.
 8. Copy your `codewind-workspace` into your `/Users/<username>` home directory.
-9. Type `./<binary-name>` in the command line window to run the installer.
+9. Type `./<binary-name>` in the command line window to run the CLI.
 10. To run a command, enter `./<binary-name> <command>`.
 
 ## Creating a cross-platform binary


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/255**
The README.md references `codewind-installer` throughout as a binary name. This is no longer the case. It is now called `cwctl-<platform>`. The only references left of this are either within a URL or referring to the name of the repository (yet to change). Other places reference this as an installer itself. It is now a CLI and therefore the references must reflect this.

**Solution**
Change the references where applicable throughout.

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>