### PR TITLE
Do not exit after create call

### DIFF
--- a/actions/project.go
+++ b/actions/project.go
@@ -32,7 +32,6 @@ func ProjectCreate(c *cli.Context) {
 	if err != nil {
 		fmt.Println(err.Error())
 	}
-	os.Exit(0)
 }
 
 func ProjectSync(c *cli.Context) {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

My refactor of the project commands into separate files meant that we were exiting after the create command had completed rather than continuing to the validate call.