### PR TITLE
Add creation time to bind start

### DIFF
--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
@@ -41,6 +42,7 @@ type (
 		ProjectType string `json:"projectType"`
 		Name        string `json:"name"`
 		Path        string `json:"path"`
+		Time        int64  `json:"creationTime"`
 	}
 
 	// BindEndRequest represents the request body parameters required to complete a bind
@@ -73,12 +75,14 @@ func Bind(projectPath string, name string, language string, projectType string, 
 	if err != nil {
 		return nil, &ProjectError{errBadPath, err, err.Error()}
 	}
+	creationTime := time.Now().UnixNano() / 1000000
 
 	bindRequest := BindRequest{
 		Language:    language,
 		Name:        name,
 		ProjectType: projectType,
 		Path:        projectPath,
+		Time:        creationTime,
 	}
 	buf := new(bytes.Buffer)
 	json.NewEncoder(buf).Encode(bindRequest)


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Add creation time to bind/start so this value can be used to start monitoring the project. Part of the fix for https://github.com/eclipse/codewind/issues/1039