### PR TITLE
Remove uneccessary volume mount for the performance container.

### DIFF
--- a/utils/docker.go
+++ b/utils/docker.go
@@ -48,7 +48,6 @@ services:
   image: codewind-performance${PLATFORM}:${TAG}
   ports: ["127.0.0.1:9095:9095"]
   container_name: codewind-performance
-  volumes: ["/var/run/docker.sock:/var/run/docker.sock","${WORKSPACE_DIRECTORY}:/codewind-workspace"]
   networks: [network]
 networks:
   network:


### PR DESCRIPTION
This should resolve https://github.com/eclipse/codewind/issues/781 by removing the unnecessarily bound volumes.