### PR TITLE
Set default flag for remote deploy

### DIFF
--- a/actions/install.go
+++ b/actions/install.go
@@ -12,8 +12,10 @@
 package actions
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -48,6 +50,10 @@ func InstallCommand(c *cli.Context) {
 
 // DoRemoteInstall : Deploy a remote PFE and support containers
 func DoRemoteInstall(c *cli.Context) {
+
+	// Since remote will always use Self Signed Certificates initally, turn on insecure flag
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 	printAsJSON := c.GlobalBool("json")
 
 	session := c.String("session")


### PR DESCRIPTION
## Problem 

Codewind is initially deployed remotely using self signed certificates.  It is therefore a requirement for the CLI command to have the --insecure flag set.However if the person doing the deployment forgets to set this, the check to validate server start will fail. 

## Solution

We always install with self signed certificates,  the disable certificate checking flag should be turned on by default for the cwctl install remote command.   This PR disables certificate checking for the install remote command. 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>