### PR TITLE
change default host ip for codewind_network

### DIFF
--- a/utils/docker.go
+++ b/utils/docker.go
@@ -51,6 +51,8 @@ services:
   networks: [network]
 networks:
   network:
+   driver_opts:
+    com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"
 volumes:
   cw-workspace:
 `
@@ -80,8 +82,12 @@ type Compose struct {
 	VOLUME struct {
 		CodewindWorkspace map[string]string `yaml:"cw-workspace"`
 	} `yaml:"volumes"`
-	NETWORK struct {
-		Network map[string]string `yaml:"network"`
+	NETWORKS struct {
+		NETWORK struct {
+			DRIVEROPTS struct {
+				HostIP string `yaml:"com.docker.network.bridge.host_binding_ipv4"`
+			} `yaml:"driver_opts"`
+		} `yaml:"network"`
 	} `yaml:"networks"`
 }
 


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>
For issue: https://github.com/eclipse/codewind/issues/611

Change the default container host ip from 0.0.0.0 to 127.0.0.1 for codewind_network
Tested the port binding is fixed, plus we do not want the app to be exposed externally.

```
     NAMES
aa7601f3ff77        cw-nodetestproject-dcd3f960-f9bf-11e9-9d5c-45e355c0947c   "docker-entrypoint.s…"   16 minutes ago      Up 16 minutes       127.0.0.1:32771->3000/tcp, 127.0.0.1:32770->9229/tcp   cw-nodetestproject-dcd3f960-f9bf-11e9-9d5c-45e355c0947c
```