### PR TITLE
remove panics errors

### DIFF
--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -21,13 +21,9 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/config"
-<<<<<<< HEAD:pkg/project/bind.go
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/sechttp"
-=======
-	"github.com/eclipse/codewind-installer/pkg/utils/connections"
 	logr "github.com/sirupsen/logrus"
->>>>>>> remove panics and change var name from uploadEndURL -> bindEndURL:pkg/utils/project/bind.go
 	"github.com/urfave/cli"
 )
 

--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -21,8 +21,13 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/config"
+<<<<<<< HEAD:pkg/project/bind.go
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/sechttp"
+=======
+	"github.com/eclipse/codewind-installer/pkg/utils/connections"
+	logr "github.com/sirupsen/logrus"
+>>>>>>> remove panics and change var name from uploadEndURL -> bindEndURL:pkg/utils/project/bind.go
 	"github.com/urfave/cli"
 )
 
@@ -126,7 +131,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 
 	var projectInfo map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &projectInfo); err != nil {
-		panic(err)
+		logr.Error(err)
 	}
 
 	projectID := projectInfo["projectID"].(string)
@@ -156,18 +161,18 @@ func Bind(projectPath string, name string, language string, projectType string, 
 }
 
 func completeBind(projectID string, conURL string, username string, connection *connections.Connection) (string, int) {
-	uploadEndURL := conURL + "/api/v1/projects/" + projectID + "/bind/end"
+	bindEndURL := conURL + "/api/v1/projects/" + projectID + "/bind/end"
 
 	payload := &BindEndRequest{ProjectID: projectID}
 	jsonPayload, _ := json.Marshal(payload)
 
 	// Make the request to end the sync process.
-	request, err := http.NewRequest("POST", uploadEndURL, bytes.NewBuffer(jsonPayload))
+	request, err := http.NewRequest("POST", bindEndURL, bytes.NewBuffer(jsonPayload))
 	request.Header.Set("Content-Type", "application/json")
 	resp, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, request, username, connection.ID)
 
 	if httpSecError != nil {
-		panic(err)
+		logr.Errorln(err)
 	}
 	return resp.Status, resp.StatusCode
 }

--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -131,7 +131,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 
 	var projectInfo map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &projectInfo); err != nil {
-		logr.Error(err)
+		logr.Errorln(err)
 	}
 
 	projectID := projectInfo["projectID"].(string)


### PR DESCRIPTION
**Problem**
We shouldnt be using panic when erroring but there are two in bind.go

**Solution**
Replace `panic(err)` with `logr.Errorln(err)` to conform with PR https://github.com/eclipse/codewind-installer/pull/209 and the introduction of logrus

**Tests**
BATS test result:
`18 tests, 0 failures, 6 skipped`
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>