### PR TITLE
Split hostname at namespace to keep length < 64 characters 

### DIFF
--- a/pkg/utils/remote/deploy.go
+++ b/pkg/utils/remote/deploy.go
@@ -140,7 +140,7 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 		OwnerReferenceName: ownerReferenceName,
 		OwnerReferenceUID:  ownerReferenceUID,
 		Privileged:         true,
-		Ingress:            "-" + workspaceID + "-" + ingressDomain,
+		Ingress:            "-" + workspaceID + "." + ingressDomain,
 		OnOpenShift:        onOpenShift,
 	}
 


### PR DESCRIPTION
## Problem

Hostnames of cloud k8s installations can have very long hostnames beyond 64 characters.  By concatenating the application name + namespace + load balancer + ingress domain the final name can be several hundred characters long.   

## Solution 

The 64 character limit is per component of the hostname.  By using a DOT separator in place of a dash at the namespace component, each component will be less than 64 chars.

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>