### PR TITLE
Remove Codewind value from template list command

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -276,12 +276,10 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{
 							Name:  "projectStyle",
-							Value: "Codewind",
 							Usage: "Filter by project style",
 						},
-						cli.StringFlag{
+						cli.BoolFlag{
 							Name:  "showEnabledOnly",
-							Value: "false",
 							Usage: "Filter by whether a template is enabled or not",
 						},
 					},

--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -26,13 +26,18 @@ import (
 func ListTemplates(c *cli.Context) {
 	templates, err := apiroutes.GetTemplates(
 		c.String("projectStyle"),
-		c.String("showEnabledOnly"),
+		c.Bool("showEnabledOnly"),
 	)
 	if err != nil {
 		log.Printf("Error getting templates: %q", err)
 		return
 	}
-	PrettyPrintJSON(templates)
+	if len(templates) > 0 {
+		PrettyPrintJSON(templates)
+	} else {
+		fmt.Println(templates)
+	}
+
 }
 
 // ListTemplateStyles lists all template styles of which Codewind is aware.

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -26,11 +26,14 @@ import (
 type (
 	// Template represents a project template.
 	Template struct {
-		Label       string `json:"label"`
-		Description string `json:"description"`
-		Language    string `json:"language"`
-		URL         string `json:"url"`
-		ProjectType string `json:"projectType"`
+		Label        string `json:"label"`
+		Description  string `json:"description"`
+		Language     string `json:"language"`
+		URL          string `json:"url"`
+		ProjectType  string `json:"projectType"`
+		ProjectStyle string `json:"projectStyle,omitempty"`
+		Source       string `json:"source,omitempty"`
+		SourceID     string `json:"sourceId,omitempty"`
 	}
 
 	// RepoOperation represents a requested operation on a template repository.
@@ -51,7 +54,7 @@ type (
 
 // GetTemplates gets project templates from PFE's REST API.
 // Filter them using the function arguments
-func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, error) {
+func GetTemplates(projectStyle string, showEnabledOnly bool) ([]Template, error) {
 	req, err := http.NewRequest("GET", config.PFEApiRoute()+"templates", nil)
 	if err != nil {
 		return nil, err
@@ -60,11 +63,11 @@ func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, erro
 	if projectStyle != "" {
 		query.Add("projectStyle", projectStyle)
 	}
-	if showEnabledOnly != "" {
-		query.Add("showEnabledOnly", showEnabledOnly)
+	if showEnabledOnly {
+		query.Add("showEnabledOnly", "true")
 	}
 	req.URL.RawQuery = query.Encode()
-
+	fmt.Println(req.URL.String())
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -80,7 +83,6 @@ func GetTemplates(projectStyle string, showEnabledOnly string) ([]Template, erro
 
 	var templates []Template
 	json.Unmarshal(byteArray, &templates)
-
 	return templates, nil
 }
 

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -67,7 +67,6 @@ func GetTemplates(projectStyle string, showEnabledOnly bool) ([]Template, error)
 		query.Add("showEnabledOnly", "true")
 	}
 	req.URL.RawQuery = query.Encode()
-	fmt.Println(req.URL.String())
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
### Summary
* `cwctl templates list` will now show all available templates rather than just the Codewind default ones.
* `cwctl templates list --showEnabledOnly` no longer needs `true` as a value as I've made it a boolean flag.
* If the number of returned templates is 0 then the CLI will print `[]` rather than `null`.
* Added `projectStyle, source, sourceId` to the Template struct as optional fields (`omitempty`) as they are in the API response. 
  * The Codewind API docs show that `source` and `sourceId` are optional hence the `omitempty`. 
  * `projectStyle` isn't present in the templates for the default templates but when searching for `--projectStyle` templates without `projectStyle` set default to Codewind. 
     * Potentially need to update the default templates [index.json](https://github.com/kabanero-io/codewind-templates/blob/master/devfiles/index.json) to include the projectStyle field for completion.

### Testing
Manual tests have been completed.
Unit tests have been changed for the new conditions and run.
