### PR TITLE
Remove Initialize Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ brew upgrade dep
 |Command         |Alias         |Usage                                                               |
 |----------------|--------------|--------------------------------------------------------------------|
 |project         |              |'Manage Codewind projects'                                          |
-|install         |`in`          |'Pull pfe, performance & initialize images from dockerhub'          |
+|install         |`in`          |'Pull pfe & performance images from dockerhub'          |
 |start           |              |'Start the Codewind containers'                                     |
 |status          |              |'Print the installation status of Codewind'                         |
 |stop            |              |'Stop the running Codewind containers'                              |

--- a/actions/commands.go
+++ b/actions/commands.go
@@ -151,7 +151,7 @@ func Commands() {
 		{
 			Name:    "install",
 			Aliases: []string{"in"},
-			Usage:   "Pull pfe, performance & initialize images from dockerhub",
+			Usage:   "Pull pfe and performance images from dockerhub",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "tag, t",

--- a/actions/install.go
+++ b/actions/install.go
@@ -32,13 +32,11 @@ func InstallCommand(c *cli.Context) {
 	tag := c.String("tag")
 	jsonOutput := c.Bool("json") || c.GlobalBool("json")
 
-	imageArr := [3]string{"docker.io/eclipse/codewind-pfe-amd64:",
-		"docker.io/eclipse/codewind-performance-amd64:",
-		"docker.io/eclipse/codewind-initialize-amd64:"}
+	imageArr := [2]string{"docker.io/eclipse/codewind-pfe-amd64:",
+		"docker.io/eclipse/codewind-performance-amd64:"}
 
-	targetArr := [3]string{"codewind-pfe-amd64:",
-		"codewind-performance-amd64:",
-		"codewind-initialize-amd64:"}
+	targetArr := [2]string{"codewind-pfe-amd64:",
+		"codewind-performance-amd64:"}
 
 	for i := 0; i < len(imageArr); i++ {
 		utils.PullImage(imageArr[i]+tag, jsonOutput)

--- a/actions/remove.go
+++ b/actions/remove.go
@@ -25,7 +25,6 @@ func RemoveCommand(c *cli.Context) {
 	imageArr := []string{
 		"eclipse/codewind-pfe-amd64:" + tag,
 		"eclipse/codewind-performance-amd64:" + tag,
-		"eclipse/codewind-initialize-amd64:" + tag,
 		"cw-",
 	}
 	networkName := "codewind"

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -162,7 +162,7 @@ func DockerCompose(tempFilePath string, tag string) {
 	}
 }
 
-// PullImage - pull pfe/performance/initialize images from dockerhub
+// PullImage - pull pfe/performance images from dockerhub
 func PullImage(image string, jsonOutput bool) {
 	ctx := context.Background()
 	cli, err := client.NewEnvClient()
@@ -220,10 +220,9 @@ func CheckContainerStatus() bool {
 // CheckImageStatus of Codewind installed/uninstalled
 func CheckImageStatus() bool {
 	var imageStatus = false
-	imageArr := [3]string{}
+	imageArr := [2]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
-	imageArr[2] = "eclipse/codewind-initialize"
 
 	images := GetImageList()
 
@@ -236,7 +235,7 @@ func CheckImageStatus() bool {
 			}
 		}
 	}
-	if imageCount >= 3 {
+	if imageCount >= 2 {
 		imageStatus = true
 	}
 
@@ -343,10 +342,9 @@ func GetPFEHostAndPort() (string, string) {
 
 // GetImageTags of Codewind images
 func GetImageTags() []string {
-	imageArr := [3]string{}
+	imageArr := [2]string{}
 	imageArr[0] = "eclipse/codewind-pfe"
 	imageArr[1] = "eclipse/codewind-performance"
-	imageArr[2] = "eclipse/codewind-initialize"
 	tagArr := []string{}
 
 	images := GetImageList()


### PR DESCRIPTION
## Problem: 

Removed initialize container

## Solution: 

Removed intialize container

## Ran tests:

bats integration.bats 
 ✓ invoke install command - install latest with --json
 - invoke status -j command - output = '{status:stopped,installed-versions:[latest]}' (skipped)
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✓ invoke con reset command - reset connections file
 ✓ invoke con list command - contains just 1 local connection
 - invoke con add command - add new connection to the list (skipped)
 - invoke con list command - ensure both connections exist  (skipped)
 - invoke con target command - set a target to something unknown (skipped)
 - invoke con target command - set the target to kube (skipped)
 - invoke con target command - check the target is now kube (skipped)
 - invoke con remove command - delete target kube (skipped)
 ✓ invoke con target command - check target returns to local
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect connection)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>