### PR TITLE
remove codewind project containers and networks before start

### DIFF
--- a/actions/start.go
+++ b/actions/start.go
@@ -28,6 +28,10 @@ func StartCommand(c *cli.Context, tempFilePath string, healthEndpoint string) {
 		tag := c.String("tag")
 		debug := c.Bool("debug")
 		fmt.Println("Debug:", debug)
+
+		// Stop all running project containers and remove codewind networks
+		StopAllCommand()
+
 		utils.CreateTempFile(tempFilePath)
 		utils.WriteToComposeFile(tempFilePath, debug)
 		utils.DockerCompose(tempFilePath, tag)

--- a/actions/stop-all.go
+++ b/actions/stop-all.go
@@ -41,4 +41,14 @@ func StopAllCommand() {
 			}
 		}
 	}
+
+	networkName := "codewind"
+	networks := utils.GetNetworkList()
+	fmt.Println("Removing Codewind docker networks..")
+	for _, network := range networks {
+		if strings.Contains(network.Name, networkName) {
+			fmt.Print("Removing docker network: ", network.Name, "... ")
+			utils.RemoveNetwork(network)
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

For issue https://github.com/eclipse/codewind/issues/611

If the `codewind_network` has already existed, but with a different `com.docker.network.bridge.host_binding_ipv4`. It needs to be recreated to apply the change.

All project containers need to be stopped before removing the `codewind_network`.

Run `stop-all` to stop all running codewind containers and remove `codewind_network` to fix this issue. 