### PR TITLE
Update an existing connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,13 @@ Subcommands:</br>
 > --label value  A displayable name
 > --url value    The ingress URL of the PFE instance
 
+`update/u` - Update an existing connection
+
+> **Flags:**
+> --conid  value   The Connection ID to update
+> --label value  A displayable name
+> --url value    The ingress URL of the PFE instance
+
 `get/g` - Get a connection using its ID
 
 > **Flags:**

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Subcommands:</br>
 > --username value              Account Username
 > --password value              Account Password
 > --client value                Client
-> --conid  value              Use connection details from a connection configuration
+> --conid value                 Use connection details from a connection configuration
 
 ## secrealm
 
@@ -297,13 +297,13 @@ Subcommands:</br>
 `update/u` - Add new or update existing Codewind credentials key in keyring
 
 > --conid  `<value>`              Connection ID (see the connections cmd)
-> --username `<value>`              Username
-> --password `<value>`              Password
+> --username `<value>`            Username
+> --password `<value>`            Password
 
 `validate/v` - Checks if credentials key exist in the keyring
 
 > --conid  `<value>`              Connection ID (see the connections cmd)
-> --username `<value>`              Username
+> --username `<value>`            Username
 
 ## secuser
 
@@ -344,25 +344,25 @@ Subcommands:</br>
 `add/a` - Add a new connection to the list
 
 > **Flags:**
-> --label value  A displayable name
-> --url value    The ingress URL of the PFE instance
+> --label value     A displayable name
+> --url value       The ingress URL of the PFE instance
 
 `update/u` - Update an existing connection
 
 > **Flags:**
-> --conid  value   The Connection ID to update
-> --label value  A displayable name
-> --url value    The ingress URL of the PFE instance
+> --conid value     The Connection ID to update
+> --label value     A displayable name
+> --url value       The ingress URL of the PFE instance
 
 `get/g` - Get a connection using its ID
 
 > **Flags:**
-> --conid  value   The Connection ID to retrieve
+> --conid value     The Connection ID to retrieve
 
 `remove/rm` - Remove a connection from the list
 
 > **Flags:**
-> --conid  value     A connection id
+> --conid value     A Connection ID
 
 `list/ls` - List known connections
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -592,6 +592,20 @@ func Commands() {
 					},
 				},
 				{
+					Name:    "update",
+					Aliases: []string{"u"},
+					Usage:   "Update and existing connection",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "conid", Usage: "Connection ID to update", Required: true},
+						cli.StringFlag{Name: "label", Usage: "A displayable name", Required: true},
+						cli.StringFlag{Name: "url", Usage: "The ingress URL of Codewind gatekeeper", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						ConnectionUpdate(c)
+						return nil
+					},
+				},
+				{
 					Name:    "get",
 					Aliases: []string{"g"},
 					Usage:   "Get a connection config by id",
@@ -620,7 +634,7 @@ func Commands() {
 					Aliases: []string{"ls"},
 					Usage:   "List known connections",
 					Action: func(c *cli.Context) error {
-						ConnectionListAll()
+						ConnectionListAll(c)
 						return nil
 					},
 				},
@@ -628,7 +642,7 @@ func Commands() {
 					Name:  "reset",
 					Usage: "Resets the connections list",
 					Action: func(c *cli.Context) error {
-						ConnectionResetList()
+						ConnectionResetList(c)
 						return nil
 					},
 				},

--- a/pkg/actions/connection.go
+++ b/pkg/actions/connection.go
@@ -19,14 +19,20 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 // ConnectionAddToList : Add new connection to the connections config file and returns the ID of the added entry
 func ConnectionAddToList(c *cli.Context) {
-	connection, err := connections.AddConnectionToList(http.DefaultClient, c)
-	if err != nil {
-		fmt.Println(err.Error())
+	printAsJSON := c.GlobalBool("json")
+	connection, conErr := connections.AddConnectionToList(http.DefaultClient, c)
+	if conErr != nil {
+		if printAsJSON {
+			fmt.Println(conErr.Error())
+		} else {
+			logr.Println(conErr.Desc)
+		}
 		os.Exit(1)
 	}
 
@@ -37,16 +43,53 @@ func ConnectionAddToList(c *cli.Context) {
 	}
 
 	response, _ := json.Marshal(Result{Status: "OK", StatusMessage: "Connection added", ConID: strings.ToUpper(connection.ID)})
-	fmt.Println(string(response))
+	if printAsJSON {
+		fmt.Println(string(response))
+	} else {
+		logr.Printf("Connection %v added successfully", strings.ToUpper(connection.ID))
+	}
+
+	os.Exit(0)
+}
+
+// ConnectionUpdate : Update an existing connection
+func ConnectionUpdate(c *cli.Context) {
+	printAsJSON := c.GlobalBool("json")
+	connection, conErr := connections.UpdateExistingConnection(http.DefaultClient, c)
+	if conErr != nil {
+		if printAsJSON {
+			fmt.Println(conErr.Error())
+		} else {
+			logr.Println(conErr.Desc)
+		}
+		os.Exit(1)
+	}
+	type Result struct {
+		Status        string `json:"status"`
+		StatusMessage string `json:"status_message"`
+		ConID         string `json:"id"`
+	}
+
+	response, _ := json.Marshal(Result{Status: "OK", StatusMessage: "Connection updated", ConID: strings.ToUpper(connection.ID)})
+	if conErr != nil {
+		fmt.Println(string(response))
+	} else {
+		logr.Printf("Connection %v updated successfully", strings.ToUpper(connection.ID))
+	}
 	os.Exit(0)
 }
 
 // ConnectionGetByID : Get connection by its id
 func ConnectionGetByID(c *cli.Context) {
+	printAsJSON := c.GlobalBool("json")
 	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	connection, err := connections.GetConnectionByID(connectionID)
-	if err != nil {
-		fmt.Println(err.Error())
+	connection, conErr := connections.GetConnectionByID(connectionID)
+	if conErr != nil {
+		if printAsJSON {
+			fmt.Println(conErr.Error())
+		} else {
+			logr.Println(conErr.Desc)
+		}
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(connection)
@@ -56,21 +99,35 @@ func ConnectionGetByID(c *cli.Context) {
 
 // ConnectionRemoveFromList : Removes a connection from the connections config file
 func ConnectionRemoveFromList(c *cli.Context) {
-	err := connections.RemoveConnectionFromList(c)
-	if err != nil {
-		fmt.Println(err.Error())
+	printAsJSON := c.GlobalBool("json")
+	conErr := connections.RemoveConnectionFromList(c)
+	if conErr != nil {
+		if printAsJSON {
+			fmt.Println(conErr.Error())
+		} else {
+			logr.Println(conErr.Desc)
+		}
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(connections.Result{Status: "OK", StatusMessage: "Connection removed"})
-	fmt.Println(string(response))
+	if printAsJSON {
+		fmt.Println(string(response))
+	} else {
+		logr.Printf("Connection removed successfully")
+	}
 	os.Exit(0)
 }
 
 // ConnectionListAll : Fetch all connections
-func ConnectionListAll() {
-	allConnections, err := connections.GetConnectionsConfig()
-	if err != nil {
-		fmt.Println(err.Error())
+func ConnectionListAll(c *cli.Context) {
+	printAsJSON := c.GlobalBool("json")
+	allConnections, conErr := connections.GetConnectionsConfig()
+	if conErr != nil {
+		if printAsJSON {
+			fmt.Println(conErr.Error())
+		} else {
+			logr.Println(conErr.Desc)
+		}
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(allConnections)
@@ -79,13 +136,22 @@ func ConnectionListAll() {
 }
 
 // ConnectionResetList : Reset to a single default local connection
-func ConnectionResetList() {
-	err := connections.ResetConnectionsFile()
-	if err != nil {
-		fmt.Println(err.Error())
+func ConnectionResetList(c *cli.Context) {
+	printAsJSON := c.GlobalBool("json")
+	conErr := connections.ResetConnectionsFile()
+	if conErr != nil {
+		if printAsJSON {
+			fmt.Println(conErr.Error())
+		} else {
+			logr.Println(conErr.Desc)
+		}
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(connections.Result{Status: "OK", StatusMessage: "Connection list reset"})
-	fmt.Println(string(response))
+	if printAsJSON {
+		fmt.Println(string(response))
+	} else {
+		logr.Printf("Connection list reset successfully")
+	}
 	os.Exit(0)
 }


### PR DESCRIPTION

## Problem 

Need a way to update connections without generating a new connection ID each time
Issue : https://github.com/eclipse/codewind/issues/1089

## Soiution 

* Add a new update command that validates the connection already exists then updates it with new parameters.
* Adds tests to check update functionality
* Displays output in both JSON or Text depending on global --json flag 

## Connections Tests (including new update test)

```
=== RUN   Test_SchemaUpgrade0to1
=== RUN   Test_SchemaUpgrade0to1/Asserts_schema_updated_to_v1_with_a_local_target
--- PASS: Test_SchemaUpgrade0to1 (0.00s)
    --- PASS: Test_SchemaUpgrade0to1/Asserts_schema_updated_to_v1_with_a_local_target (0.00s)
=== RUN   Test_GetConnectionsConfig
=== RUN   Test_GetConnectionsConfig/Asserts_there_is_only_one_connection
--- PASS: Test_GetConnectionsConfig (0.00s)
    --- PASS: Test_GetConnectionsConfig/Asserts_there_is_only_one_connection (0.00s)
=== RUN   Test_CreateNewConnection
=== RUN   Test_CreateNewConnection/Adds_new_connection_to_the_config
--- PASS: Test_CreateNewConnection (0.00s)
    --- PASS: Test_CreateNewConnection/Adds_new_connection_to_the_config (0.00s)
=== RUN   Test_UpdateConnection
=== RUN   Test_UpdateConnection/Updates_an_existing_connection
--- PASS: Test_UpdateConnection (0.00s)
    --- PASS: Test_UpdateConnection/Updates_an_existing_connection (0.00s)
=== RUN   Test_RemoveConnectionFromList
=== RUN   Test_RemoveConnectionFromList/Check_we_have_2_connections
=== RUN   Test_RemoveConnectionFromList/Remove_the_https://codewind.server.remote_connection
--- PASS: Test_RemoveConnectionFromList (0.00s)
    --- PASS: Test_RemoveConnectionFromList/Check_we_have_2_connections (0.00s)
    --- PASS: Test_RemoveConnectionFromList/Remove_the_https://codewind.server.remote_connection (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/pkg/connections   0.178s
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>