### PR TITLE
Add INGRESS_PREFIX to PFE for remote deployment

### DIFF
--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -141,8 +141,11 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 		OwnerReferenceUID:  ownerReferenceUID,
 		Privileged:         true,
 		Ingress:            "-" + workspaceID + "." + ingressDomain,
+		RequestedIngress:   ingressDomain,
 		OnOpenShift:        onOpenShift,
 	}
+
+	codewindInstance.RequestedIngress = ingressDomain
 
 	err = DeployKeycloak(config, clientset, codewindInstance, remoteDeployOptions, onOpenShift)
 	if err != nil {

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -126,6 +126,10 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 			Value: codewind.Ingress,
 		},
 		{
+			Name:  "INGRESS_PREFIX",
+			Value: codewind.RequestedIngress, // provides access to project containers
+		},
+		{
 			Name:  "ON_OPENSHIFT",
 			Value: strconv.FormatBool(codewind.OnOpenShift),
 		},

--- a/pkg/remote/types.go
+++ b/pkg/remote/types.go
@@ -32,6 +32,7 @@ type Codewind struct {
 	OwnerReferenceUID  types.UID
 	Privileged         bool
 	Ingress            string
+	RequestedIngress   string // resolved where possible or set by cli flag
 	OnOpenShift        bool
 }
 


### PR DESCRIPTION
## Problem

Addresses issue  https://github.com/eclipse/codewind/issues/1212 where INGRESS_PREFIX was  absent from a PFE container after deployment

## Solution

Add INGRESS_PREFIX using determined domain name or the supplied domain from the CLI flag.

## Tests

Manual testing to ensure that the environment was being set inside a newly deployed PFE POD : 

```
sh-4.2# printenv | grep -i  ingress
INGRESS_PREFIX=apps.<someserver>.<someip>.nip.io
```




Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>