### PR TITLE
Add call to close

### DIFF
--- a/utils/project/sync.go
+++ b/utils/project/sync.go
@@ -122,6 +122,7 @@ func syncFiles(projectPath string, projectId string, synctime int64) ([]string, 
 				if err != nil {
 					return nil
 				}
+				defer resp.Body.Close()
 			}
 		} else {
 			shouldIgnore := ignoreFileOrDirectory(info.Name(), true)


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>
Fixes a problem with 'Too may file handles' being open because we were not closing the http connection when uploading files'
