### PR TITLE
Install remote

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -119,9 +119,12 @@
   version = "v5.0.2"
 
 [[projects]]
-  digest = "1:4882ca4e50712f367a52a467a277dcd8ef877b82acaa5973baea92fe7443f2eb"
+  digest = "1:8a85f428bc6ebfa87f53216b6e43b52b30eccbcffcbd6b057a69ee16718a2248"
   name = "github.com/gogo/protobuf"
-  packages = ["proto"]
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
   pruneopts = "UT"
   revision = "0ca988a254f991240804bf9821f3450d87ccbb1b"
   version = "v1.3.0"
@@ -157,12 +160,72 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:ca4524b4855ded427c7003ec903a5c854f37e7b1e8e2a93277243462c5b753a8"
+  name = "github.com/googleapis/gnostic"
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions",
+  ]
+  pruneopts = "UT"
+  revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
+  version = "v0.3.1"
+
+[[projects]]
+  digest = "1:78d28d5b84a26159c67ea51996a230da4bc07cac648adaae1dfb5fc0ec8e40d3"
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1afb36080aec31e0d1528973ebe6721b191b0369"
+  version = "v0.3.8"
+
+[[projects]]
+  digest = "1:beb5b4f42a25056f0aa291b5eadd21e2f2903a05d15dfe7caf7eaee7e12fa972"
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
+  version = "1.1.8"
+
+[[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
   pruneopts = "UT"
   revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
   version = "v1.0.2"
+
+[[projects]]
+  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   digest = "1:906eb1ca3c8455e447b99a45237b2b9615b665608fd07ad12cce847dd9a1ec43"
@@ -192,6 +255,25 @@
   version = "v1.0.1"
 
 [[projects]]
+  branch = "release-4.4"
+  digest = "1:66566fda046aaf819ee113385d0db4da041aa4db379cabee8f970492bb40e39e"
+  name = "github.com/openshift/api"
+  packages = ["route/v1"]
+  pruneopts = "UT"
+  revision = "e7fa4b871a25985ef0cc36c2fbd9f2cb4445dc9c"
+
+[[projects]]
+  branch = "release-4.4"
+  digest = "1:01d15ba8714388466b93dbf25cf10e2faa1a8603f6c1d0f08a038aa25d9cf2fb"
+  name = "github.com/openshift/client-go"
+  packages = [
+    "route/clientset/versioned/scheme",
+    "route/clientset/versioned/typed/route/v1",
+  ]
+  pruneopts = "UT"
+  revision = "2823239d2298214509c3536714f684101799e81b"
+
+[[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -214,6 +296,14 @@
   pruneopts = "UT"
   revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
   version = "v1.4.2"
+
+[[projects]]
+  digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab"
+  version = "v1.0.5"
 
 [[projects]]
   digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
@@ -244,7 +334,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:50804d40964a0c59170e827824e79bbf810cc10ae57603d8facce8a1f48f9a83"
+  digest = "1:e770fca694de6d53025c299f5dffe4a315151a67489f29cb3ec0757e2916c407"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -254,20 +344,38 @@
     "openpgp/errors",
     "openpgp/packet",
     "openpgp/s2k",
+    "ssh/terminal",
   ]
   pruneopts = "UT"
   revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
 
 [[projects]]
   branch = "master"
-  digest = "1:3e0062766e6b0bcfe1ba1ed1d3f08a8e1e99cd5831426e2596dc9537d28f2adb"
+  digest = "1:3fa9cdf9e0e7f1b1d888b55a710bc90ce5ab1f27feac343cebee6e0b7f31e2d4"
   name = "golang.org/x/net"
   packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
     "internal/socks",
     "proxy",
   ]
   pruneopts = "UT"
   revision = "ca1201d0de80cfde86cb01aea620983605dfe99b"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8d1c112fb1679fa097e9a9255a786ee47383fa2549a3da71bcb1334a693ebcfe"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
 
 [[projects]]
   branch = "master"
@@ -279,6 +387,55 @@
   ]
   pruneopts = "UT"
   revision = "51ab0e2deafac1f46c46ad59cf0921be2f180c3d"
+
+[[projects]]
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/language",
+    "internal/language/compact",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = "UT"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:32a1c8a24e8d0259416f84720d6c32e5c52cf10d01c19a7d23dcfa868f6b6235"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "UT"
+  revision = "6d3f0bb11be5e03f8353894b7240e7d793e40a8f"
+
+[[projects]]
+  digest = "1:e0a1881f9e0564bebdeac98c75e59f07acdde6ed3a5396e0e613eaad31194866"
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = "UT"
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
   branch = "master"
@@ -303,12 +460,209 @@
   version = "v1.24.0"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
+  digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+  version = "v2.2.4"
+
+[[projects]]
   branch = "v3"
   digest = "1:46754188622566b86271d7526cb643b88c2b9589ee224c2d55e282f0f35a0df8"
   name = "gopkg.in/yaml.v3"
   packages = ["."]
   pruneopts = "UT"
   revision = "674ba3eaed223079f9377fbb0c98c0951bf6ec10"
+
+[[projects]]
+  branch = "master"
+  digest = "1:bd776e2c0357331ee88cbe8989a7424ddc1e20b49066739fc9a86dbe704df284"
+  name = "k8s.io/api"
+  packages = [
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "auditregistration/v1alpha1",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "autoscaling/v2beta2",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "coordination/v1",
+    "coordination/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1",
+    "scheduling/v1alpha1",
+    "scheduling/v1beta1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1",
+  ]
+  pruneopts = "UT"
+  revision = "842530cfd124a922391f76c1243845b5a415cee4"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e42d0dd7c90b36189681f57c93606e59661351dfc9d55e383863ce583c0f1dd0"
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/clock",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/naming",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/uuid",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = "UT"
+  revision = "31cb258e7ad9e746e7f46dbd0844c992ed56d179"
+
+[[projects]]
+  digest = "1:3620c1d82183765e30dd6d7190ed56fcb410a7e382c3e8410d7cf0cafa7dd9fd"
+  name = "k8s.io/client-go"
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/auditregistration/v1alpha1",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta2",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1",
+    "kubernetes/typed/coordination/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1beta1",
+    "kubernetes/typed/node/v1alpha1",
+    "kubernetes/typed/node/v1beta1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
+    "pkg/version",
+    "plugin/pkg/client/auth/exec",
+    "rest",
+    "rest/watch",
+    "tools/auth",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/reference",
+    "transport",
+    "util/cert",
+    "util/connrotation",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/keyutil",
+  ]
+  pruneopts = "UT"
+  revision = "78d2af792babf2dd937ba2e2a8d99c753a5eda89"
+  version = "v12.0.0"
+
+[[projects]]
+  digest = "1:93e82f25d75aba18436ad1ac042cb49493f096011f2541075721ed6f9e05c044"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2ca9ad30301bf30a8a6e0fa2110db6b8df699a91"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8a5e4720aca8a94c876d960a2b86afcaf98e8ded4b5bd7fe42d920806b292c57"
+  name = "k8s.io/utils"
+  packages = ["integer"]
+  pruneopts = "UT"
+  revision = "8d271d903fe4c290aa361acfb242cff7bcee96f1"
+
+[[projects]]
+  digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
+  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -319,10 +673,24 @@
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/term",
     "github.com/google/go-github/github",
+    "github.com/openshift/api/route/v1",
+    "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1",
+    "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/urfave/cli",
     "github.com/zalando/go-keyring",
     "gopkg.in/yaml.v3",
+    "k8s.io/api/apps/v1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/uuid",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/tools/clientcmd",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,6 +27,14 @@
   source = "https://github.com/docker/engine"
   version = "19.03.3"
 
+[[constraint]]
+  name = "github.com/openshift/api"
+  branch = "release-4.4"
+
+[[constraint]]
+  name = "github.com/openshift/client-go"
+  branch = "release-4.4"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -167,6 +167,29 @@ func Commands() {
 				InstallCommand(c)
 				return nil
 			},
+			Subcommands: []cli.Command{
+				{
+					Name:    "remote",
+					Aliases: []string{"r"},
+					Usage:   "Install a remote deployment of Codewind",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "namespace,n", Usage: "Kubernetes namespace", Required: true},
+						cli.StringFlag{Name: "session,ses", Usage: "Codewind session secret", Required: false},
+						cli.StringFlag{Name: "ingress,i", Usage: "Ingress Domain eg: 10.22.33.44.nip.io", Required: false},
+						cli.StringFlag{Name: "addkeycloak,k", Usage: "Deploy an instance of Keycloak", Required: false},
+						cli.StringFlag{Name: "kadminuser,au", Usage: "Keycloak admin user", Required: false},
+						cli.StringFlag{Name: "kadminpass,ap", Usage: "Keycloak admin password", Required: false},
+						cli.StringFlag{Name: "kdevuser,du", Usage: "Keycloak developer username to add", Required: false},
+						cli.StringFlag{Name: "kdevpass,dp", Usage: "Keycloak developer username initial password", Required: false},
+						cli.StringFlag{Name: "krealm,r", Usage: "Keycloak realm to setup", Required: false},
+						cli.StringFlag{Name: "kclient,c", Usage: "Keycloak client to setup", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						DoRemoteInstall(c)
+						return nil
+					},
+				},
+			},
 		},
 
 		{

--- a/utils/httpClient.go
+++ b/utils/httpClient.go
@@ -11,9 +11,37 @@
 
 package utils
 
-import "net/http"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
 
 // HTTPClient : An net HTTP Client to simplify testing
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
+}
+
+// WaitForService : Wait for service to start
+func WaitForService(url string, successStatusCode int, maxRetries int) error {
+	retries := 0
+	client := http.Client{
+		Timeout: time.Second * 5,
+	}
+	for {
+		response, err := client.Get(url)
+		if err == nil && response.StatusCode == successStatusCode {
+			fmt.Println(".")
+			return nil
+		}
+		fmt.Print(".")
+		time.Sleep(1 * time.Second)
+		retries++
+		if retries == maxRetries {
+			break
+		}
+	}
+	fmt.Println(".")
+	return errors.New("Service did not respond")
 }

--- a/utils/remote/configure-keycloak.go
+++ b/utils/remote/configure-keycloak.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import (

--- a/utils/remote/configure-keycloak.go
+++ b/utils/remote/configure-keycloak.go
@@ -1,0 +1,124 @@
+package remote
+
+import (
+	"errors"
+	"flag"
+	"net/http"
+
+	"github.com/eclipse/codewind-installer/utils"
+	"github.com/eclipse/codewind-installer/utils/security"
+	logr "github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+// SetupKeycloak : sets up keycloak with a realm, client and user
+func SetupKeycloak(codewindInstance Codewind, deployOptions *DeployOptions) error {
+
+	authURL := KeycloakPrefix + codewindInstance.Ingress
+	if deployOptions.KeycloakTLSSecure {
+		authURL = "https://" + authURL
+	} else {
+		authURL = "http://" + authURL
+	}
+	gateKeeperProtocol := "http://"
+	if deployOptions.GateKeeperTLSSecure {
+		gateKeeperProtocol = "https://"
+	}
+
+	logr.Infoln("Waiting for Keycloak to start")
+	startErr := utils.WaitForService(authURL, 200, 500)
+	if startErr != nil {
+		return errors.New("Keycloak did not start in a reasonable about of time")
+	}
+
+	logr.Infoln("Configuring Keycloak...")
+	logr.Infoln(authURL)
+
+	// Authenticate to get an admin access token
+	flagSet := flag.NewFlagSet("authentication", 0)
+	flagSet.String("host", authURL, "doc")
+	flagSet.String("realm", "master", "doc")
+	flagSet.String("username", deployOptions.KeycloakUser, "doc")
+	flagSet.String("password", deployOptions.KeycloakPassword, "doc")
+	flagSet.String("client", "admin-cli", "doc")
+	c := cli.NewContext(nil, flagSet, nil)
+	tokens, secErr := security.SecAuthenticate(http.DefaultClient, c, "", "")
+	if secErr != nil {
+		utils.PrettyPrintJSON(secErr)
+		return secErr.Err
+	}
+
+	// Create a new realm
+	logr.Infoln("Creating Keycloak realm")
+	realmFlagset := flag.NewFlagSet("setupRealm", 0)
+	realmFlagset.String("host", authURL, "doc")
+	realmFlagset.String("newrealm", deployOptions.KeycloakRealm, "doc")
+	realmFlagset.String("accesstoken", tokens.AccessToken, "doc")
+	c = cli.NewContext(nil, realmFlagset, nil)
+	secErr = security.SecRealmCreate(c)
+	if secErr != nil {
+		utils.PrettyPrintJSON(secErr)
+		return secErr.Err
+	}
+
+	// Create a new client
+	logr.Infoln("Creating Keycloak client")
+	gatekeeperPublicURL := gateKeeperProtocol + GatekeeperPrefix + codewindInstance.Ingress + "/*"
+	clientFlagset := flag.NewFlagSet("setupClient", 0)
+	clientFlagset.String("host", authURL, "doc")
+	clientFlagset.String("redirect", gatekeeperPublicURL, "doc")
+	clientFlagset.String("realm", deployOptions.KeycloakRealm, "doc")
+	clientFlagset.String("newclient", deployOptions.KeycloakClient, "doc")
+	clientFlagset.String("accesstoken", tokens.AccessToken, "doc")
+	c = cli.NewContext(nil, clientFlagset, nil)
+	secErr = security.SecClientCreate(c)
+	if secErr != nil {
+		utils.PrettyPrintJSON(secErr)
+		return secErr.Err
+	}
+
+	// Create an initial user
+	logr.Infoln("Creating Keycloak initial user")
+	userCreateFlagset := flag.NewFlagSet("createUser", 0)
+	userCreateFlagset.String("host", authURL, "doc")
+	userCreateFlagset.String("realm", deployOptions.KeycloakRealm, "doc")
+	userCreateFlagset.String("name", deployOptions.KeycloakDevUser, "doc")
+	userCreateFlagset.String("accesstoken", tokens.AccessToken, "doc")
+	c = cli.NewContext(nil, userCreateFlagset, nil)
+	secErr = security.SecUserCreate(c)
+	if secErr != nil {
+		utils.PrettyPrintJSON(secErr)
+		return secErr.Err
+	}
+
+	// Create an initial user password
+	logr.Infoln("Updating Keycloak user password")
+	userPassFlagset := flag.NewFlagSet("createUser", 0)
+	userPassFlagset.String("host", authURL, "doc")
+	userPassFlagset.String("realm", deployOptions.KeycloakRealm, "doc")
+	userPassFlagset.String("name", deployOptions.KeycloakDevUser, "doc")
+	userPassFlagset.String("newpw", deployOptions.KeycloakDevPassword, "doc")
+	userPassFlagset.String("accesstoken", tokens.AccessToken, "doc")
+	c = cli.NewContext(nil, userPassFlagset, nil)
+	secErr = security.SecUserSetPW(c)
+	if secErr != nil {
+		utils.PrettyPrintJSON(secErr)
+		return secErr.Err
+	}
+
+	// Load client secret
+	logr.Infoln("Fetching client secret")
+	clientSecFlagset := flag.NewFlagSet("getClientSecret", 0)
+	clientSecFlagset.String("host", authURL, "doc")
+	clientSecFlagset.String("realm", deployOptions.KeycloakRealm, "doc")
+	clientSecFlagset.String("clientid", deployOptions.KeycloakClient, "doc")
+	clientSecFlagset.String("accesstoken", tokens.AccessToken, "doc")
+	c = cli.NewContext(nil, clientSecFlagset, nil)
+	registeredSecret, secErr := security.SecClientGetSecret(c)
+	if secErr != nil {
+		utils.PrettyPrintJSON(secErr)
+		return secErr.Err
+	}
+	deployOptions.ClientSecret = registeredSecret.Secret
+	return nil
+}

--- a/utils/remote/defaults.go
+++ b/utils/remote/defaults.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import corev1 "k8s.io/api/core/v1"

--- a/utils/remote/defaults.go
+++ b/utils/remote/defaults.go
@@ -1,0 +1,56 @@
+package remote
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	// PFEPrefix is the prefix all PFE-related resources: deployment, service, and ingress/route
+	PFEPrefix = "codewind-pfe"
+
+	// PerformancePrefix is the prefix for all performance-dashboard related resources: deployment and service
+	PerformancePrefix = "codewind-performance"
+
+	// KeycloakPrefix is the prefix for all keycloak related resources: deployment and service
+	KeycloakPrefix = "codewind-keycloak"
+
+	// GatekeeperPrefix is the prefix for all gatekeeper related resources: deployment and service
+	GatekeeperPrefix = "codewind-gatekeeper"
+
+	// PFEImage is the docker image that will be used in the Codewind-PFE pod
+	PFEImage = "eclipse/codewind-pfe-amd64"
+
+	// PerformanceImage is the docker image that will be used in the Performance dashboard pod
+	PerformanceImage = "eclipse/codewind-performance-amd64"
+
+	// KeycloakImage is the docker image that will be used in the Codewind-Keycloak pod
+	KeycloakImage = "marko11/codewind-keycloak-amd64"
+
+	// GatekeeperImage is the docker image that will be used in the Codewind-Gatekeeper pod
+	GatekeeperImage = "marko11/codewind-gatekeeper-amd64"
+
+	// PFEImageTag is the image tag associated with the docker image that's used for Codewind-PFE
+	PFEImageTag = "latest"
+
+	// PerformanceTag is the image tag associated with the docker image that's used for the Performance dashboard
+	PerformanceTag = "latest"
+
+	// KeycloakImageTag is the image tag associated with the docker image that's used for Codewind-Keycloak
+	KeycloakImageTag = "latest"
+
+	// GatekeeperImageTag is the image tag associated with the docker image that's used for Codewind-Gatekeeper
+	GatekeeperImageTag = "latest"
+
+	// ImagePullPolicy is the pull policy used for all containers in Codewind, defaults to Always
+	ImagePullPolicy = corev1.PullAlways
+
+	// PFEContainerPort is the port at which Codewind-PFE is exposed
+	PFEContainerPort = 9191
+
+	// PerformanceContainerPort is the port at which the Performance dashboard is exposed
+	PerformanceContainerPort = 9095
+
+	// KeycloakContainerPort is the port at which Keycloak is exposed
+	KeycloakContainerPort = 8080
+
+	// GatekeeperContainerPort is the port at which the Gatekeeper is exposed
+	GatekeeperContainerPort = 9096
+)

--- a/utils/remote/deploy.go
+++ b/utils/remote/deploy.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import (

--- a/utils/remote/deploy.go
+++ b/utils/remote/deploy.go
@@ -84,10 +84,11 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 	ingressDomain := remoteDeployOptions.IngressDomain
 
 	// Use a supplied ingress if one was not installed
-	if remoteDeployOptions.IngressDomain == "" {
+	if remoteDeployOptions.IngressDomain == "" && !onOpenShift {
+		logr.Infof("Attempting to discover Ingress Domain")
 		svcList := clientset.CoreV1().Services("ingress-nginx")
 		svc, err := svcList.List(v1.ListOptions{})
-		if err != nil && svc != nil && svc.Items != nil {
+		if err == nil && svc != nil && svc.Items != nil {
 			ingressDomain = svc.Items[0].Spec.ClusterIP + ".nip.io"
 		}
 	}

--- a/utils/remote/deploy.go
+++ b/utils/remote/deploy.go
@@ -1,0 +1,186 @@
+package remote
+
+import (
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/eclipse/codewind-installer/utils"
+	"github.com/eclipse/codewind-installer/utils/remote/kube"
+	logr "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// DeployOptions : Keycloak initial config
+type DeployOptions struct {
+	Namespace             string
+	IngressDomain         string
+	InstallKeycloak       bool
+	KeycloakUser          string
+	KeycloakPassword      string
+	KeycloakDevUser       string
+	KeycloakDevPassword   string
+	KeycloakRealm         string
+	KeycloakClient        string
+	KeycloakSecure        bool
+	KeycloakTLSSecure     bool
+	GateKeeperTLSSecure   bool
+	CodewindSessionSecret string
+	ClientSecret          string
+}
+
+// DeploymentResult : Ingress root URLs
+type DeploymentResult struct {
+	GatekeeperURL string
+	KeycloakURL   string
+}
+
+// DeployRemote : InstallRemote
+func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemInstError) {
+
+	kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logr.Infof("Unable to retrieve Kubernetes clientset %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	namespace := remoteDeployOptions.Namespace
+	// Get the current namespace
+	if namespace == "" {
+		namespace = kube.GetCurrentNamespace()
+	}
+
+	logr.Infof("Using namespace : %v\n", namespace)
+
+	pfeImage, performanceImage, keycloakImage, gatekeeperImage := GetImages()
+
+	logr.Infoln("Container images : ")
+	logr.Infoln(pfeImage)
+	logr.Infoln(performanceImage)
+	logr.Infoln(keycloakImage)
+	logr.Infoln(gatekeeperImage)
+
+	// Determine if we're running on OpenShift or not.
+	onOpenShift := kube.DetectOpenShift(config)
+	logr.Infof("Running on openshift: %t\n", onOpenShift)
+
+	workspaceID := strings.ToLower(strconv.FormatInt(utils.CreateTimestamp(), 36))
+
+	// Get the ingress host
+	ingressDomain := remoteDeployOptions.IngressDomain
+
+	// Use a supplied ingress if one was not installed
+	if remoteDeployOptions.IngressDomain == "" {
+		svcList := clientset.CoreV1().Services("ingress-nginx")
+		svc, err := svcList.List(v1.ListOptions{})
+		if err != nil && svc != nil && svc.Items != nil {
+			ingressDomain = svc.Items[0].Spec.ClusterIP + ".nip.io"
+		}
+	}
+
+	// Check ingress service installed
+	if ingressDomain == "" {
+		remoteInstError := errors.New(errNoIngressService)
+		return nil, &RemInstError{errOpNoIngress, remoteInstError, remoteInstError.Error()}
+	}
+
+	logr.Infof("Using ingress domain: %v\n", ingressDomain)
+
+	var ownerReferenceName string
+	var ownerReferenceUID types.UID
+	ownerReferenceName = "codewind" + workspaceID
+
+	logr.Errorln("TODO : Build PVC, Acct and Secret")
+	ownerReferenceUID = uuid.NewUUID()
+	workspacePVC := "codewind"
+	serviceAccountName := "codewind"
+	secretName := "codewind"
+
+	// Create the Codewind deployment object
+	codewindInstance := Codewind{
+		PFEName:            PFEPrefix + workspaceID,
+		PFEImage:           pfeImage,
+		PerformanceName:    PerformancePrefix + workspaceID,
+		PerformanceImage:   performanceImage,
+		KeycloakName:       KeycloakPrefix + workspaceID,
+		KeycloakImage:      keycloakImage,
+		GatekeeperName:     GatekeeperPrefix + workspaceID,
+		GatekeeperImage:    gatekeeperImage,
+		Namespace:          namespace,
+		WorkspaceID:        workspaceID,
+		PVCName:            workspacePVC,
+		ServiceAccountName: serviceAccountName,
+		PullSecret:         secretName,
+		OwnerReferenceName: ownerReferenceName,
+		OwnerReferenceUID:  ownerReferenceUID,
+		Privileged:         true,
+		Ingress:            "-" + workspaceID + "-" + ingressDomain,
+		OnOpenShift:        onOpenShift,
+	}
+
+	err = DeployKeycloak(config, clientset, codewindInstance, remoteDeployOptions, onOpenShift)
+	if err != nil {
+		log.Printf("Codewind Keycloak failed, exiting...")
+		os.Exit(1)
+	}
+
+	err = SetupKeycloak(codewindInstance, remoteDeployOptions)
+	if err != nil {
+		log.Printf("Codewind Keycloak configuration failed, exiting...")
+		os.Exit(1)
+	}
+
+	err = DeployPFE(config, clientset, codewindInstance, remoteDeployOptions)
+	if err != nil {
+		log.Printf("Codewind deployment failed, exiting...")
+		os.Exit(1)
+	}
+
+	err = DeployPerformance(clientset, codewindInstance, remoteDeployOptions)
+	if err != nil {
+		log.Printf("Codewind deployment failed, exiting...")
+		os.Exit(1)
+	}
+
+	err = DeployGatekeeper(config, clientset, codewindInstance, remoteDeployOptions)
+	if err != nil {
+		log.Printf("Codewind Gatekeeper deployment failed, exiting...")
+		os.Exit(1)
+	}
+
+	gatekeeperURL := GatekeeperPrefix + codewindInstance.Ingress
+	keycloakURL := KeycloakPrefix + codewindInstance.Ingress
+
+	if remoteDeployOptions.GateKeeperTLSSecure {
+		gatekeeperURL = "https://" + gatekeeperURL
+	} else {
+		gatekeeperURL = "http://" + gatekeeperURL
+	}
+
+	if remoteDeployOptions.KeycloakTLSSecure {
+		keycloakURL = "https://" + keycloakURL
+	} else {
+		keycloakURL = "http://" + keycloakURL
+	}
+
+	deploymentResult := DeploymentResult{
+		GatekeeperURL: gatekeeperURL,
+		KeycloakURL:   keycloakURL,
+	}
+
+	return &deploymentResult, nil
+}

--- a/utils/remote/deploy_gatekeeper.go
+++ b/utils/remote/deploy_gatekeeper.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import (

--- a/utils/remote/deploy_gatekeeper.go
+++ b/utils/remote/deploy_gatekeeper.go
@@ -1,0 +1,293 @@
+package remote
+
+import (
+	"os"
+
+	v1 "github.com/openshift/api/route/v1"
+	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	log "github.com/sirupsen/logrus"
+	logr "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+)
+
+// DeployGatekeeper : Deploy gatekeepers
+func DeployGatekeeper(config *restclient.Config, clientset *kubernetes.Clientset, codewindInstance Codewind, deployOptions *DeployOptions) error {
+
+	log.Infoln("Preparing Codewind Gatekeeper resources")
+
+	gatekeeperSecrets := createGatekeeperSecrets(codewindInstance, deployOptions)
+	gatekeeperService := createGatekeeperService(codewindInstance)
+	gatekeeperDeploy := createGatekeeperDeploy(codewindInstance, deployOptions)
+	gatekeeperSessionSecret := createGatekeeperSessionSecret(codewindInstance, deployOptions)
+
+	serverKey, serverCert, err := createCertificate(GatekeeperPrefix+codewindInstance.Ingress, "Codewind Gatekeeper")
+	gatekeeperTLSSecret := createGatekeeperTLSSecret(codewindInstance, serverKey, serverCert)
+
+	log.Infoln("Deploying Codewind Gatekeeper Secrets")
+
+	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&gatekeeperSecrets)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Gatekeeper secrets: %v\n", err)
+		return err
+	}
+
+	log.Infoln("Deploying Codewind Gatekeeper Session Secrets")
+	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&gatekeeperSessionSecret)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind secrets: %v\n", err)
+		return err
+	}
+
+	log.Infoln("Deploying Codewind Gatekeeper TLS Secrets")
+	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&gatekeeperTLSSecret)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Gatekeeper TLS secrets: %v\n", err)
+		return err
+	}
+
+	log.Infoln("Deploying Codewind Gatekeeper Deployment")
+	_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Create(&gatekeeperDeploy)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Gatekeeper deployment: %v\n", err)
+		return err
+	}
+
+	log.Infoln("Deploying Codewind Gatekeeper Service")
+	_, err = clientset.CoreV1().Services(deployOptions.Namespace).Create(&gatekeeperService)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Gatekeeper service: %v\n", err)
+		return err
+	}
+
+	// Expose Codewind over an ingress or route
+	if codewindInstance.OnOpenShift {
+		logr.Infof("Deploying Codewind Gatekeeper Route")
+		// Deploy a route on OpenShift
+		route := createRouteGatekeeper(codewindInstance)
+		routev1client, err := routev1.NewForConfig(config)
+		if err != nil {
+			log.Printf("Error retrieving route client for OpenShift: %v\n", err)
+			os.Exit(1)
+		}
+		_, err = routev1client.Routes(codewindInstance.Namespace).Create(&route)
+		if err != nil {
+			log.Printf("Error: Unable to create route for Codewind: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		logr.Infof("Deploying Codewind Gatekeeper Ingress")
+		ingress := createIngressGatekeeper(codewindInstance)
+		_, err = clientset.ExtensionsV1beta1().Ingresses(codewindInstance.Namespace).Create(&ingress)
+		if err != nil {
+			log.Printf("Error: Unable to create ingress for Codewind Gatekeeper: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	return nil
+}
+
+func createGatekeeperTLSSecret(codewind Codewind, pemPrivateKey string, pemPublicCert string) corev1.Secret {
+	secrets := map[string]string{
+		"tls.crt": pemPublicCert,
+		"tls.key": pemPrivateKey,
+	}
+	name := "secret-codewind-tls"
+	return generateSecrets(codewind, name, secrets)
+}
+
+func createGatekeeperSessionSecret(codewind Codewind, deployOptions *DeployOptions) corev1.Secret {
+	secrets := map[string]string{
+		"session_secret": deployOptions.CodewindSessionSecret,
+	}
+	name := "secret-codewind-session"
+	return generateSecrets(codewind, name, secrets)
+}
+
+func createGatekeeperSecrets(codewind Codewind, deployOptions *DeployOptions) corev1.Secret {
+	secrets := map[string]string{
+		"client_secret": deployOptions.ClientSecret,
+	}
+	name := "secret-codewind-client"
+	return generateSecrets(codewind, name, secrets)
+}
+
+func createGatekeeperDeploy(codewind Codewind, deployOptions *DeployOptions) appsv1.Deployment {
+	labels := map[string]string{
+		"app":               GatekeeperPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+
+	volumes := []corev1.Volume{}
+	volumeMounts := []corev1.VolumeMount{}
+	envVars := setGatekeeperEnvVars(codewind, deployOptions)
+	return generateDeployment(codewind, GatekeeperPrefix, codewind.GatekeeperImage, GatekeeperContainerPort, volumes, volumeMounts, envVars, labels)
+}
+
+func createGatekeeperService(codewind Codewind) corev1.Service {
+	labels := map[string]string{
+		"app":               GatekeeperPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+	return generateService(codewind, GatekeeperPrefix, GatekeeperContainerPort, labels)
+}
+
+// createIngressGatekeeper returns a Kubernetes ingress for the Codewind Gatekeeper service
+func createIngressGatekeeper(codewind Codewind) extensionsv1.Ingress {
+	labels := map[string]string{
+		"app":               GatekeeperPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+
+	annotations := map[string]string{
+		"nginx.ingress.kubernetes.io/rewrite-target":     "/",
+		"nginx.ingress.kubernetes.io/backend-protocol":   "HTTPS",
+		"kubernetes.io/ingress.class":                    "nginx",
+		"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
+	}
+	// blockOwnerDeletion := true
+	// controller := true
+
+	return extensionsv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "extensions/v1beta1",
+			Kind:       "Ingress",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        GatekeeperPrefix + "-" + codewind.WorkspaceID,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: extensionsv1.IngressSpec{
+			TLS: []extensionsv1.IngressTLS{
+				{
+					Hosts:      []string{GatekeeperPrefix + codewind.Ingress},
+					SecretName: "secret-codewind-tls" + "-" + codewind.WorkspaceID,
+				},
+			},
+			Rules: []extensionsv1.IngressRule{
+				{
+					Host: GatekeeperPrefix + codewind.Ingress,
+					IngressRuleValue: extensionsv1.IngressRuleValue{
+						HTTP: &extensionsv1.HTTPIngressRuleValue{
+							Paths: []extensionsv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: extensionsv1.IngressBackend{
+										ServiceName: GatekeeperPrefix + "-" + codewind.WorkspaceID,
+										ServicePort: intstr.FromInt(GatekeeperContainerPort),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// createRouteGatekeeper returns an OpenShift route for the gatekeeper service
+func createRouteGatekeeper(codewind Codewind) v1.Route {
+	labels := map[string]string{
+		"app":               PFEPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+
+	weight := int32(100)
+	// blockOwnerDeletion := true
+	// controller := true
+
+	return v1.Route{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Route",
+			APIVersion: "route.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   GatekeeperPrefix + "-" + codewind.WorkspaceID,
+			Labels: labels,
+			// OwnerReferences: []metav1.OwnerReference{
+			// 	{
+			// 		APIVersion:         "apps/v1",
+			// 		BlockOwnerDeletion: &blockOwnerDeletion,
+			// 		Controller:         &controller,
+			// 		Kind:               "ReplicaSet",
+			// 		Name:               codewind.OwnerReferenceName,
+			// 		UID:                codewind.OwnerReferenceUID,
+			// 	},
+			// },
+		},
+		Spec: v1.RouteSpec{
+			Host: GatekeeperPrefix + codewind.Ingress,
+			Port: &v1.RoutePort{
+				TargetPort: intstr.FromInt(GatekeeperContainerPort),
+			},
+			TLS: &v1.TLSConfig{
+				InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
+				Termination:                   v1.TLSTerminationPassthrough,
+			},
+			To: v1.RouteTargetReference{
+				Kind:   "Service",
+				Name:   GatekeeperPrefix + "-" + codewind.WorkspaceID,
+				Weight: &weight,
+			},
+		},
+	}
+}
+
+func setGatekeeperEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.EnvVar {
+
+	keycloakURL := KeycloakPrefix + codewind.Ingress
+
+	if deployOptions.KeycloakTLSSecure {
+		keycloakURL = "https://" + keycloakURL
+	} else {
+		keycloakURL = "http://" + keycloakURL
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "AUTH_URL",
+			Value: keycloakURL,
+		},
+		{
+			Name:  "CLIENT_ID",
+			Value: deployOptions.KeycloakClient,
+		},
+		{
+			Name:  "ENABLE_AUTH",
+			Value: "1",
+		},
+		{
+			Name:  "GATEKEEPER_HOST",
+			Value: GatekeeperPrefix + codewind.Ingress,
+		},
+		{
+			Name:  "REALM",
+			Value: deployOptions.KeycloakRealm,
+		},
+		{
+			Name:  "WORKSPACE_SERVICE",
+			Value: "CODEWIND_PFE_" + codewind.WorkspaceID,
+		},
+		{
+			Name: "CLIENT_SECRET",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret-codewind-client" + "-" + codewind.WorkspaceID}, Key: "client_secret"}},
+		},
+		{
+			Name: "SESSION_SECRET",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret-codewind-session" + "-" + codewind.WorkspaceID}, Key: "session_secret"}},
+		},
+		{
+			Name:  "PORTAL_HTTPS",
+			Value: "true",
+		},
+	}
+}

--- a/utils/remote/deploy_keycloak.go
+++ b/utils/remote/deploy_keycloak.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import (

--- a/utils/remote/deploy_keycloak.go
+++ b/utils/remote/deploy_keycloak.go
@@ -1,0 +1,237 @@
+package remote
+
+import (
+	"os"
+
+	v1 "github.com/openshift/api/route/v1"
+	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	log "github.com/sirupsen/logrus"
+	logr "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+)
+
+// DeployKeycloak : Deploy Keycloak instance
+func DeployKeycloak(config *restclient.Config, clientset *kubernetes.Clientset, codewindInstance Codewind, deployOptions *DeployOptions, onOpenShift bool) error {
+	// Deploy Keycloak
+	keycloakSecrets := createKeycloakSecrets(codewindInstance, deployOptions)
+	keycloakService := createKeycloakService(codewindInstance)
+	keycloakDeploy := createKeycloakDeploy(codewindInstance)
+	serverKey, serverCert, err := createCertificate(KeycloakPrefix+codewindInstance.Ingress, "Codewind Keycloak")
+	keycloakTLSSecret := createKeycloakTLSSecret(codewindInstance, serverKey, serverCert)
+
+	log.Infoln("Deploying Codewind Keycloak Secrets")
+	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&keycloakSecrets)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Keycloak secrets: %v\n", err)
+		return err
+	}
+	_, err = clientset.CoreV1().Services(deployOptions.Namespace).Create(&keycloakService)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Keycloak service: %v\n", err)
+		return err
+	}
+	_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Create(&keycloakDeploy)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Keycloak deployment: %v\n", err)
+		return err
+	}
+
+	log.Infoln("Deploying Codewind Keycloak TLS Secrets")
+	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&keycloakTLSSecret)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Keycloak TLS secrets: %v\n", err)
+		return err
+	}
+
+	// Expose Codewind over an ingress or route
+	if onOpenShift {
+		// Deploy a route on OpenShift
+		route := createKeycloakRoute(codewindInstance)
+		routev1client, err := routev1.NewForConfig(config)
+		if err != nil {
+			log.Printf("Error retrieving route client for OpenShift: %v\n", err)
+			os.Exit(1)
+		}
+		_, err = routev1client.Routes(deployOptions.Namespace).Create(&route)
+		if err != nil {
+			log.Printf("Error: Unable to create route for Codewind: %v\n", err)
+			os.Exit(1)
+		}
+
+	} else {
+		logr.Infof("Deploying Codewind Keycloak Ingress")
+		ingress := createIngressKeycloak(codewindInstance)
+		_, err = clientset.ExtensionsV1beta1().Ingresses(deployOptions.Namespace).Create(&ingress)
+		if err != nil {
+			log.Printf("Error: Unable to create ingress for Codewind Keycloak: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	return nil
+}
+
+func createKeycloakTLSSecret(codewind Codewind, pemPrivateKey string, pemPublicCert string) corev1.Secret {
+	secrets := map[string]string{
+		"tls.crt": pemPublicCert,
+		"tls.key": pemPrivateKey,
+	}
+	name := "secret-keycloak-tls"
+	return generateSecrets(codewind, name, secrets)
+}
+
+func createKeycloakSecrets(codewind Codewind, deployOptions *DeployOptions) corev1.Secret {
+	secrets := map[string]string{
+		"keycloak-admin-user":     deployOptions.KeycloakUser,
+		"keycloak-admin-password": deployOptions.KeycloakPassword,
+	}
+	name := "secret-keycloak-user"
+	return generateSecrets(codewind, name, secrets)
+}
+
+func createKeycloakDeploy(codewind Codewind) appsv1.Deployment {
+	labels := map[string]string{
+		"app":               KeycloakPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+	volumes := []corev1.Volume{}
+	volumeMounts := []corev1.VolumeMount{}
+	envVars := setKeycloakEnvVars(codewind)
+	return generateDeployment(codewind, KeycloakPrefix, codewind.KeycloakImage, KeycloakContainerPort, volumes, volumeMounts, envVars, labels)
+}
+
+func createKeycloakService(codewind Codewind) corev1.Service {
+	labels := map[string]string{
+		"app":               KeycloakPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+	return generateService(codewind, KeycloakPrefix, KeycloakContainerPort, labels)
+}
+
+// CreateIngressKeycloak returns a Kubernetes ingress for the Codewind Keycloak service
+func createIngressKeycloak(codewind Codewind) extensionsv1.Ingress {
+	labels := map[string]string{
+		"app":               KeycloakPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+
+	annotations := map[string]string{
+		"nginx.ingress.kubernetes.io/rewrite-target":     "/",
+		"nginx.ingress.kubernetes.io/backend-protocol":   "HTTP",
+		"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
+		"kubernetes.io/ingress.class":                    "nginx",
+	}
+
+	// blockOwnerDeletion := true
+	// controller := true
+
+	return extensionsv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "extensions/v1beta1",
+			Kind:       "Ingress",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        KeycloakPrefix + "-" + codewind.WorkspaceID,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: extensionsv1.IngressSpec{
+			TLS: []extensionsv1.IngressTLS{
+				{
+					Hosts:      []string{KeycloakPrefix + codewind.Ingress},
+					SecretName: "secret-keycloak-tls" + "-" + codewind.WorkspaceID,
+				},
+			},
+			Rules: []extensionsv1.IngressRule{
+				{
+					Host: KeycloakPrefix + codewind.Ingress,
+					IngressRuleValue: extensionsv1.IngressRuleValue{
+						HTTP: &extensionsv1.HTTPIngressRuleValue{
+							Paths: []extensionsv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: extensionsv1.IngressBackend{
+										ServiceName: KeycloakPrefix + "-" + codewind.WorkspaceID,
+										ServicePort: intstr.FromInt(KeycloakContainerPort),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// createKeycloakRoute returns an OpenShift route for the Keycloak service
+func createKeycloakRoute(codewind Codewind) v1.Route {
+	labels := map[string]string{
+		"app":               KeycloakPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+
+	weight := int32(100)
+	// blockOwnerDeletion := true
+	// controller := true
+
+	return v1.Route{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Route",
+			APIVersion: "route.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   KeycloakPrefix + "-" + codewind.WorkspaceID,
+			Labels: labels,
+			// OwnerReferences: []metav1.OwnerReference{
+			// 	{
+			// 		APIVersion:         "apps/v1",
+			// 		BlockOwnerDeletion: &blockOwnerDeletion,
+			// 		Controller:         &controller,
+			// 		Kind:               "ReplicaSet",
+			// 		Name:               codewind.OwnerReferenceName,
+			// 		UID:                codewind.OwnerReferenceUID,
+			// 	},
+			// },
+		},
+		Spec: v1.RouteSpec{
+			Host: KeycloakPrefix + codewind.Ingress,
+			Port: &v1.RoutePort{
+				TargetPort: intstr.FromInt(KeycloakContainerPort),
+			},
+			TLS: &v1.TLSConfig{
+				InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
+				Termination:                   v1.TLSTerminationEdge,
+			},
+			To: v1.RouteTargetReference{
+				Kind:   "Service",
+				Name:   KeycloakPrefix + "-" + codewind.WorkspaceID,
+				Weight: &weight,
+			},
+		},
+	}
+}
+
+func setKeycloakEnvVars(codewind Codewind) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name: "KEYCLOAK_USER",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret-keycloak-user" + "-" + codewind.WorkspaceID}, Key: "keycloak-admin-user"}},
+		},
+		{
+			Name: "KEYCLOAK_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret-keycloak-user" + "-" + codewind.WorkspaceID}, Key: "keycloak-admin-password"}},
+		},
+		{
+			Name:  "PROXY_ADDRESS_FORWARDING",
+			Value: "true",
+		},
+	}
+}

--- a/utils/remote/deploy_performance.go
+++ b/utils/remote/deploy_performance.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import (

--- a/utils/remote/deploy_performance.go
+++ b/utils/remote/deploy_performance.go
@@ -1,0 +1,66 @@
+package remote
+
+import (
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DeployPerformance takes in a `codewind` object and deploys Codewind and the performance dashboard into the specified namespace
+func DeployPerformance(clientset *kubernetes.Clientset, codewind Codewind, deployOptions *DeployOptions) error {
+
+	// Deploy the Performance dashboard
+	performanceService := createPerformanceService(codewind)
+	performanceDeploy := createPerformanceDeploy(codewind)
+
+	log.Infoln("Deploying Codewind Performance Dashboard...")
+	_, err := clientset.CoreV1().Services(deployOptions.Namespace).Create(&performanceService)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Performance service: %v\n", err)
+		return err
+	}
+	_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Create(&performanceDeploy)
+	if err != nil {
+		log.Errorf("Error: Unable to create Codewind Performance deployment: %v\n", err)
+		return err
+	}
+	return nil
+}
+
+func createPerformanceDeploy(codewind Codewind) appsv1.Deployment {
+	labels := map[string]string{
+		"app":               PerformancePrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+
+	volumes := []corev1.Volume{}
+	volumeMounts := []corev1.VolumeMount{}
+	envVars := setPerformanceEnvVars(codewind)
+	return generateDeployment(codewind, PerformancePrefix, codewind.PerformanceImage, PerformanceContainerPort, volumes, volumeMounts, envVars, labels)
+}
+
+func createPerformanceService(codewind Codewind) corev1.Service {
+	labels := map[string]string{
+		"app":               PerformancePrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+	return generateService(codewind, PerformancePrefix, PerformanceContainerPort, labels)
+}
+
+func setPerformanceEnvVars(codewind Codewind) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "IN_K8",
+			Value: "true",
+		},
+		{
+			Name:  "PORTAL_HTTPS",
+			Value: "false",
+		},
+		{
+			Name:  "CODEWIND_INGRESS",
+			Value: codewind.Ingress,
+		},
+	}
+}

--- a/utils/remote/deploy_pfe.go
+++ b/utils/remote/deploy_pfe.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import (

--- a/utils/remote/deploy_pfe.go
+++ b/utils/remote/deploy_pfe.go
@@ -1,0 +1,171 @@
+package remote
+
+import (
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+)
+
+// DeployPFE : Deploy PFE instance
+func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codewindInstance Codewind, deployOptions *DeployOptions) error {
+	service := createPFEService(codewindInstance)
+	deploy := createPFEDeploy(codewindInstance)
+	log.Infoln("Deploying Codewind Service")
+	_, err := clientset.CoreV1().Services(deployOptions.Namespace).Create(&service)
+	if err != nil {
+		log.Errorf("Unable to create Codewind service: %v\n", err)
+		return err
+	}
+	_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Create(&deploy)
+	if err != nil {
+		log.Errorf("Unable to create Codewind deployment: %v\n", err)
+		return err
+	}
+	return nil
+}
+
+// createPFEDeploy : creates a Kubernetes deploy resource
+func createPFEDeploy(codewind Codewind) appsv1.Deployment {
+	labels := map[string]string{
+		"app":               "codewind-pfe",
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+	volumes, volumeMounts := setPFEVolumes(codewind)
+	envVars := setPFEEnvVars(codewind)
+	return generateDeployment(codewind, PFEPrefix, codewind.PFEImage, PFEContainerPort, volumes, volumeMounts, envVars, labels)
+}
+
+// createPFEService : creates a Kubernetes service
+func createPFEService(codewind Codewind) corev1.Service {
+	labels := map[string]string{
+		"app":               "codewind-pfe",
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+	return generateService(codewind, PFEPrefix, PFEContainerPort, labels)
+}
+
+func setPFEEnvVars(codewind Codewind) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "TEKTON_PIPELINE",
+			Value: "tekton-pipelines",
+		},
+		{
+			Name:  "IN_K8",
+			Value: "true",
+		},
+		{
+			Name:  "PORTAL_HTTPS",
+			Value: "true",
+		},
+		{
+			Name:  "KUBE_NAMESPACE",
+			Value: codewind.Namespace,
+		},
+		{
+			Name:  "TILLER_NAMESPACE",
+			Value: codewind.Namespace,
+		},
+		{
+			Name:  "CHE_WORKSPACE_ID",
+			Value: codewind.WorkspaceID,
+		},
+		{
+			Name:  "PVC_NAME",
+			Value: codewind.PVCName,
+		},
+		{
+			Name:  "SERVICE_NAME",
+			Value: "codewind-" + codewind.WorkspaceID,
+		},
+		{
+			Name:  "SERVICE_ACCOUNT_NAME",
+			Value: codewind.ServiceAccountName,
+		},
+		{
+			Name:  "MICROCLIMATE_RELEASE_NAME",
+			Value: "RELEASE-NAME",
+		},
+		{
+			Name:  "HOST_WORKSPACE_DIRECTORY",
+			Value: "/projects",
+		},
+		{
+			Name:  "CONTAINER_WORKSPACE_DIRECTORY",
+			Value: "/codewind-workspace",
+		},
+		{
+			Name:  "OWNER_REF_NAME",
+			Value: codewind.OwnerReferenceName,
+		},
+		{
+			Name:  "OWNER_REF_UID",
+			Value: string(codewind.OwnerReferenceUID),
+		},
+		{
+			Name:  "CODEWIND_PERFORMANCE_SERVICE",
+			Value: PerformancePrefix + "-" + codewind.WorkspaceID,
+		},
+		{
+			Name:  "CHE_INGRESS_HOST",
+			Value: codewind.Ingress,
+		},
+		{
+			Name:  "ON_OPENSHIFT",
+			Value: strconv.FormatBool(codewind.OnOpenShift),
+		},
+	}
+}
+
+// setPFEVolumes returns the 3 volumes & corresponding volume mounts required by the PFE container:
+// project workspace, buildah volume, and the docker registry secret (the latter of which is optional)
+func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
+	secretMode := int32(511)
+	isOptional := true
+
+	volumes := []corev1.Volume{
+		// {
+		// 	Name: "shared-workspace",
+		// 	VolumeSource: corev1.VolumeSource{
+		// 		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+		// 			ClaimName: codewind.PVCName,
+		// 		},
+		// 	},
+		// },
+		{
+			Name: "buildah-volume",
+		},
+		{
+			Name: "registry-secret",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					DefaultMode: &secretMode,
+					SecretName:  codewind.PullSecret,
+					Optional:    &isOptional,
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		// {
+		// 	Name:      "shared-workspace",
+		// 	MountPath: "/codewind-workspace",
+		// 	SubPath:   codewind.WorkspaceID + "/projects",
+		// },
+		{
+			Name:      "buildah-volume",
+			MountPath: "/var/lib/containers",
+		},
+		{
+			Name:      "registry-secret",
+			MountPath: "/tmp/secret",
+		},
+	}
+
+	return volumes, volumeMounts
+}

--- a/utils/remote/install_utils.go
+++ b/utils/remote/install_utils.go
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package remote
+
+import (
+	"encoding/json"
+)
+
+// RemInstError : Deployment package errors
+type RemInstError struct {
+	Op   string
+	Err  error
+	Desc string
+}
+
+const (
+	errOpNotFound  = "rem_not_found"
+	errOpNoIngress = "rem_no_ingress"
+)
+
+const (
+	errTargetNotFound   = "Target deployment not found"
+	errNoIngressService = "Please check you have installed ingress-nginx into your Kubernetes environment or use the --ingress flag to set the domain"
+)
+
+// RemInstError : Error formatted in JSON containing an errorOp and a description from
+// either a fault condition in the CLI, or an error payload from a REST request
+func (se *RemInstError) Error() string {
+	type Output struct {
+		Operation   string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	tempOutput := &Output{Operation: se.Op, Description: se.Err.Error()}
+	jsonError, _ := json.Marshal(tempOutput)
+	return string(jsonError)
+}
+
+// Result : status message
+type Result struct {
+	Status        string `json:"status"`
+	StatusMessage string `json:"status_message"`
+}

--- a/utils/remote/kube/kube.go
+++ b/utils/remote/kube/kube.go
@@ -1,0 +1,54 @@
+package kube
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetKubeClientConfig retrieves the Kubernetes client config from the cluster
+func GetKubeClientConfig() clientcmd.ClientConfig {
+	// Retrieve the Kube client config
+	clientconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	)
+	return clientconfig
+}
+
+// GetCurrentNamespace gets the current namespace in the Kubernetes context
+func GetCurrentNamespace() string {
+	// Instantiate loader for kubeconfig file.
+	kubeconfig := GetKubeClientConfig()
+	namespace, _, err := kubeconfig.Namespace()
+	if err != nil {
+		panic(err)
+	}
+	return namespace
+}
+
+// DetectOpenShift determines if we're running on an OpenShift cluster
+// From https://github.com/eclipse/che-operator/blob/2f639261d8b5416b2934591e12925ee0935814dd/pkg/util/util.go#L63
+func DetectOpenShift(config *rest.Config) bool {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		log.Errorf("Unable to detect if running on OpenShift: %v\n", err)
+		os.Exit(1)
+	}
+	apiList, err := discoveryClient.ServerGroups()
+	if err != nil {
+		log.Errorf("Error attempting to retrieve list of API Groups: %v\n", err)
+		os.Exit(1)
+	}
+	apiGroups := apiList.Groups
+	for _, group := range apiGroups {
+		if group.Name == "route.openshift.io" {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/remote/kube/kube.go
+++ b/utils/remote/kube/kube.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package kube
 
 import (

--- a/utils/remote/types.go
+++ b/utils/remote/types.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import "k8s.io/apimachinery/pkg/types"

--- a/utils/remote/types.go
+++ b/utils/remote/types.go
@@ -1,0 +1,35 @@
+package remote
+
+import "k8s.io/apimachinery/pkg/types"
+
+// Codewind represents a Codewind instance: name, namespace, volume, serviceaccount, and pull secrets
+type Codewind struct {
+	PFEName            string
+	PerformanceName    string
+	GatekeeperName     string
+	KeycloakName       string
+	PFEImage           string
+	PerformanceImage   string
+	GatekeeperImage    string
+	KeycloakImage      string
+	Namespace          string
+	WorkspaceID        string
+	PVCName            string
+	ServiceAccountName string
+	PullSecret         string
+	OwnerReferenceName string
+	OwnerReferenceUID  types.UID
+	Privileged         bool
+	Ingress            string
+	OnOpenShift        bool
+}
+
+// ServiceAccountPatch contains an array of imagePullSecrets that will be patched into a Kubernetes service account
+type ServiceAccountPatch struct {
+	ImagePullSecrets *[]ImagePullSecret `json:"imagePullSecrets"`
+}
+
+// ImagePullSecret represents a Kubernetes imagePullSecret
+type ImagePullSecret struct {
+	Name string `json:"name"`
+}

--- a/utils/remote/util.go
+++ b/utils/remote/util.go
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package remote
 
 import (

--- a/utils/remote/util.go
+++ b/utils/remote/util.go
@@ -1,0 +1,251 @@
+package remote
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"time"
+
+	logr "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+// GetImages returns the images that are to be used for PFE and the Performance dashboard in Codewind
+// If environment vars are set (such as $PFE_IMAGE, $PFE_TAG, $PERFORMANCE_IMAGE, or $PERFORMANCE_TAG), it will use those,
+// otherwise it defaults to the constants defined in constants/default.go
+func GetImages() (string, string, string, string) {
+	var pfeImage, performanceImage, keycloakImage, gatekeeperImage string
+	var pfeTag, performanceTag, keycloakTag, gatekeeperTag string
+
+	if pfeImage = os.Getenv("PFE_IMAGE"); pfeImage == "" {
+		pfeImage = PFEImage
+	}
+	if performanceImage = os.Getenv("PERFORMANCE_IMAGE"); performanceImage == "" {
+		performanceImage = PerformanceImage
+	}
+	if keycloakImage = os.Getenv("KEYCLOAK_IMAGE"); keycloakImage == "" {
+		keycloakImage = KeycloakImage
+	}
+	if gatekeeperImage = os.Getenv("GATEKEEPER_IMAGE"); gatekeeperImage == "" {
+		gatekeeperImage = GatekeeperImage
+	}
+	if pfeTag = os.Getenv("PFE_TAG"); pfeTag == "" {
+		pfeTag = PFEImageTag
+	}
+	if performanceTag = os.Getenv("PERFORMANCE_TAG"); performanceTag == "" {
+		performanceTag = PerformanceTag
+	}
+	if keycloakTag = os.Getenv("KEYCLOAK_TAG"); keycloakTag == "" {
+		keycloakTag = KeycloakImageTag
+	}
+	if gatekeeperTag = os.Getenv("GATEKEEPER_TAG"); gatekeeperTag == "" {
+		gatekeeperTag = GatekeeperImageTag
+	}
+	return pfeImage + ":" + pfeTag, performanceImage + ":" + performanceTag, keycloakImage + ":" + keycloakTag, gatekeeperImage + ":" + gatekeeperTag
+}
+
+// PatchServiceAccount takes in a list of secret names, and patches it to the specified service account
+func PatchServiceAccount(clientset *kubernetes.Clientset, codewind Codewind) error {
+	patch := ServiceAccountPatch{
+		ImagePullSecrets: &[]ImagePullSecret{
+			{
+				Name: codewind.PullSecret,
+			},
+		},
+	}
+
+	b, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+
+	_, err = clientset.CoreV1().ServiceAccounts(codewind.Namespace).Patch(codewind.ServiceAccountName, types.StrategicMergePatchType, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// generateDeployment returns a Kubernetes deployment object with the given name for the given image.
+// Additionally, volume/volumemounts and env vars can be specified.
+func generateDeployment(codewind Codewind, name string, image string, port int, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar, labels map[string]string) appsv1.Deployment {
+
+	//blockOwnerDeletion := true
+	//controller := true
+	replicas := int32(1)
+	deployment := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-" + codewind.WorkspaceID,
+			Namespace: codewind.Namespace,
+			Labels:    labels,
+			// OwnerReferences: []metav1.OwnerReference{
+			// 	{
+			// 		APIVersion:         "apps/v1",
+			// 		BlockOwnerDeletion: &blockOwnerDeletion,
+			// 		Controller:         &controller,
+			// 		Kind:               "ReplicaSet",
+			// 		Name:               codewind.OwnerReferenceName,
+			// 		UID:                codewind.OwnerReferenceUID,
+			// 	},
+			// },
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					//ServiceAccountName: codewind.ServiceAccountName,
+					Volumes: volumes,
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Image:           image,
+							ImagePullPolicy: ImagePullPolicy,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &codewind.Privileged,
+							},
+							VolumeMounts: volumeMounts,
+							Env:          envVars,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: int32(port),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+func generateSecrets(codewind Codewind, name string, secrets map[string]string) corev1.Secret {
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-" + codewind.WorkspaceID,
+			Namespace: codewind.Namespace,
+		},
+		StringData: secrets,
+	}
+	return secret
+}
+
+// generateService returns a Kubernetes service object with the given name, exposed over the specified port
+// for the container with the given labels.
+func generateService(codewind Codewind, name string, port int, labels map[string]string) corev1.Service {
+	//blockOwnerDeletion := true
+	//controller := true
+	service := corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-" + codewind.WorkspaceID,
+			Namespace: codewind.Namespace,
+			Labels:    labels,
+			// OwnerReferences: []metav1.OwnerReference{
+			// 	{
+			// 		APIVersion:         "apps/v1",
+			// 		BlockOwnerDeletion: &blockOwnerDeletion,
+			// 		Controller:         &controller,
+			// 		Kind:               "ReplicaSet",
+			// 		Name:               codewind.OwnerReferenceName,
+			// 		UID:                codewind.OwnerReferenceUID,
+			// 	},
+			// },
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port: int32(port),
+					Name: name + "-http",
+				},
+			},
+			Selector: labels,
+		},
+	}
+	return service
+}
+
+func createCertificate(dnsName string, certTitle string) (string, string, error) {
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{certTitle},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 180),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{dnsName},
+	}
+
+	logr.Println("Creating " + dnsName + " server Key")
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		logr.Errorln("Unable to create server key")
+		return "", "", err
+	}
+
+	logr.Println("Creating " + dnsName + " server certificate")
+	certDerBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(privateKey), privateKey)
+	if err != nil {
+		logr.Errorf("Failed to create certificate: %s\n", err)
+		return "", "", err
+	}
+
+	out := &bytes.Buffer{}
+	pem.Encode(out, &pem.Block{Type: "CERTIFICATE", Bytes: certDerBytes})
+	pemPublicCert := out.String()
+	out.Reset()
+	pem.Encode(out, pemBlockForKey(privateKey))
+	pemPrivateKey := out.String()
+	out.Reset()
+
+	return pemPrivateKey, pemPublicCert, nil
+}
+
+func publicKey(privateKey interface{}) interface{} {
+	switch k := privateKey.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}
+
+func pemBlockForKey(privateKey interface{}) *pem.Block {
+	switch k := privateKey.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
## Problem

Need a way to Install Codewind Remote, Keycloak, Gatekeeper and Performance containers

## Solution

This PR adds a way to deploy and configure the required Kube services

## Example usage : 

**Create a namespace to install into : **

```
kubectl create namespace {your_namespace};
```


**On Kubernetes for Docker Mac**

If not already installed you will need to install an ingress load balancer into your Kube environment eg:

```
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml

kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
```
 
**Use CLI to create the remote deployment**

```
cwctl --insecure install remote \
  --namespace {your_namespace}  \
  --kadminuser admin \
  --kadminpass <keycloakPassword>  \
  --krealm codewind \
  --kclient codewind  \
  --kdevuser developer \
  --kdevpass  <userPassword>
```
  
**For Openshift** 

```
cwctl --insecure install remote \
  --namespace {your_namespace}  \
  --kadminuser admin \
  --kadminpass <keycloakPassword>  \
  --krealm codewind \
  --kclient codewind  \
  --kdevuser developer \
  --kdevpass  <userPassword>
  --ingress "apps.myopenshiftserver.10.20.30.40.nip.io"
```

Example output : 

```
INFO[0000] Using namespace : {your_namespace}                   
INFO[0000] Container images :                           
INFO[0000] eclipse/codewind-pfe-amd64:latest            
INFO[0000] eclipse/codewind-performance-amd64:latest    
INFO[0000] marko11/codewind-keycloak-amd64:latest         <---- 
INFO[0000] marko11/codewind-gatekeeper-amd64:latest       <---- 
INFO[0000] Running on openshift: false                  
INFO[0000] Using ingress domain: 10.20.30.40.nip.io    
INFO[0000] Creating codewind-keycloak-k2brrr7a-10.20.30.40.nip.io server Key 
INFO[0000] Creating codewind-keycloak-k2brrr7a-10.20.30.40.nip.io server certificate 
INFO[0000] Deploying Codewind Keycloak Secrets          
INFO[0000] Deploying Codewind Keycloak TLS Secrets      
INFO[0000] Deploying Codewind Keycloak Ingress          
INFO[0000] Waiting for Keycloak to start                
...............
INFO[0029] Configuring Keycloak...                      
INFO[0029] https://codewind-keycloak-k2brrr7a-10.20.30.40.nip.io
INFO[0030] Creating Keycloak realm                      
INFO[0031] Creating Keycloak client                     
INFO[0031] Creating Keycloak initial user               
INFO[0031] Updating Keycloak user password              
INFO[0032] Fetching client secret                       
INFO[0032] Deploying Codewind Service                   
INFO[0032] Deploying Codewind Performance Dashboard...  
INFO[0032] Preparing Codewind Gatekeeper resources      
INFO[0032] Creating codewind-gatekeeper-k2brrr7a-10.20.30.40.nip.io server Key 
INFO[0032] Creating codewind-gatekeeper-k2brrr7a-10.20.30.40.nip.io server certificate 
INFO[0032] Deploying Codewind Gatekeeper Secrets        
INFO[0032] Deploying Codewind Gatekeeper Session Secrets 
INFO[0032] Deploying Codewind Gatekeeper TLS Secrets    
INFO[0032] Deploying Codewind Gatekeeper Deployment     
INFO[0032] Deploying Codewind Gatekeeper Service        
INFO[0032] Deploying Codewind Gatekeeper Ingress        
INFO[0032] Waiting for Codewind Gatekeeper to start on https://codewind-gatekeeper-k2brrr7a-10.20.30.40.nip.io 
........
INFO[0039] Waiting for Codewind PFE to start            
.
INFO[0039] Codewind is available at: https://codewind-gatekeeper-k2brrr7a-10.20.30.40.nip.io
```

## Authentication: 

Add a connection to the remote deployment : 

```
cwctl --insecure connections add --label MyTestKubeCluster --url https://codewind-gatekeeper-k2brrr7a-10.20.30.40.nip.io

{"status":"OK","status_message":"Connection added","id":"K2BPWS07"}
```

4. Update keyring with credentials:

```
cwctl seckeyring update --username developer --password  {my password} --conid K2BPWS07 

{"status":"OK"}
```
5. Obtain an access token for use with PFE :

```
 cwctl --insecure sectoken get --username developer --conid K2BPWS07

{
        "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSl.....
```


## TODO : 

1. Replace temporary images with eclipse/* docker images for gatekeeper and keycloak
2. Add socket.io authentication for IDEs to use
3. Enable PFE REST backed commands (like bind / sync) to use obtained authentication tokens



Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>