### PR TITLE
Set minimum API version to 1.30

### DIFF
--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -165,7 +165,7 @@ func DockerCompose(tempFilePath string, tag string) {
 // PullImage - pull pfe/performance images from dockerhub
 func PullImage(image string, jsonOutput bool) {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
 	errors.CheckErr(err, 200, "")
 
 	var codewindOut io.ReadCloser
@@ -255,7 +255,7 @@ func RemoveImage(imageID string) {
 // GetContainerList from docker
 func GetContainerList() []types.Container {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
 	errors.CheckErr(err, 200, "")
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
@@ -267,7 +267,7 @@ func GetContainerList() []types.Container {
 // GetImageList from docker
 func GetImageList() []types.ImageSummary {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
 	errors.CheckErr(err, 200, "")
 
 	images, err := cli.ImageList(ctx, types.ImageListOptions{})
@@ -279,7 +279,7 @@ func GetImageList() []types.ImageSummary {
 // GetNetworkList from docker
 func GetNetworkList() []types.NetworkResource {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
 	errors.CheckErr(err, 200, "")
 
 	networks, err := cli.NetworkList(ctx, types.NetworkListOptions{})
@@ -291,7 +291,7 @@ func GetNetworkList() []types.NetworkResource {
 // StopContainer will stop only codewind containers
 func StopContainer(container types.Container) {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
 	errors.CheckErr(err, 200, "")
 
 	// Stop the running container
@@ -312,7 +312,7 @@ func StopContainer(container types.Container) {
 // RemoveNetwork will remove docker network
 func RemoveNetwork(network types.NetworkResource) {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
 	errors.CheckErr(err, 200, "")
 
 	if err := cli.NetworkRemove(ctx, network.ID); err != nil {


### PR DESCRIPTION
Backport of https://github.com/eclipse/codewind-installer/pull/212 to the 0.6.0 branch.

I've verified on a system with Docker API < 1.40 (1.39 specifically, as in https://github.com/eclipse/codewind/issues/731). And I'm able to start Codewind up, and bind projects.