### PR TITLE
Fix lint errors

### DIFF
--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -47,6 +47,7 @@ type (
 		ProjectID string `json:"id"`
 	}
 
+	// BindResponse represents the API response
 	BindResponse struct {
 		ProjectID     string         `json:"projectID"`
 		Status        string         `json:"status"`

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -45,11 +45,15 @@ type (
 		RelativePath string `json:"path"`
 		Message      string `json:"msg"`
 	}
+
+	// UploadedFile is the file to sync
 	UploadedFile struct {
 		FilePath   string `json:"filePath"`
 		Status     string `json:"status"`
 		StatusCode int    `json:"statusCode"`
 	}
+
+	// SyncResponse is the status of the file syncing
 	SyncResponse struct {
 		Status        string         `json:"status"`
 		StatusCode    int            `json:"statusCode"`
@@ -136,7 +140,7 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 
 			fileUploadBody := FileUploadMsg{
 				IsDirectory:  info.IsDir(),
-				Mode: uint(info.Mode().Perm()),
+				Mode:         uint(info.Mode().Perm()),
 				RelativePath: relativePath,
 				Message:      "",
 			}


### PR DESCRIPTION
**Problem**
Linter was flagging errors/warnings on some exported functions with no comments. 

**Solution**
Add the comments to the functions, fixing the errors/warning

We should look at putting golint/go vet into jenkins to testing for linter problems