### PR TITLE
Remove bind mount to ensure PFE can start on Windows.

### DIFF
--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/eclipse/codewind-installer/errors"
 	"github.com/google/go-github/github"
-	"gopkg.in/yaml.v3"
 )
 
 // CreateTempFile in the same directory as the binary for docker compose
@@ -49,29 +48,9 @@ func CreateTempFile(filePath string) bool {
 	return false
 }
 
-// WriteToComposeFile the contents of the docker compose yaml
-func WriteToComposeFile(tempFilePath string, debug bool) bool {
-	if tempFilePath == "" {
-		return false
-	}
-
-	dataStruct := Compose{}
-
-	unmarshDataErr := yaml.Unmarshal([]byte(data), &dataStruct)
-	errors.CheckErr(unmarshDataErr, 202, "")
-
-	marshalledData, err := yaml.Marshal(&dataStruct)
-	errors.CheckErr(err, 203, "")
-
-	if debug == true {
-		fmt.Printf("==> %s structure is: \n%s\n\n", tempFilePath, string(marshalledData))
-	} else {
-		fmt.Println("==> environment structure written to " + tempFilePath)
-	}
-
-	err = ioutil.WriteFile(tempFilePath, marshalledData, 0644)
+func WriteToTempFile(tempFilePath string, marshalledData []byte) {
+	err := ioutil.WriteFile(tempFilePath, marshalledData, 0644)
 	errors.CheckErr(err, 204, "")
-	return true
 }
 
 // DeleteTempFile once the the Codewind environment has been created


### PR DESCRIPTION
This PR disables bind mounts on Windows to allow pfe to start, it also moves docker-compose code to docker.go.

This is for  https://github.com/eclipse/codewind/issues/910

Signed-off-by: Howard Hellyer <hhellyer@uk.ibm.com>