### PR TITLE
Use passed in workspace for location

### DIFF
--- a/pkg/utils/project/upgrade.go
+++ b/pkg/utils/project/upgrade.go
@@ -58,7 +58,7 @@ func UpgradeProjects(c *cli.Context) *ProjectError {
 			language := result["language"]
 			projectType := result["projectType"]
 			name := result["name"]
-			location := result["workspace"] + name
+			location := oldDir + "/" + name
 			fmt.Println("Calling bind for project " + name + "," + projectType + "," + language + " in " + location)
 
 			if language != "" && projectType != "" && name != "" && location != "" {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

I have updated the upgrade command to use determine the location of projects by using the passed in workspace location with the project name rather than information from the inf.  I've tested this on window and mac.