### PR TITLE
Get deploymentID from projectID in `sync`

### DIFF
--- a/actions/project.go
+++ b/actions/project.go
@@ -40,7 +40,7 @@ func ProjectSync(c *cli.Context) {
 	PrintAsJSON := c.GlobalBool("json")
 	response, err := project.SyncProject(c)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println(err.Err)
 	} else {
 		if PrintAsJSON {
 			jsonResponse, _ := json.Marshal(response)

--- a/utils/project/projectDeployment.go
+++ b/utils/project/projectDeployment.go
@@ -170,17 +170,10 @@ func ListTargetDeployments(projectID string) (*DeploymentTargets, *ProjectError)
 
 // GetDeploymentURL returns to the deployment URL for a given projectID, unique to each project deployment
 func GetDeploymentURL(projectID string) (string, *ProjectError) {
-	targetDeployments, err := ListTargetDeployments(projectID)
+	depID, err := GetDeploymentID(projectID)
+
 	if err != nil {
 		return "", err
-	}
-	depTargets := targetDeployments.DeploymentTargets
-	var depID string
-	if len(depTargets) > 0 {
-		depID = depTargets[0].DeploymentID
-	} else {
-		projError := errors.New("Deployment not found for project " + projectID)
-		return "", &ProjectError{errOpNotFound, projError, textDepMissing}
 	}
 
 	projectDepInfo, depErr := deployments.GetDeploymentByID(depID)
@@ -192,6 +185,23 @@ func GetDeploymentURL(projectID string) (string, *ProjectError) {
 		return config.PFEApiRoute(), nil
 	}
 	return projectDepInfo.URL, nil
+}
+
+// GetDeploymentID gets the the deploymentID for a given projectID
+func GetDeploymentID(projectID string) (string, *ProjectError) {
+	targetDeployments, err := ListTargetDeployments(projectID)
+	if err != nil {
+		return "", err
+	}
+	depTargets := targetDeployments.DeploymentTargets
+	var depID string
+	if len(depTargets) > 0 {
+		depID = depTargets[0].DeploymentID
+	} else {
+		projError := errors.New("Deployment not found for project " + projectID)
+		return "", &ProjectError{errOpNotFound, projError, projError.Error()}
+	}
+	return depID, nil
 }
 
 // getProjectDeploymentConfigDir : get directory path to the deployments file

--- a/utils/project/project_utils.go
+++ b/utils/project/project_utils.go
@@ -24,15 +24,16 @@ type ProjectError struct {
 }
 
 const (
-	errBadPath     = "proj_path"     // Invalid path provided
-	errBadType     = "proj_type"     // Invalid type provided
-	errOpResponse  = "proj_response" // Bad response to http
-	errOpFileParse = "proj_parse"
-	errOpFileLoad  = "proj_load"
-	errOpFileWrite = "proj_write"
-	errOpConflict  = "proj_conflict"
-	errOpNotFound  = "proj_notfound"
-	errOpInvalidID = "proj_id_invalid"
+	errBadPath       = "proj_path"     // Invalid path provided
+	errBadType       = "proj_type"     // Invalid type provided
+	errOpResponse    = "proj_response" // Bad response to http
+	errOpFileParse   = "proj_parse"
+	errOpFileLoad    = "proj_load"
+	errOpFileWrite   = "proj_write"
+	errOpConflict    = "proj_conflict"
+	errOpNotFound    = "proj_notfound"
+	errOpDepNotFound = "proj_notfound"
+	errOpInvalidID   = "proj_id_invalid"
 )
 
 const (


### PR DESCRIPTION
### Summary

- Fixes `dep_not_found` error introduced in https://github.com/eclipse/codewind-installer/pull/165 for any calls made to sync commmand, whereby `depID` was being read from CLI context, but not accepted as a command flag. This was commented out as a quickfix in https://github.com/eclipse/codewind-installer/pull/167.

- Now gets the `depID` from `projID`, and then uses the `deploymentURL` as the host in the `api/v1/sync` calls.

- Removes nested errors being printed by the `sync` command. e.g an error obj inside error_description.

Once this goes in, I will rebase into https://github.com/eclipse/codewind-installer/pull/166 to change deployments to connections.

### Tests

- Manual bind and then sync of a project. Tested with a non-existent deployment to return the `dep_not_found` error. 

Signed-off-by: James Cockbain <james.cockbain@ibm.com>