### PR TITLE
Sechttp wrapper

### DIFF
--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -75,6 +75,7 @@ func AddTemplateRepo(c *cli.Context) {
 		return
 	}
 	extensions, err := apiroutes.GetExtensions(conID)
+	fmt.Println(extensions)
 	if err == nil {
 		utils.OnAddTemplateRepo(extensions, url, repos)
 	}

--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -75,7 +75,6 @@ func AddTemplateRepo(c *cli.Context) {
 		return
 	}
 	extensions, err := apiroutes.GetExtensions(conID)
-	fmt.Println(extensions)
 	if err == nil {
 		utils.OnAddTemplateRepo(extensions, url, repos)
 	}

--- a/pkg/apiroutes/extensions.go
+++ b/pkg/apiroutes/extensions.go
@@ -38,7 +38,7 @@ func GetExtensions(conID string) ([]utils.Extension, error) {
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}

--- a/pkg/apiroutes/extensions.go
+++ b/pkg/apiroutes/extensions.go
@@ -17,18 +17,30 @@ import (
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
 
 // GetExtensions gets project extensions from PFE's REST API.
 func GetExtensions(conID string) ([]utils.Extension, error) {
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
-	resp, err := http.Get(conURL + "/api/v1/extensions")
+
+	req, err := http.NewRequest("GET", conURL+"/api/v1/extensions", nil)
 	if err != nil {
 		return nil, err
+	}
+	client := &http.Client{}
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 
 	defer resp.Body.Close()

--- a/pkg/apiroutes/ignored-paths.go
+++ b/pkg/apiroutes/ignored-paths.go
@@ -45,7 +45,7 @@ func GetIgnoredPaths(conID, projectType string, httpClient utils.HTTPClient) (Ig
 	q.Add("projectType", projectType)
 	req.URL.RawQuery = q.Encode()
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}

--- a/pkg/apiroutes/ignored-paths.go
+++ b/pkg/apiroutes/ignored-paths.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
 
@@ -26,7 +28,11 @@ type IgnoredPaths []string
 
 // GetIgnoredPaths calls pfe to get the default ignoredPaths for that projectType
 func GetIgnoredPaths(conID, projectType string, httpClient utils.HTTPClient) (IgnoredPaths, error) {
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
@@ -38,10 +44,10 @@ func GetIgnoredPaths(conID, projectType string, httpClient utils.HTTPClient) (Ig
 	q := req.URL.Query()
 	q.Add("projectType", projectType)
 	req.URL.RawQuery = q.Encode()
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
+	client := &http.Client{}
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 
 	if resp.StatusCode != 200 {

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -78,7 +78,7 @@ func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template,
 	}
 	req.URL.RawQuery = query.Encode()
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -110,7 +110,7 @@ func GetTemplateStyles(conID string) ([]string, error) {
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -142,7 +142,7 @@ func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -189,7 +189,7 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -232,7 +232,7 @@ func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
 	req, err := http.NewRequest("DELETE", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -335,7 +335,7 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -20,6 +20,8 @@ import (
 	"net/url"
 
 	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
 
@@ -55,7 +57,11 @@ type (
 // GetTemplates gets project templates from PFE's REST API.
 // Filter them using the function arguments
 func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template, error) {
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
@@ -72,9 +78,9 @@ func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template,
 	}
 	req.URL.RawQuery = query.Encode()
 	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 
 	defer resp.Body.Close()
@@ -91,15 +97,23 @@ func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template,
 
 // GetTemplateStyles gets all template styles from PFE's REST API
 func GetTemplateStyles(conID string) ([]string, error) {
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
-	resp, err := http.Get(conURL + "/api/v1/templates/styles")
+	req, err := http.NewRequest("GET", conURL+"/api/v1/templates/styles", nil)
 	if err != nil {
 		return nil, err
 	}
-
+	client := &http.Client{}
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
+	}
 	defer resp.Body.Close()
 
 	byteArray, err := ioutil.ReadAll(resp.Body)
@@ -115,13 +129,22 @@ func GetTemplateStyles(conID string) ([]string, error) {
 
 // GetTemplateRepos gets all template repos from PFE's REST API
 func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
-	resp, err := http.Get(conURL + "/api/v1/templates/repositories")
+	req, err := http.NewRequest("GET", conURL+"/api/v1/templates/repositories", nil)
 	if err != nil {
 		return nil, err
+	}
+	client := &http.Client{}
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 
 	defer resp.Body.Close()
@@ -151,18 +174,24 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 	}
 	jsonValue, _ := json.Marshal(values)
 
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
 
-	resp, err := http.Post(
-		conURL+"/api/v1/templates/repositories",
-		"application/json",
-		bytes.NewBuffer(jsonValue),
-	)
+	req, err := http.NewRequest("POST", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
+	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
+	}
+	client := &http.Client{}
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
@@ -191,22 +220,21 @@ func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
 	values := map[string]string{"url": URL}
 	jsonValue, _ := json.Marshal(values)
 
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
 
-	req, err := http.NewRequest(
-		"DELETE",
-		conURL+"/api/v1/templates/repositories",
-		bytes.NewBuffer(jsonValue),
-	)
+	req, err := http.NewRequest("DELETE", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
 	req.Header.Set("Content-Type", "application/json")
-
 	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
@@ -294,22 +322,22 @@ func DisableTemplateRepos(conID string, repoURLs []string) ([]utils.TemplateRepo
 func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubResponseFromBatchOperation, error) {
 	jsonValue, _ := json.Marshal(operations)
 
-	conURL, conErr := config.PFEOrigin(conID)
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
 		return nil, conErr.Err
 	}
 
-	req, err := http.NewRequest(
-		"PATCH",
-		conURL+"/api/v1/batch/templates/repositories",
-		bytes.NewBuffer(jsonValue),
-	)
+	req, err := http.NewRequest("PATCH", conURL+"/api/v1/batch/templates/repositories", bytes.NewBuffer(jsonValue))
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo.Username, conID)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 	if resp.StatusCode != 207 {
 		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,6 @@ package config
 
 import (
 	"os"
-	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/utils"
@@ -27,26 +26,6 @@ type ConfigError struct {
 
 const errOpConfConNotFound = "config_connection_notfound"
 const errOpConfPFEHostnamePortNotFound = "config_pfe_hostname_port_notfound"
-
-// PFEOrigin is the origin from which PFE is running, e.g. "http://127.0.0.1:9090"
-func PFEOrigin(unFormattedConID string) (string, *ConfigError) {
-	conID := strings.TrimSpace(strings.ToLower(unFormattedConID))
-	var PFEURL string
-	if conID != "local" {
-		conInfo, conErr := connections.GetConnectionByID(conID)
-		if conErr != nil {
-			return "", &ConfigError{errOpConfConNotFound, conErr.Err, conErr.Desc}
-		}
-		PFEURL = conInfo.URL
-	} else {
-		localURL, localErr := getLocalHostnameAndPort()
-		if localErr != nil {
-			return "", &ConfigError{errOpConfConNotFound, localErr.Err, localErr.Desc}
-		}
-		PFEURL = localURL
-	}
-	return PFEURL, nil
-}
 
 // PFEOriginFromConnection is used when GetConnectionByID(conID) has already been called to stop it being run twice in one function
 func PFEOriginFromConnection(connection *connections.Connection) (string, *ConfigError) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,28 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPFEOriginError(t *testing.T) {
-	tests := map[string]struct {
-		connectionID    string
-		wantedErrorOp   string
-		wantedErrorDesc string
-	}{
-		"get templates of all styles": {
-			connectionID:    "123123123",
-			wantedErrorOp:   "config_connection_notfound",
-			wantedErrorDesc: "Connection 123123123 not found",
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			got, err := PFEOrigin(test.connectionID)
-			assert.Equal(t, "", got)
-			assert.Equal(t, err.Op, test.wantedErrorOp)
-			assert.Equal(t, err.Desc, test.wantedErrorDesc)
-		})
-	}
-}
-
 func TestPFEOriginFromConnection(t *testing.T) {
 	tests := map[string]struct {
 		connection    *connections.Connection

--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -99,7 +99,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 
 	request, err := http.NewRequest("POST", bindURL, bytes.NewReader(buf.Bytes()))
 	request.Header.Set("Content-Type", "application/json")
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, request, conInfo.Username, conID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, request, conInfo)
 	if httpSecError != nil {
 		return nil, &ProjectError{errOpResponse, httpSecError.Err, httpSecError.Desc}
 	}
@@ -152,7 +152,7 @@ func completeBind(projectID string, conURL string, connection *connections.Conne
 	// Make the request to end the sync process.
 	request, err := http.NewRequest("POST", bindEndURL, bytes.NewBuffer(jsonPayload))
 	request.Header.Set("Content-Type", "application/json")
-	resp, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, request, connection.Username, connection.ID)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, request, connection)
 
 	if httpSecError != nil {
 		logr.Errorln(err)

--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -129,13 +129,6 @@ func Bind(projectPath string, name string, language string, projectType string, 
 	// Generate the .codewind/connections/{projectID}.json file based on the given conID
 	SetConnection(conID, projectID)
 
-	// Read connections.json to find the URL of the connection
-	conURL, projErr := GetConnectionURL(projectID)
-
-	if projErr != nil {
-		return nil, projErr
-	}
-
 	// Sync all the project files
 	_, _, uploadedFilesList := syncFiles(projectPath, projectID, conURL, 0, conInfo)
 

--- a/pkg/project/projectConnection_test.go
+++ b/pkg/project/projectConnection_test.go
@@ -103,14 +103,6 @@ func Test_ProjectConnection(t *testing.T) {
 		assert.Equal(t, testConnectionID, connection.ID)
 	})
 
-	t.Run("Asserts the correct host URL is returned", func(t *testing.T) {
-		hostURL, projError := GetConnectionURL(testProjectID)
-		if projError != nil {
-			t.Fail()
-		}
-		assert.Equal(t, testHost, hostURL)
-	})
-
 	t.Run("Asserts resetting the connection is successful", func(t *testing.T) {
 		projError := ResetConnectionFile(testProjectID)
 		if projError != nil {

--- a/pkg/project/projectDeployment.go
+++ b/pkg/project/projectDeployment.go
@@ -20,8 +20,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/eclipse/codewind-installer/pkg/config"
-
 	"github.com/eclipse/codewind-installer/pkg/connections"
 )
 
@@ -87,19 +85,6 @@ func GetConnection(projectID string) (*ConnectionFile, *ProjectError) {
 		return nil, projErr
 	}
 	return connectionTargets, nil
-}
-
-// GetConnectionURL : Return the connection URL for a given projectID, unique to each project connection
-func GetConnectionURL(projectID string) (string, *ProjectError) {
-	conID, err := GetConnectionID(projectID)
-	if err != nil {
-		return "", err
-	}
-	conURL, conErr := config.PFEOrigin(conID)
-	if conErr != nil {
-		return "", nil
-	}
-	return conURL, nil
 }
 
 // GetConnectionID : Gets the the connectionID for a given projectID

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -167,7 +167,7 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 				// TODO - How do we handle partial success?
 				request, err := http.NewRequest("PUT", projectUploadURL, bytes.NewReader(buf.Bytes()))
 				request.Header.Set("Content-Type", "application/json")
-				resp, httpSecError := sechttp.DispatchHTTPRequest(client, request, connection.Username, connection.ID)
+				resp, httpSecError := sechttp.DispatchHTTPRequest(client, request, connection)
 				uploadedFiles = append(uploadedFiles, UploadedFile{
 					FilePath:   relativePath,
 					Status:     resp.Status,


### PR DESCRIPTION
Implements https://github.com/eclipse/codewind/issues/1143

### Summary
* Changed API routes to talk to PFE using @markcor11's HTTPS request wrapper for remote deployments.
- [x] GetTemplates
  * Tested using `cwctl --insecure templates ls --conid K34MCHAO`. Worked as expected.
- [x] GetTemplateStyles
  * Tested using `cwctl --insecure templates styles --conid K34MCHAO`. Worked as expected, output was `["Appsody", "Codewind", "OpenShift"]`. `OpenShift` does not appear locally.
- [x] GetTemplateRepos
  * Tested using `cwctl --insecure templates repos ls --conid K34MCHAO`. Worked as expected, output was an array of 3 items: `Default Templates`, `OpenShift Templates` and `Appsody Stacks - incubator`. The `Kabenero Collection` templates were not there as is the current behaviour when running in Kubernetes.
- [x] AddTemplateRepo
  * Tested using `cwctl --insecure templates repos add --url https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json --conid K34MCHAO`. Worked as expected. First removed the repository and added it back. Adding a repo that already existed outputted a 400.
- [x] DeleteTemplateRepo
  * Tested using `cwctl --insecure templates repos rm --url https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json --conid K34MCHAO`. Worked as expected. Tested by removing an existing repository. Removing a repository that doesn't exist returned `GetTemplateRepos` output (Status must be 200).
- [x] BatchPatchTemplateRepos
  * Tested using `templates repos disable/enable`. Requested repo was disabled and enabled as expected.
- [x] GetExtensions - ~~Untested but same logic as others. Need to work out how to test.~~ Verified by adding logging to the function call.
- [x] GetIgnoredPaths - ~~Untested but same logic as others. Need to work out how to test.~~ Tested by running a `project create` and logging the output of the `ignoredPaths` API call.

### Testing
Manual tests completed as detailed above.

### Additional
* Removes the PFEOrigin function as it isn't used anywhere in the codebase anymore.