### PR TITLE
Move built binaries to the top level for jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,9 @@ spec:
                         CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o cwctl-linux
                         chmod -v +x cwctl-*
 
+                        # move the built binaries to the top level direcotory
+                        mv cwctl-* ../../
+                        cd ../../
                     '''
                 }
             }


### PR DESCRIPTION
**Problem**
Previous merge #187 broke the build process. After `cd cli/cmd` command in the jenkins file, the binaries were being built in the correct place but further down in the the `build` stage it was expecting the binaries to be at the top level of the directory. There is also no directory reset so once down into `cli/cmd`, it isn't coming back up to the expected level.

**Solution**
Move the binaries from the directory they are built in `/cmd/cli` to the top level of the project and jump back up to the top level directory as expected later on in the jenkins build. This should fix the failing master build.

**Testing**
Tested on {WIP} PR https://github.com/eclipse/codewind-installer/pull/182/ 
This test PR is submitted by toby and therefore the jenkins changes were ran. It has passed the Jenkins build with these changes in place.

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>