### PR TITLE
Testing for Upgrade Projects

### DIFF
--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -79,7 +79,8 @@ func ProjectBind(c *cli.Context) {
 
 // UpgradeProjects : Upgrades projects
 func UpgradeProjects(c *cli.Context) {
-	response, err := project.UpgradeProjects(c)
+	dir := strings.TrimSpace(c.String("workspace"))
+	response, err := project.UpgradeProjects(dir)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/pkg/project/upgrade.go
+++ b/pkg/project/upgrade.go
@@ -17,15 +17,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/urfave/cli"
 )
 
-// UpgradeProjects : Upgrade projects (local connection only)
-func UpgradeProjects(c *cli.Context) (*map[string]interface{}, *ProjectError) {
-
-	oldDir := strings.TrimSpace(c.String("workspace"))
+func UpgradeProjects(oldDir string) (*map[string]interface{}, *ProjectError) {
 	// Check to see if the workspace exists
 	_, err := os.Stat(oldDir)
 	if err != nil {
@@ -64,7 +58,7 @@ func UpgradeProjects(c *cli.Context) (*map[string]interface{}, *ProjectError) {
 			if language != "" && projectType != "" && name != "" && location != "" {
 				_, bindErr := Bind(location, name, language, projectType, "", "local")
 				if bindErr != nil {
-					errResponse := make(map[string]interface{})
+					errResponse := make(map[string]string)
 					errResponse["projectName"] = name
 					errResponse["error"] = bindErr.Desc
 					migrationStatus["failed"] = append(migrationStatus["failed"].([]interface{}), &errResponse)

--- a/pkg/project/upgrade_test.go
+++ b/pkg/project/upgrade_test.go
@@ -1,0 +1,102 @@
+/*******************************************************************************
+* Copyright (c) 2019 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package project
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UpgradeProjects(t *testing.T) {
+	workspaceFolder := "../../resources/workspaces/"
+
+	/*
+		Currently unused, awaiting valid output testing
+			validOuput := make(map[string]interface{})
+			validOuput["migrated"] = []string{"valid-project"}
+			validOuput["failed"] = make([]interface{}, 0)
+	*/
+
+	missingInfoOutput := make(map[string]interface{})
+	missingInfoOutput["migrated"] = make([]string, 0)
+	missingInfoOutput["failed"] = []interface{}{
+		&map[string]string{
+			"projectName": "missing-project-info",
+			"error":       "Unable to upgrade project, failed to determine project details",
+		},
+	}
+
+	missingDirectoryOutput := make(map[string]interface{})
+	missingDirectoryOutput["migrated"] = make([]string, 0)
+	missingDirectoryOutput["failed"] = []interface{}{
+		&map[string]string{
+			"projectName": "missing-project-dir",
+			"error":       "stat ../../resources/workspaces/error-projects/missing-project-dir/missing-project-dir: no such file or directory",
+		},
+	}
+
+	tests := map[string]struct {
+		workspaceDir   string
+		expectsErr     bool
+		expectedOutput *map[string]interface{}
+	}{
+		"success case: missing directory should return bad path error": {
+			workspaceDir:   "/does-not-exist/",
+			expectsErr:     true,
+			expectedOutput: nil,
+		},
+		"success case: missing .projects directory should return no projects error": {
+			workspaceDir:   "/no-projects-dir/",
+			expectsErr:     true,
+			expectedOutput: nil,
+		},
+		"success case: empty .projects directory returns empty output and no errors": {
+			workspaceDir:   "/empty/",
+			expectsErr:     false,
+			expectedOutput: &map[string]interface{}{"migrated": []string{}, "failed": []interface{}{}},
+		},
+		/*
+			TODO: requires API call to bind project. Needs to be mocked.
+				"success case: successfully upgrades a valid project": {
+					workspaceDir:   "/valid-projects",
+					expectsErr:     false,
+					expectedOutput: &validOuput,
+				},
+		*/
+		"success case: reports failed upgrade when project inf is mnissing information": {
+			workspaceDir:   "/error-projects/missing-project-info",
+			expectsErr:     false,
+			expectedOutput: &missingInfoOutput,
+		},
+		"success case: reports failed upgrade when project directory is missing": {
+			workspaceDir:   "/error-projects/missing-project-dir",
+			expectsErr:     false,
+			expectedOutput: &missingDirectoryOutput,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := path.Join(workspaceFolder, test.workspaceDir)
+			response, err := UpgradeProjects(path)
+
+			assert.Exactly(t, test.expectedOutput, response, "upgrade gave incorrect response")
+			if test.expectsErr {
+				assert.Error(t, err, "upgrade did not return an error when one was expected")
+			} else {
+				assert.Equal(t, (*ProjectError)(nil), err, "upgrade returned error %+v when none were expected", err)
+			}
+		})
+	}
+
+}

--- a/resources/workspaces/error-projects/missing-project-dir/.projects/missing-project-dir.inf
+++ b/resources/workspaces/error-projects/missing-project-dir/.projects/missing-project-dir.inf
@@ -1,0 +1,5 @@
+{
+    "name": "missing-project-dir",
+    "language": "go",
+    "projectType": "docker"
+}

--- a/resources/workspaces/error-projects/missing-project-info/.projects/missing-project-info.inf
+++ b/resources/workspaces/error-projects/missing-project-info/.projects/missing-project-info.inf
@@ -1,0 +1,3 @@
+{
+    "name": "missing-project-info"
+}

--- a/resources/workspaces/valid-projects/.projects/valid-project.inf
+++ b/resources/workspaces/valid-projects/.projects/valid-project.inf
@@ -1,0 +1,5 @@
+{
+  "name": "valid-project",
+  "language": "nodejs",
+  "projectType": "nodejs"
+}


### PR DESCRIPTION
Tests written for previous upgradeProjects PR, testing error and success cases, using mock workspaces placed in resources dir.

Missing tests for successful project upgrades pending mocks for API.

Changed arguments for upgradeProjects to use a path string rather than a *Context to allow for easier testing. 

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>