### PR TITLE
Send file permissions for uploaded files.

### DIFF
--- a/pkg/utils/project/sync.go
+++ b/pkg/utils/project/sync.go
@@ -40,6 +40,7 @@ type (
 	// FileUploadMsg is the message sent on uploading a file
 	FileUploadMsg struct {
 		IsDirectory  bool   `json:"isDirectory"`
+		Mode         uint    `json:"mode"`
 		RelativePath string `json:"path"`
 		Message      string `json:"msg"`
 	}
@@ -134,6 +135,7 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 
 			fileUploadBody := FileUploadMsg{
 				IsDirectory:  info.IsDir(),
+				Mode: uint(info.Mode().Perm()),
 				RelativePath: relativePath,
 				Message:      "",
 			}

--- a/pkg/utils/project/sync.go
+++ b/pkg/utils/project/sync.go
@@ -40,7 +40,7 @@ type (
 	// FileUploadMsg is the message sent on uploading a file
 	FileUploadMsg struct {
 		IsDirectory  bool   `json:"isDirectory"`
-		Mode         uint    `json:"mode"`
+		Mode         uint   `json:"mode"`
 		RelativePath string `json:"path"`
 		Message      string `json:"msg"`
 	}


### PR DESCRIPTION
This PR sends the file mode as a parameter on file upload so we can preserve file permissions during upload. This should ensure they match the users expectations. Git preserves file permissions as does docker. If we lose permissions between the user checking out files and building their docker image remotely then (e.g.) files that should be executable in a docker image may not be.