### PR TITLE
CLI Che Sync Fix 

### DIFF
--- a/pkg/utils/connections/connection.go
+++ b/pkg/utils/connections/connection.go
@@ -239,12 +239,23 @@ func saveConnectionsConfigFile(ConnectionConfig *ConnectionConfig) *ConError {
 
 // getConnectionConfigDir : get directory path to the connections file
 func getConnectionConfigDir() string {
-	const GOOS string = runtime.GOOS
+	val, isSet := os.LookupEnv("CHE_API_EXTERNAL")
 	homeDir := ""
-	if GOOS == "windows" {
-		homeDir = os.Getenv("USERPROFILE")
+	if isSet && (val != "") {
+		val, isSet := os.LookupEnv("CHE_PROJECTS_ROOT")
+		if isSet && (val != "") {
+			homeDir = val
+		} else {
+			// Cannot set projects root without env variable, suggests issue with Codewind Che installation
+			panic("CHE_PROJECTS_ROOT not set")
+		}
 	} else {
-		homeDir = os.Getenv("HOME")
+		const GOOS string = runtime.GOOS
+		if GOOS == "windows" {
+			homeDir = os.Getenv("USERPROFILE")
+		} else {
+			homeDir = os.Getenv("HOME")
+		}
 	}
 	return path.Join(homeDir, ".codewind", "config")
 }

--- a/pkg/utils/project/projectDeployment.go
+++ b/pkg/utils/project/projectDeployment.go
@@ -158,12 +158,23 @@ func RemoveConnectionFile(projectID string) *ProjectError {
 
 // getProjectConnectionConfigDir : Get directory path to the connection file
 func getProjectConnectionConfigDir() string {
-	const GOOS string = runtime.GOOS
+	val, isSet := os.LookupEnv("CHE_API_EXTERNAL")
 	homeDir := ""
-	if GOOS == "windows" {
-		homeDir = os.Getenv("USERPROFILE")
+	if isSet && (val != "") {
+		val, isSet := os.LookupEnv("CHE_PROJECTS_ROOT")
+		if isSet && (val != "") {
+			homeDir = val
+		} else {
+			// Cannot set projects root without env variable, suggests issue with Codewind Che installation
+			panic("CHE_PROJECTS_ROOT not set")
+		}
 	} else {
-		homeDir = os.Getenv("HOME")
+		const GOOS string = runtime.GOOS
+		if GOOS == "windows" {
+			homeDir = os.Getenv("USERPROFILE")
+		} else {
+			homeDir = os.Getenv("HOME")
+		}
 	}
 	return path.Join(homeDir, ".codewind", "config", "connections")
 }


### PR DESCRIPTION
- Moving connection and projects dirs to use the shared workspace between Theia and sidecar when on Che
- Performs a check to see if Che environment variables are set to see if the CLI is being run in Che before setting the home dir
- Allows connection data to be shared between the two copies of cwctl, fixing [issue 906](https://github.com/eclipse/codewind/issues/906)

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>