### PR TITLE
Handle HTTP 503 service unavailable

### DIFF
--- a/pkg/security/authenticate.go
+++ b/pkg/security/authenticate.go
@@ -121,6 +121,7 @@ func SecAuthenticate(httpClient utils.HTTPClient, c *cli.Context, connectionReal
 		return nil, &SecError{errOpConnection, err, err.Error()}
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Cache-Control", "no-cache")
 	req.Header.Add("cache-control", "no-cache")
 
@@ -142,6 +143,9 @@ func SecAuthenticate(httpClient utils.HTTPClient, c *cli.Context, connectionReal
 		keycloakAPIError := parseKeycloakError(string(body), res.StatusCode)
 		kcError := errors.New(string(keycloakAPIError.Error))
 		return nil, &SecError{errOpResponse, kcError, kcError.Error()}
+	case httpCode == http.StatusServiceUnavailable:
+		txtError := errors.New(textAuthIsDown)
+		return nil, &SecError{errOpResponse, txtError, txtError.Error()}
 	case httpCode != http.StatusOK:
 		err = errors.New(string(body))
 		return nil, &SecError{errOpResponse, err, err.Error()}

--- a/pkg/security/security_utils.go
+++ b/pkg/security/security_utils.go
@@ -55,6 +55,7 @@ const (
 	textUserNotFound   = "Registered User not found"
 	textUnableToParse  = "Unable to parse Keycloak response"
 	textInvalidOptions = "Invalid or missing command line options"
+	textAuthIsDown     = "Authentication service unavailable"
 )
 
 // SecError : Error formatted in JSON containing an errorOp and a description from


### PR DESCRIPTION
## Problem

If the authentication service is not running,  the CLI returns an error that is the cloud platform HTML page rather than a meaningful code.  See issue https://github.com/eclipse/codewind/issues/1216

## Solution 

**Handle special case 503** - We can extend this list of errors as needed but since there may be diagnostic data in the response, for example when the authentication service responds with a standard http code but then adds an error string like "incorrect password",  we would lose those messages if we just returned a stock response for all http codes.

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>