### PR TITLE
JSON return for UpgradeProjects

### DIFF
--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -79,7 +79,8 @@ func ProjectBind(c *cli.Context) {
 
 // UpgradeProjects : Upgrades projects
 func UpgradeProjects(c *cli.Context) {
-	err := project.UpgradeProjects(c)
+	response, err := project.UpgradeProjects(c)
+	PrettyPrintJSON(response)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)


### PR DESCRIPTION
For [#961](https://github.com/eclipse/codewind/issues/961)

Removed prints from UpgradeProjects, replaced with second return value containing a breakdown of which projects succeeded and which failed to upgrade. 

This enables UpgradeProjects to exit with code 1 if any projects fail to upgrade and allows the JSON formatted output be parsed.

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>