### PR TITLE
Remote deploy - create namespace if it does not exist

### DIFF
--- a/pkg/remote/install_utils.go
+++ b/pkg/remote/install_utils.go
@@ -23,8 +23,9 @@ type RemInstError struct {
 }
 
 const (
-	errOpNotFound  = "rem_not_found"
-	errOpNoIngress = "rem_no_ingress"
+	errOpNotFound        = "rem_not_found"
+	errOpNoIngress       = "rem_no_ingress"
+	errOpCreateNamespace = "rem_create_namespace"
 )
 
 const (


### PR DESCRIPTION
## Problem

When deploying Codewind remote the namespace must already exist see issue : https://github.com/eclipse/codewind/issues/1211

## Solution

During install,  check if the namespace already exists, if not create the namespace and deploy Codewind into the newly created namespace. 

If no --namespace is provided deploy into the "current" namespace

## Log update : 

```
INFO[0000] Checking namespace marktest99 exists         
INFO[0000] Creating marktest99 namespace                
INFO[0000] Using namespace : marktest99                 
INFO[0000] Container images :                           
INFO[0000] eclipse/codewind-pfe-amd64:latest            
INFO[0000] eclipse/codewind-performance-amd64:latest    
INFO[0000] eclipse/codewind-keycloak-amd64:latest       
INFO[0000] eclipse/codewind-gatekeeper-amd64:latest     
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>