### PR TITLE
Error Handling for Failed Upgrades

### DIFF
--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -80,11 +80,11 @@ func ProjectBind(c *cli.Context) {
 // UpgradeProjects : Upgrades projects
 func UpgradeProjects(c *cli.Context) {
 	response, err := project.UpgradeProjects(c)
-	PrettyPrintJSON(response)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
+	PrettyPrintJSON(response)
 	os.Exit(0)
 }
 

--- a/pkg/project/upgrade.go
+++ b/pkg/project/upgrade.go
@@ -80,9 +80,5 @@ func UpgradeProjects(c *cli.Context) (*map[string]interface{}, *ProjectError) {
 		}
 		return nil
 	})
-	if len(migrationStatus["failed"].([]interface{})) > 0 {
-		err := errors.New("One or more projects failed to upgrade")
-		return &migrationStatus, &ProjectError{textUpgradeError, err, err.Error()}
-	}
 	return &migrationStatus, nil
 }


### PR DESCRIPTION
As per https://github.com/eclipse/codewind/issues/961
- CLI should exit with code 0 even if projects failed to upgrade, only exit 0 on a catastrophic failure with no JSON produced
- Only one top-level object should be printed

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>