### PR TITLE
update readme directory to build a binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ $ brew upgrade dep
 4. Use the `cd` command to go to the `eclipse` directory that you previously created.
 5. After you go to this directory, clone the repository by typing `git clone https://github.com/eclipse/codewind-installer.git`.
 6. Use the `cd` command to go to the project directory and install the vendor packages with the `dep ensure -v` command.
-7. Build the binary and give it a name with the `go build -o <binary-name>` command. To build a binary without the debug symbols, use the `go build -ldflags="-s -w" -o <binary-name>` command.
-8. Copy your `codewind-workspace` into your `/Users/<username>` home directory.
-9. Type `./<binary-name>` in the command line window to run the CLI.
-10. To run a command, enter `./<binary-name> <command>`.
+7. Using the `cd` command, navigate into `/cmd/cli/` within the project directory.
+8. Build the binary and give it a name with the `go build -o <binary-name>` command. To build a binary without the debug symbols, use the `go build -ldflags="-s -w" -o <binary-name>` command.
+9. Copy your `codewind-workspace` into your `/Users/<username>` home directory.
+10. Type `./<binary-name>` in the command line window to run the CLI.
+11. To run a command, enter `./<binary-name> <command>`.
 
 ## Creating a cross-platform binary
 


### PR DESCRIPTION
**Problem**
The README is not explicit with the directory needed to be within for a user to build a binary when developing the CLI. If a user tries to build a binary without being in the same directory as `main.go` they will be faced with an unpleasant and somewhat less than useful error - `can't load package: package github.com/eclipse/codewind-installer: no Go files in /Users/..`

**Solution**
Add a new step (7) to explicitly tell the user to `cd` into `/cmd/cli` to be able to build a binary. 

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>