### PR TITLE
Fix error return codes

### DIFF
--- a/integration.bats
+++ b/integration.bats
@@ -160,8 +160,9 @@
   run go run main.go seckeyring validate --conid remoteNotKnown --username testuser
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "$output" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
+  [ "${lines[1]}" = "exit status 1" ]
+  [ "$status" -eq 1 ]
 }
 
 @test "invoke seckeyring validate command - key not found (incorrect username)"  {
@@ -169,7 +170,8 @@
   run go run main.go seckeyring validate --conid local --username testuser_unknown
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "$output" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
+  [ "${lines[1]}" = "exit status 1" ]
+  [ "$status" -eq 1 ]
 }
 

--- a/pkg/actions/connection.go
+++ b/pkg/actions/connection.go
@@ -27,7 +27,7 @@ func ConnectionAddToList(c *cli.Context) {
 	connection, err := connections.AddConnectionToList(http.DefaultClient, c)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	type Result struct {
@@ -47,7 +47,7 @@ func ConnectionGetByID(c *cli.Context) {
 	connection, err := connections.GetConnectionByID(connectionID)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(connection)
 	fmt.Println(string(response))
@@ -59,7 +59,7 @@ func ConnectionRemoveFromList(c *cli.Context) {
 	err := connections.RemoveConnectionFromList(c)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(connections.Result{Status: "OK", StatusMessage: "Connection removed"})
 	fmt.Println(string(response))
@@ -71,7 +71,7 @@ func ConnectionListAll() {
 	allConnections, err := connections.GetConnectionsConfig()
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(allConnections)
 	fmt.Println(string(response))
@@ -83,7 +83,7 @@ func ConnectionResetList() {
 	err := connections.ResetConnectionsFile()
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(connections.Result{Status: "OK", StatusMessage: "Connection list reset"})
 	fmt.Println(string(response))

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -81,7 +81,7 @@ func DoRemoteInstall(c *cli.Context) {
 		} else {
 			logr.Errorf("Error: %v - %v\n", remInstError.Op, remInstError.Desc)
 		}
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	gatekeeperURL := deploymentResult.GatekeeperURL

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -26,6 +26,7 @@ func ProjectValidate(c *cli.Context) {
 	err := project.ValidateProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 	os.Exit(0)
 }
@@ -44,6 +45,7 @@ func ProjectSync(c *cli.Context) {
 	response, err := project.SyncProject(c)
 	if err != nil {
 		fmt.Println(err.Err)
+		os.Exit(1)
 	} else {
 		if PrintAsJSON {
 			jsonResponse, _ := json.Marshal(response)
@@ -61,6 +63,7 @@ func ProjectBind(c *cli.Context) {
 	response, err := project.BindProject(c)
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	} else {
 		if PrintAsJSON {
 			jsonResponse, _ := json.Marshal(response)
@@ -90,7 +93,7 @@ func ProjectSetConnection(c *cli.Context) {
 	err := project.SetConnection(projectID, conID)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project target added successfully"})
 	fmt.Println(string(response))
@@ -103,7 +106,7 @@ func ProjectGetConnection(c *cli.Context) {
 	connectionTargets, err := project.GetConnectionID(projectID)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	fmt.Println(connectionTargets)
 	os.Exit(0)
@@ -115,7 +118,7 @@ func ProjectRemoveConnection(c *cli.Context) {
 	err := project.ResetConnectionFile(projectID)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project target removed successfully"})
 	fmt.Println(string(response))

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -36,6 +36,7 @@ func ProjectCreate(c *cli.Context) {
 	err := project.DownloadTemplate(c)
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/pkg/actions/security.go
+++ b/pkg/actions/security.go
@@ -30,6 +30,7 @@ func SecurityTokenGet(c *cli.Context) {
 		utils.PrettyPrintJSON(auth)
 	} else {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 	os.Exit(0)
 }
@@ -39,6 +40,7 @@ func SecurityCreateRealm(c *cli.Context) {
 	err := security.SecRealmCreate(c)
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	} else {
 		utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	}
@@ -50,6 +52,7 @@ func SecurityClientCreate(c *cli.Context) {
 	err := security.SecClientCreate(c)
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	} else {
 		utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	}
@@ -61,14 +64,14 @@ func SecurityClientGet(c *cli.Context) {
 	registeredClient, err := security.SecClientGet(c)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	if registeredClient != nil {
 		utils.PrettyPrintJSON(registeredClient)
 		os.Exit(0)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
-	os.Exit(0)
+	os.Exit(1)
 }
 
 // SecurityClientGetSecret : Retrieve a client secret from Keycloak
@@ -76,14 +79,14 @@ func SecurityClientGetSecret(c *cli.Context) {
 	registeredClientSecret, err := security.SecClientGetSecret(c)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	if registeredClientSecret != nil {
 		utils.PrettyPrintJSON(registeredClientSecret)
 		os.Exit(0)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
-	os.Exit(0)
+	os.Exit(1)
 }
 
 // SecurityUserCreate : Create a user in a Keycloak realm
@@ -91,6 +94,7 @@ func SecurityUserCreate(c *cli.Context) {
 	err := security.SecUserCreate(c)
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	} else {
 		utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	}
@@ -102,14 +106,14 @@ func SecurityUserGet(c *cli.Context) {
 	registeredUser, err := security.SecUserGet(c)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	if registeredUser != nil {
 		utils.PrettyPrintJSON(registeredUser)
 		os.Exit(0)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "Not found"})
-	os.Exit(0)
+	os.Exit(1)
 }
 
 // SecurityUserSetPassword : Set a users password in Keycloak
@@ -117,7 +121,7 @@ func SecurityUserSetPassword(c *cli.Context) {
 	err := security.SecUserSetPW(c)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "OK"})
 	os.Exit(0)
@@ -131,7 +135,7 @@ func SecurityKeyUpdate(c *cli.Context) {
 	err := security.SecKeyUpdate(connectionID, username, password)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(security.Result{Status: "OK"})
 	fmt.Println(string(response))
@@ -145,7 +149,7 @@ func SecurityKeyValidate(c *cli.Context) {
 	_, err := security.SecKeyGetSecret(connectionID, username)
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 	response, _ := json.Marshal(security.Result{Status: "OK"})
 	fmt.Println(string(response))

--- a/pkg/actions/status.go
+++ b/pkg/actions/status.go
@@ -59,10 +59,10 @@ func StatusCommandRemoteConnection(c *cli.Context) {
 			}
 			output, _ := json.Marshal(resp)
 			fmt.Println(string(output))
+			os.Exit(1)
 		} else {
 			fmt.Println("Codewind did not respond on remote connection", conID)
 			log.Println(err)
-			os.Exit(1)
 		}
 	}
 

--- a/pkg/actions/status.go
+++ b/pkg/actions/status.go
@@ -41,7 +41,7 @@ func StatusCommandRemoteConnection(c *cli.Context) {
 	connection, conErr := connections.GetConnectionByID(conID)
 	if conErr != nil {
 		fmt.Println(conErr)
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	PFEReady, err := apiroutes.IsPFEReady(http.DefaultClient, connection.URL)
@@ -55,15 +55,15 @@ func StatusCommandRemoteConnection(c *cli.Context) {
 			}
 			if err != nil {
 				fmt.Println(err)
-				os.Exit(0)
+				os.Exit(1)
 			}
 			output, _ := json.Marshal(resp)
 			fmt.Println(string(output))
 		} else {
 			fmt.Println("Codewind did not respond on remote connection", conID)
 			log.Println(err)
+			os.Exit(1)
 		}
-		os.Exit(0)
 	}
 
 	// Codewind responded

--- a/pkg/utils/project/bind.go
+++ b/pkg/utils/project/bind.go
@@ -15,8 +15,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -78,7 +78,8 @@ func Bind(projectPath string, name string, language string, projectType string, 
 
 	conInfo, conErr := connections.GetConnectionByID(conID)
 	if conErr != nil {
-		log.Fatalf(conErr.Op)
+		fmt.Printf(conErr.Op)
+		os.Exit(1)
 	}
 
 	bindRequest := BindRequest{

--- a/pkg/utils/project/bind.go
+++ b/pkg/utils/project/bind.go
@@ -15,8 +15,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -78,8 +78,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 
 	conInfo, conErr := connections.GetConnectionByID(conID)
 	if conErr != nil {
-		fmt.Printf(conErr.Op)
-		os.Exit(0)
+		log.Fatalf(conErr.Op)
 	}
 
 	bindRequest := BindRequest{

--- a/pkg/utils/project/bind.go
+++ b/pkg/utils/project/bind.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -78,8 +77,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 
 	conInfo, conErr := connections.GetConnectionByID(conID)
 	if conErr != nil {
-		fmt.Printf(conErr.Op)
-		os.Exit(1)
+		return nil, &ProjectError{errOpConNotFound, conErr.Err, conErr.Error()}
 	}
 
 	bindRequest := BindRequest{


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/928**
We currently have false positives on some commands and this is causing issues with how the IDE's consume output. The CLI API calls are seen as a single entity and therefore if an API call fails, it should be conveyed in the return status of the CLI command.

**Solution**
- amend return codes currently in place
- add `exit code 1` when an error is thrown but only printed. `fmt.Println()` will by default print to `stdout` and exit with a code 0 (causing the false positives in some cases)
- updated BATS testing file to handle the new return output and codes

**Testing**
- unit tests run manually
- BATS output:
```
➜  codewind-installer git:(fix-return-codes) bats integration.bats 
 ✓ invoke install command - install latest with --json
 - invoke status -j command - output = '{status:stopped,installed-versions:[latest]}' (skipped)
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✓ invoke con reset command - reset connections file
 ✓ invoke con list command - contains just 1 local connection
 - invoke con add command - add new connection to the list (skipped)
 - invoke con list command - ensure both connections exist  (skipped)
 - invoke con target command - set a target to something unknown (skipped)
 - invoke con target command - set the target to kube (skipped)
 - invoke con target command - check the target is now kube (skipped)
 - invoke con remove command - delete target kube (skipped)
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect connection)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

18 tests, 0 failures, 7 skipped
```
Signed-off-by: Liam Hampton liam.hampton@ibm.com