### PR TITLE
Bind sync json

### DIFF
--- a/actions/commands.go
+++ b/actions/commands.go
@@ -40,6 +40,10 @@ func Commands() {
 			Name:  "insecure",
 			Usage: "disable certificate checking",
 		},
+		cli.BoolFlag{
+			Name:  "json, j",
+			Usage: "ouput as JSON",
+		},
 	}
 
 	// create commands
@@ -156,7 +160,7 @@ func Commands() {
 				},
 				cli.BoolFlag{
 					Name:  "json, j",
-					Usage: "specify terminal output",
+					Usage: "ouput as JSON",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -191,7 +195,7 @@ func Commands() {
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "json, j",
-					Usage: "specify terminal output",
+					Usage: "ouput as JSON",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/actions/install.go
+++ b/actions/install.go
@@ -21,7 +21,7 @@ import (
 //InstallCommand to pull images from dockerhub
 func InstallCommand(c *cli.Context) {
 	tag := c.String("tag")
-	jsonOutput := c.Bool("json")
+	jsonOutput := c.Bool("json") || c.GlobalBool("json")
 
 	imageArr := [3]string{"docker.io/eclipse/codewind-pfe-amd64:",
 		"docker.io/eclipse/codewind-performance-amd64:",

--- a/actions/project.go
+++ b/actions/project.go
@@ -37,24 +37,34 @@ func ProjectCreate(c *cli.Context) {
 }
 
 func ProjectSync(c *cli.Context) {
-	// PrintAsJSON := c.GlobalBool("json")
+	PrintAsJSON := c.GlobalBool("json")
 	response, err := project.SyncProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
 	} else {
-		jsonResponse, _ := json.Marshal(response)
-		fmt.Println(string(jsonResponse))
+		if PrintAsJSON {
+			jsonResponse, _ := json.Marshal(response)
+			fmt.Println(string(jsonResponse))
+		} else {
+			fmt.Println("Status: " + response.Status)
+		}
 	}
 	os.Exit(0)
 }
 
 func ProjectBind(c *cli.Context) {
+	PrintAsJSON := c.GlobalBool("json")
 	response, err := project.BindProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
 	} else {
-		jsonResponse, _ := json.Marshal(response)
-		fmt.Println(string(jsonResponse))
+		if PrintAsJSON {
+			jsonResponse, _ := json.Marshal(response)
+			fmt.Println(string(jsonResponse))
+		} else {
+			fmt.Println("Project ID: " + response.ProjectID)
+			fmt.Println("Status: " + response.Status)
+		}
 	}
 	os.Exit(0)
 }

--- a/actions/project.go
+++ b/actions/project.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/eclipse/codewind-installer/utils"
 	"github.com/eclipse/codewind-installer/utils/project"
 	"github.com/urfave/cli"
 )
@@ -42,8 +41,10 @@ func ProjectSync(c *cli.Context) {
 	response, err := project.SyncProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
+	} else {
+		jsonResponse, _ := json.Marshal(response)
+		fmt.Println(string(jsonResponse))
 	}
-	utils.PrettyPrintJSON(response)
 	os.Exit(0)
 }
 
@@ -51,8 +52,10 @@ func ProjectBind(c *cli.Context) {
 	response, err := project.BindProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
+	} else {
+		jsonResponse, _ := json.Marshal(response)
+		fmt.Println(string(jsonResponse))
 	}
-	utils.PrettyPrintJSON(response)
 	os.Exit(0)
 }
 

--- a/actions/project.go
+++ b/actions/project.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/eclipse/codewind-installer/utils"
 	"github.com/eclipse/codewind-installer/utils/project"
 	"github.com/urfave/cli"
 )
@@ -37,18 +38,21 @@ func ProjectCreate(c *cli.Context) {
 }
 
 func ProjectSync(c *cli.Context) {
-	err := project.SyncProject(c)
+	// PrintAsJSON := c.GlobalBool("json")
+	response, err := project.SyncProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
+	utils.PrettyPrintJSON(response)
 	os.Exit(0)
 }
 
 func ProjectBind(c *cli.Context) {
-	err := project.BindProject(c)
+	response, err := project.BindProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
+	utils.PrettyPrintJSON(response)
 	os.Exit(0)
 }
 

--- a/actions/status.go
+++ b/actions/status.go
@@ -39,7 +39,7 @@ func StatusCommand(c *cli.Context) {
 
 // StatusCommandRemoteDeployment : Output remote deployment details
 func StatusCommandRemoteDeployment(c *cli.Context, d *deployments.Deployment) {
-	jsonOutput := c.Bool("json")
+	jsonOutput := c.Bool("json") || c.GlobalBool("json")
 	apiResponse, err := apiroutes.GetAPIEnvironment(c, d.URL)
 	if err != nil {
 		if jsonOutput {
@@ -89,7 +89,7 @@ func StatusCommandRemoteDeployment(c *cli.Context, d *deployments.Deployment) {
 
 // StatusCommandLocalDeployment : Output local deployment details
 func StatusCommandLocalDeployment(c *cli.Context) {
-	jsonOutput := c.Bool("json")
+	jsonOutput := c.Bool("json") || c.GlobalBool("json")
 	if utils.CheckContainerStatus() {
 		// Started
 		hostname, port := utils.GetPFEHostAndPort()

--- a/utils/deployments/deployment.go
+++ b/utils/deployments/deployment.go
@@ -14,6 +14,7 @@ package deployments
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -109,6 +110,7 @@ func FindTargetDeployment() (*Deployment, *DepError) {
 // GetDeploymentByID : retrieve a single deployment with matching ID
 func GetDeploymentByID(depID string) (*Deployment, *DepError) {
 	deploymentList, depErr := GetAllDeployments()
+	fmt.Println(depID)
 	if depErr != nil {
 		return nil, depErr
 	}

--- a/utils/deployments/deployment.go
+++ b/utils/deployments/deployment.go
@@ -14,7 +14,6 @@ package deployments
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -110,7 +109,6 @@ func FindTargetDeployment() (*Deployment, *DepError) {
 // GetDeploymentByID : retrieve a single deployment with matching ID
 func GetDeploymentByID(depID string) (*Deployment, *DepError) {
 	deploymentList, depErr := GetAllDeployments()
-	fmt.Println(depID)
 	if depErr != nil {
 		return nil, depErr
 	}

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -167,7 +167,6 @@ func PullImage(image string, jsonOutput bool) {
 	codewindOut, err = cli.ImagePull(ctx, image, types.ImagePullOptions{})
 
 	errors.CheckErr(err, 100, "")
-
 	if jsonOutput == true {
 		defer codewindOut.Close()
 		io.Copy(os.Stdout, codewindOut)

--- a/utils/project/bind.go
+++ b/utils/project/bind.go
@@ -161,7 +161,7 @@ func completeBind(projectID string, depURL string) (string, int) {
 	jsonPayload, _ := json.Marshal(payload)
 
 	// Make the request to end the sync process.
-	resp, err := http.Post(uploadEndUrl, "application/json", bytes.NewBuffer(jsonPayload))
+	resp, err := http.Post(uploadEndURL, "application/json", bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		panic(err)
 	}

--- a/utils/project/bind.go
+++ b/utils/project/bind.go
@@ -48,10 +48,10 @@ type (
 	}
 
 	BindResponse struct {
-		ProjectID     string         `json:"ProjectID"`
-		Status        string         `json:"Status"`
-		StatusCode    int            `json:"StatusCode"`
-		UploadedFiles []UploadedFile `json:"UploadedFiles"`
+		ProjectID     string         `json:"projectID"`
+		Status        string         `json:"status"`
+		StatusCode    int            `json:"statusCode"`
+		UploadedFiles []UploadedFile `json:"uploadedFiles"`
 	}
 )
 

--- a/utils/project/bind.go
+++ b/utils/project/bind.go
@@ -48,10 +48,10 @@ type (
 	}
 
 	BindResponse struct {
-		ProjectID          string         `json:"ProjectID"`
-		ResponseStatus     string         `json:"ResponseStatus"`
-		ResponseStatusCode int            `json:"ResponseStatusCode"`
-		UploadedFiles      []UploadedFile `json:"UploadedFiles"`
+		ProjectID     string         `json:"ProjectID"`
+		Status        string         `json:"Status"`
+		StatusCode    int            `json:"StatusCode"`
+		UploadedFiles []UploadedFile `json:"UploadedFiles"`
 	}
 )
 
@@ -146,10 +146,10 @@ func Bind(projectPath string, name string, language string, projectType string, 
 	// Call bind/end to complete
 	completeStatus, completeStatusCode := completeBind(projectID, depURL)
 	response := BindResponse{
-		ProjectID:          projectID,
-		UploadedFiles:      uploadedFilesList,
-		ResponseStatus:     completeStatus,
-		ResponseStatusCode: completeStatusCode,
+		ProjectID:     projectID,
+		UploadedFiles: uploadedFilesList,
+		Status:        completeStatus,
+		StatusCode:    completeStatusCode,
 	}
 	return &response, nil
 }

--- a/utils/project/sync.go
+++ b/utils/project/sync.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/config"
-	"github.com/eclipse/codewind-installer/utils/deployments"
 	"github.com/urfave/cli"
 )
 
@@ -58,25 +57,25 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 	projectPath := strings.TrimSpace(c.String("path"))
 	projectID := strings.TrimSpace(c.String("id"))
 	synctime := int64(c.Int("time"))
-	depID := strings.TrimSpace(c.String("d"))
 
 	_, err := os.Stat(projectPath)
 	if err != nil {
 		return nil, &ProjectError{errBadPath, err, err.Error()}
 	}
 
-	deploymentInfo, err := deployments.GetDeploymentByID(depID)
+	// deploymentInfo, err := deployments.GetDeploymentByID(depID)
 
-	if err != nil {
-		return nil, &ProjectError{errOpNotFound, err, err.Error()}
-	}
+	// if err != nil {
+	// 	return nil, &ProjectError{errOpNotFound, err, err.Error()}
+	// }
 
-	var depURL string
-	if depID != "local" {
-		depURL = deploymentInfo.URL
-	} else {
-		depURL = config.PFEApiRoute()
-	}
+	// var depURL string
+	// if depID != "local" {
+	// 	depURL = deploymentInfo.URL
+	// } else {
+	// 	depURL = config.PFEApiRoute()
+	// }
+	depURL := config.PFEApiRoute()
 
 	// Sync all the necessary project files
 	fileList, modifiedList, uploadedFilesList := syncFiles(projectPath, projectID, depURL, synctime)

--- a/utils/project/sync.go
+++ b/utils/project/sync.go
@@ -42,14 +42,14 @@ type (
 		Message      string `json:"msg"`
 	}
 	UploadedFile struct {
-		FilePath   string `json:"FilePath"`
-		Status     string `json:"Status"`
-		StatusCode int    `json:"StatusCode"`
+		FilePath   string `json:"filePath"`
+		Status     string `json:"status"`
+		StatusCode int    `json:"statusCode"`
 	}
 	SyncResponse struct {
-		Status        string         `json:"Status"`
-		StatusCode    int            `json:"StatusCode"`
-		UploadedFiles []UploadedFile `json:"UploadedFiles"`
+		Status        string         `json:"status"`
+		StatusCode    int            `json:"statusCode"`
+		UploadedFiles []UploadedFile `json:"uploadedFiles"`
 	}
 )
 

--- a/utils/project/sync.go
+++ b/utils/project/sync.go
@@ -43,14 +43,14 @@ type (
 		Message      string `json:"msg"`
 	}
 	UploadedFile struct {
-		FilePath           string `json:"FilePath"`
-		ResponseStatus     string `json:"ResponseStatus"`
-		ResponseStatusCode int    `json:"ResponseStatusCode"`
+		FilePath   string `json:"FilePath"`
+		Status     string `json:"Status"`
+		StatusCode int    `json:"StatusCode"`
 	}
 	SyncResponse struct {
-		ResponseStatus     string         `json:"ResponseStatus"`
-		ResponseStatusCode int            `json:"ResponseStatusCode"`
-		UploadedFiles      []UploadedFile `json:"UploadedFiles"`
+		Status        string         `json:"Status"`
+		StatusCode    int            `json:"StatusCode"`
+		UploadedFiles []UploadedFile `json:"UploadedFiles"`
 	}
 )
 
@@ -83,9 +83,9 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 	// Complete the upload
 	completeStatus, completeStatusCode := completeUpload(projectID, fileList, modifiedList, depURL, synctime)
 	response := SyncResponse{
-		UploadedFiles:      uploadedFilesList,
-		ResponseStatus:     completeStatus,
-		ResponseStatusCode: completeStatusCode,
+		UploadedFiles: uploadedFilesList,
+		Status:        completeStatus,
+		StatusCode:    completeStatusCode,
 	}
 
 	return &response, nil
@@ -151,9 +151,9 @@ func syncFiles(projectPath string, projectID string, depURL string, synctime int
 				request.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(request)
 				uploadedFiles = append(uploadedFiles, UploadedFile{
-					FilePath:           relativePath,
-					ResponseStatus:     resp.Status,
-					ResponseStatusCode: resp.StatusCode,
+					FilePath:   relativePath,
+					Status:     resp.Status,
+					StatusCode: resp.StatusCode,
 				})
 				if err != nil {
 					return nil

--- a/utils/project/sync_test.go
+++ b/utils/project/sync_test.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package project
 
 import (


### PR DESCRIPTION


### Summary
PR for https://github.com/eclipse/codewind/issues/830
Added a global `--json` flag which changes the output of `project bind` and `project sync` to be in a JSON format. This will be used by the editor plugins.

To run a command with the JSON flag is must come before the [command] section of the CLI, such as: `cwctl --json project bind  -l nodejs -t nodejs -p ~/codewind-workspace/anothernodeapp -n finalapp23`

Project bind will output:

*Normal*
```
Project ID: 398a7030-f727-11e9-a235-118bb4d3585f
Status: 200 OK
```
*--JSON*
```
{"ProjectID":"547de4c0-f728-11e9-a235-118bb4d3585f","Status":"200 OK","StatusCode":200,"UploadedFiles":[{"FilePath":".cw-settings","Status":"200 OK","StatusCode":200},{"FilePath":".dockerignore","Status":"200 OK","StatusCode":200},{"FilePath":".gitignore","Status":"200 OK","StatusCode":200},{"FilePath":"Dockerfile","Status":"200 OK","StatusCode":200},{"FilePath":"Dockerfile-tools","Status":"200 OK","StatusCode":200},{"FilePath":"README.md","Status":"200 OK","StatusCode":200},{"FilePath":"chart/node/Chart.yaml","Status":"200 OK","StatusCode":200},{"FilePath":"chart/node/templates/basedeployment.yaml","Status":"200 OK","StatusCode":200},{"FilePath":"chart/node/templates/deployment.yaml","Status":"200 OK","StatusCode":200},{"FilePath":"chart/node/templates/hpa.yaml","Status":"200 OK","StatusCode":200},{"FilePath":"chart/node/templates/istio.yaml","Status":"200 OK","StatusCode":200},{"FilePath":"chart/node/templates/service.yaml","Status":"200 OK","StatusCode":200},{"FilePath":"chart/node/values.yaml","Status":"200 OK","StatusCode":200},{"FilePath":"cli-config.yml","Status":"200 OK","StatusCode":200},{"FilePath":"nodejs_dc.log","Status":"200 OK","StatusCode":200},{"FilePath":"nodejs_restclient.log","Status":"200 OK","StatusCode":200},{"FilePath":"nodemon.json","Status":"200 OK","StatusCode":200},{"FilePath":"package-lock.json","Status":"200 OK","StatusCode":200},{"FilePath":"package.json","Status":"200 OK","StatusCode":200},{"FilePath":"public/404.html","Status":"200 OK","StatusCode":200},{"FilePath":"public/500.html","Status":"200 OK","StatusCode":200},{"FilePath":"public/index.html","Status":"200 OK","StatusCode":200},{"FilePath":"server/config/local.json","Status":"200 OK","StatusCode":200},{"FilePath":"server/routers/health.js","Status":"200 OK","StatusCode":200},{"FilePath":"server/routers/index.js","Status":"200 OK","StatusCode":200},{"FilePath":"server/routers/public.js","Status":"200 OK","StatusCode":200},{"FilePath":"server/server.js","Status":"200 OK","StatusCode":200},{"FilePath":"server/services/index.js","Status":"200 OK","StatusCode":200},{"FilePath":"server/services/service-manager.js","Status":"200 OK","StatusCode":200},{"FilePath":"test/test-demo.js","Status":"200 OK","StatusCode":200},{"FilePath":"test/test-server.js","Status":"200 OK","StatusCode":200}]}
```

And is the same for `sync` but without the ProjectID.

### Additional stuff
Add the legal header to `sync_tests.go` as I missed it in a previous PR.
Added the capability for `install` and `status` to use the new global `--json` flag.

### Tests
I have only done manual testing as there are currently no tests for `project bind` and `project sync`.