### PR TITLE
Error handling for bind command

### DIFF
--- a/utils/project/bind.go
+++ b/utils/project/bind.go
@@ -79,13 +79,17 @@ func Bind(projectPath string, Name string, Language string, BuildType string) *P
 	request.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(request)
 	if err != nil {
-		return &ProjectError{errBadType, err, err.Error()}
+		bindError := errors.New(textNoCodewind)
+		return &ProjectError{errOpResponse, bindError, bindError.Error()}
 	}
 
 	switch httpCode := resp.StatusCode; {
 	case httpCode == 400:
 		err = errors.New(textInvalidType)
 		return &ProjectError{errOpResponse, err, textInvalidType}
+	case httpCode == 404:
+		err = errors.New(textAPINotFound)
+		return &ProjectError{errOpResponse, err, textAPINotFound}
 	case httpCode == 409:
 		err = errors.New(textDupName)
 		return &ProjectError{errOpResponse, err, textDupName}

--- a/utils/project/project_utils.go
+++ b/utils/project/project_utils.go
@@ -40,6 +40,8 @@ const (
 	textInvalidProjectID = "project ID is invalid"
 	textDeploymentExists = "project already added to this deployment"
 	textDepMissing       = "project deployment not found"
+	textNoCodewind       = "unable to connect to Codewind server"
+	textAPINotFound      = "unable to find requested resource on Codewind server"
 )
 
 // ProjectError : Error formatted in JSON containing an errorOp and a description from


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Added error handling for no PFE running and for missing API in PFE (this will happen if cwctl is used with an old PFE)