### PR TITLE
Add Username to connection and remove --username flag from Bind and Sync

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -88,7 +88,6 @@ func Commands() {
 						cli.StringFlag{Name: "type, t", Usage: "The type of the project", Required: true},
 						cli.StringFlag{Name: "path, p", Usage: "The path to the project", Required: true},
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id for the project", Required: false},
-						cli.StringFlag{Name: "username,u", Usage: "Account Username", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						ProjectBind(c)
@@ -103,7 +102,6 @@ func Commands() {
 						cli.StringFlag{Name: "path, p", Usage: "the path to the project", Required: true},
 						cli.StringFlag{Name: "id, i", Usage: "the project id", Required: true},
 						cli.StringFlag{Name: "time, t", Usage: "time of the last sync for the given project", Required: true},
-						cli.StringFlag{Name: "username,u", Usage: "Account Username", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						ProjectSync(c)
@@ -636,6 +634,7 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "label", Usage: "A displayable name", Required: true},
 						cli.StringFlag{Name: "url", Usage: "The ingress URL of Codewind gatekeeper", Required: true},
+						cli.StringFlag{Name: "username,u", Usage: "Username", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						ConnectionAddToList(c)

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -644,11 +644,12 @@ func Commands() {
 				{
 					Name:    "update",
 					Aliases: []string{"u"},
-					Usage:   "Update and existing connection",
+					Usage:   "Update an existing connection",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "conid", Usage: "Connection ID to update", Required: true},
 						cli.StringFlag{Name: "label", Usage: "A displayable name", Required: true},
 						cli.StringFlag{Name: "url", Usage: "The ingress URL of Codewind gatekeeper", Required: true},
+						cli.StringFlag{Name: "username,u", Usage: "Username", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						ConnectionUpdate(c)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,6 +25,35 @@ func TestPFEOriginError(t *testing.T) {
 			assert.Equal(t, "", got)
 			assert.Equal(t, err.Op, test.wantedErrorOp)
 			assert.Equal(t, err.Desc, test.wantedErrorDesc)
+		})
+	}
+}
+
+func TestPFEOriginFromConnection(t *testing.T) {
+	tests := map[string]struct {
+		connection    *connections.Connection
+		url           string
+		wantedErrorOp string
+	}{
+		"get templates of all styles": {
+			connection: &connections.Connection{
+				ID:       "123",
+				Label:    "connection1",
+				URL:      "ibm.com",
+				AuthURL:  "ibm.com/auth",
+				Realm:    "codewind",
+				ClientID: "codewind",
+				Username: "developer",
+			},
+			url:           "ibm.com",
+			wantedErrorOp: "config_connection_notfound",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := PFEOriginFromConnection(test.connection)
+			assert.Equal(t, test.url, got)
+			assert.Nil(t, err)
 		})
 	}
 }

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -14,7 +14,6 @@ package connections
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -214,9 +213,6 @@ func updateConnectionList(action int, httpClient utils.HTTPClient, connectionID 
 	if err != nil {
 		return nil, &ConError{errOpFileWrite, err, err.Error()}
 	}
-
-	fmt.Println("connectionID: " + connectionID)
-	fmt.Println("username: " + username)
 
 	return &newConnection, nil
 }

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -14,6 +14,7 @@ package connections
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -43,6 +44,7 @@ type Connection struct {
 	AuthURL  string `json:"auth"`
 	Realm    string `json:"realm"`
 	ClientID string `json:"clientid"`
+	Username string `json:"username"`
 }
 
 const actionUpdateEntry = 0x01
@@ -71,6 +73,7 @@ func ResetConnectionsFile() *ConError {
 				AuthURL:  "",
 				Realm:    "",
 				ClientID: "",
+				Username: "",
 			},
 		},
 	}
@@ -115,7 +118,8 @@ func AddConnectionToList(httpClient utils.HTTPClient, c *cli.Context) (*Connecti
 	conID := strings.ToUpper(strconv.FormatInt(utils.CreateTimestamp(), 36))
 	label := strings.TrimSpace(c.String("label"))
 	url := strings.TrimSpace(c.String("url"))
-	conInfo, conErr := updateConnectionList(actionAddEntry, httpClient, conID, label, url)
+	username := strings.TrimSpace(c.String("username"))
+	conInfo, conErr := updateConnectionList(actionAddEntry, httpClient, conID, label, url, username)
 	return conInfo, conErr
 }
 
@@ -124,12 +128,13 @@ func UpdateExistingConnection(httpClient utils.HTTPClient, c *cli.Context) (*Con
 	conID := strings.ToUpper(c.String("conid"))
 	label := strings.TrimSpace(c.String("label"))
 	url := strings.TrimSpace(c.String("url"))
-	conInfo, conErr := updateConnectionList(actionUpdateEntry, httpClient, conID, label, url)
+	username := strings.TrimSpace(c.String("username"))
+	conInfo, conErr := updateConnectionList(actionUpdateEntry, httpClient, conID, label, url, username)
 	return conInfo, conErr
 }
 
 // updateConnectionList : validates then adds a new connection to the connection config
-func updateConnectionList(action int, httpClient utils.HTTPClient, connectionID string, label string, url string) (*Connection, *ConError) {
+func updateConnectionList(action int, httpClient utils.HTTPClient, connectionID string, label string, url string, username string) (*Connection, *ConError) {
 	if strings.EqualFold(connectionID, "LOCAL") {
 		err := errors.New("Local is a required connection that must not be modified")
 		return nil, &ConError{errOpProtected, err, err.Error()}
@@ -146,7 +151,7 @@ func updateConnectionList(action int, httpClient utils.HTTPClient, connectionID 
 	if action == actionAddEntry {
 		for i := 0; i < len(data.Connections); i++ {
 			if strings.EqualFold(label, data.Connections[i].Label) || strings.EqualFold(url, data.Connections[i].URL) {
-				conErr := errors.New("Connection ID: " + connectionID + " already exists. Use the update command to modify")
+				conErr := errors.New("Connection ID: " + data.Connections[i].ID + " already exists. Use the update command to modify")
 				return nil, &ConError{errOpConflict, conErr, conErr.Error()}
 			}
 		}
@@ -177,6 +182,7 @@ func updateConnectionList(action int, httpClient utils.HTTPClient, connectionID 
 		AuthURL:  gatekeeperEnv.AuthURL,
 		Realm:    gatekeeperEnv.Realm,
 		ClientID: gatekeeperEnv.ClientID,
+		Username: username,
 	}
 
 	switch action {
@@ -208,6 +214,10 @@ func updateConnectionList(action int, httpClient utils.HTTPClient, connectionID 
 	if err != nil {
 		return nil, &ConError{errOpFileWrite, err, err.Error()}
 	}
+
+	fmt.Println("connectionID: " + connectionID)
+	fmt.Println("username: " + username)
+
 	return &newConnection, nil
 }
 

--- a/pkg/connections/connection_test.go
+++ b/pkg/connections/connection_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/gatekeeper"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -74,7 +74,7 @@ func Test_CreateNewConnection(t *testing.T) {
 
 	ResetConnectionsFile()
 
-	mockResponse := apiroutes.GatekeeperEnvironment{AuthURL: "http://a.mock.auth.server.remote:1234", Realm: "remoteRealm", ClientID: "remoteClient"}
+	mockResponse := gatekeeper.GatekeeperEnvironment{AuthURL: "http://a.mock.auth.server.remote:1234", Realm: "remoteRealm", ClientID: "remoteClient"}
 	jsonResponse, _ := json.Marshal(mockResponse)
 	body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 

--- a/pkg/connections/connection_test.go
+++ b/pkg/connections/connection_test.go
@@ -115,7 +115,7 @@ func Test_UpdateConnection(t *testing.T) {
 
 	ResetConnectionsFile()
 
-	mockResponse := apiroutes.GatekeeperEnvironment{AuthURL: "http://a.mock.auth.server.remote:1234", Realm: "remoteRealm", ClientID: "remoteClient"}
+	mockResponse := gatekeeper.GatekeeperEnvironment{AuthURL: "http://a.mock.auth.server.remote:1234", Realm: "remoteRealm", ClientID: "remoteClient"}
 	jsonResponse, _ := json.Marshal(mockResponse)
 	body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 

--- a/pkg/project/upgrade.go
+++ b/pkg/project/upgrade.go
@@ -56,7 +56,7 @@ func UpgradeProjects(oldDir string) (*map[string]interface{}, *ProjectError) {
 			location := oldDir + "/" + name
 
 			if language != "" && projectType != "" && name != "" && location != "" {
-				_, bindErr := Bind(location, name, language, projectType, "", "local")
+				_, bindErr := Bind(location, name, language, projectType, "local")
 				if bindErr != nil {
 					errResponse := make(map[string]string)
 					errResponse["projectName"] = name


### PR DESCRIPTION
### Summary
* Completes enhancement https://github.com/eclipse/codewind/issues/1104
* Adds a Username field to the connection struct
* Removes the need for a `--username` flag on sync, bind and in the future any other commands which use the `sechttp` library to communicate with PFE remotely.
* Adds new `PFEOriginFromConnection` function which can be used in place of `PFEOrigin` when the connection information is already in scope of a function (`connectionByID` has already been called).

#### Additional
* Fixes logging output when connection already exists when a `connection add` is attempted - output was returning a random ID rather than one for the existing connection.
* Fixes logic for previous PR when setting `https` for local PFE url.

### Testing
Manual tests to ensure bind and sync still work.
@markcor11 has also manually ran this code to see that it still works on remote deployments. 
I've also added a function for getting the PFEOrigin when the connection object already exists.

Signed-off-by: James Wallis <james.wallis1@ibm.com>