### PR TITLE
Set debug port for PFE in debug mode

### DIFF
--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -96,8 +96,10 @@ const internalPFEPort = 9090
 
 // constants to identify the range of external ports on which to expose PFE
 const (
-	minTCPPort = 10000
-	maxTCPPort = 11000
+	minTCPPort   = 10000
+	maxTCPPort   = 11000
+	minDebugPort = 34000
+	maxDebugPort = 35000
 )
 
 // DockerCompose to set up the Codewind environment
@@ -385,6 +387,12 @@ func IsTCPPortAvailable(minTCPPort int, maxTCPPort int) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// DetermineDebugPortForPFE determines a debug port to use for PFE based on the external PFE port
+func DetermineDebugPortForPFE() (pfeDebugPort string) {
+	_, debugPort := IsTCPPortAvailable(minDebugPort, maxDebugPort)
+	return debugPort
 }
 
 // GetContainerTags of the Codewind version(s) currently running

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -43,7 +43,8 @@ func CreateTempFile(filePath string) bool {
 		errors.CheckErr(err, 201, "")
 		defer file.Close()
 
-		fmt.Println("==> created file", filePath)
+		dir, _ := os.Getwd()
+		fmt.Println("==> created file", path.Join(dir, filePath))
 		return true
 	}
 	return false
@@ -59,6 +60,12 @@ func WriteToComposeFile(tempFilePath string, debug bool) bool {
 
 	unmarshDataErr := yaml.Unmarshal([]byte(data), &dataStruct)
 	errors.CheckErr(unmarshDataErr, 202, "")
+
+	if debug == true && len(dataStruct.SERVICES.PFE.Ports) > 0 {
+		debugPort := DetermineDebugPortForPFE()
+		// Add the debug port to the docker compose data
+		dataStruct.SERVICES.PFE.Ports = append(dataStruct.SERVICES.PFE.Ports, "127.0.0.1:"+debugPort+":9777")
+	}
 
 	marshalledData, err := yaml.Marshal(&dataStruct)
 	errors.CheckErr(err, 203, "")


### PR DESCRIPTION
Adds the debug port to the docker compose data for the PFE container when the `--debug` flag is set.

To test, run `cwctl start --debug`, you should see the pfe container start with 2 ports (PFE server port and a debug port)

Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>