### PR TITLE
syncFiles: turn Windows paths into *NIX paths for upload

### DIFF
--- a/pkg/utils/project/sync.go
+++ b/pkg/utils/project/sync.go
@@ -124,7 +124,8 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 			if shouldIgnore {
 				return nil
 			}
-			relativePath := path[(len(projectPath) + 1):]
+			// use ToSlash to try and get both Windows and *NIX paths to be *NIX for pfe
+			relativePath := filepath.ToSlash(path[(len(projectPath) + 1):])
 			// Create list of all files for a project
 			fileList = append(fileList, relativePath)
 


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

When uploading from Windows, the Windows file separator (\) was being interpreted as a character in the file name. This resulted in project uploads being a flat series of files names after their relative directories, which unsurprisingly wouldn't then build. This PR will change all file separators in the path to forward slashes (/). When reaching the PFE container (based on CentOS, a *NIX system) these will correctly interpret these as file separators, and the correct buildable directory structure will be preserved.