### PR TITLE
fix two broken bats tests

### DIFF
--- a/integration.bats
+++ b/integration.bats
@@ -47,7 +47,7 @@
 
 @test "invoke con reset command - reset connections file" {
   cd cmd/cli/
-  run go run main.go con reset
+  run go run main.go --json con reset
   echo "status = ${status}"
   echo "output trace = ${output}"
    [ "$output" = '{"status":"OK","status_message":"Connection list reset"}' ]
@@ -56,10 +56,10 @@
 
 @test "invoke con list command - contains just 1 local connection" {
   cd cmd/cli/
-  run go run main.go con list
+  run go run main.go --json con list
   echo "status = ${status}"
   echo "output trace = ${output}"
-   [ "$output" = '{"schemaversion":1,"connections":[{"id":"local","label":"Codewind local connection","url":"","auth":"","realm":"","clientid":""}]}' ]
+   [ "$output" = '{"schemaversion":1,"connections":[{"id":"local","label":"Codewind local connection","url":"","auth":"","realm":"","clientid":"","username":""}]}' ]
    [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
**Problem**
Due to recent upgrades and commits, two bats tests have been broken
1) invoke con reset command - reset connections file
2) invoke con list command - contains just 1 local connection

**Solution**
- Add the JSON flag for the test to match the expected output
- Add a missing parameter from the second failing test

**Testing**
BEFORE
```
 ✓ invoke install command - install latest with --json
 ✓ invoke status -j command - output = '{status:stopped,installed-versions:[latest]}'
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✗ invoke con reset command - reset connections file
   (in test file integration.bats, line 53)
     `[ "$output" = '{"status":"OK","status_message":"Connection list reset"}' ]' failed
   status = 0
   output trace = time="2019-11-21T11:06:36Z" level=info msg="Connection list reset successfully"
 ✗ invoke con list command - contains just 1 local connection
   (in test file integration.bats, line 62)
     `[ "$output" = '{"schemaversion":1,"connections":[{"id":"local","label":"Codewind local connection","url":"","auth":"","realm":"","clientid":"","username":""}]}' ]' failed
   status = 0
   output trace = {"schemaversion":1,"connections":[{"id":"local","label":"Codewind local connection","url":"","auth":"","realm":"","clientid":"","username":""}]}
 - invoke con add command - add new connection to the list (skipped: environment not available yet)
 - invoke con list command - ensure both connections exist  (skipped: environment not available yet)
 - invoke con target command - set a target to something unknown (skipped: environment not available yet)
 - invoke con target command - set the target to kube (skipped: environment not available yet)
 - invoke con target command - check the target is now kube (skipped: environment not available yet)
 - invoke con remove command - delete target kube (skipped: environment not available yet)
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect connection)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

18 tests, 2 failures, 6 skipped
```

AFTER
```
 ✓ invoke install command - install latest with --json
 ✓ invoke status -j command - output = '{status:stopped,installed-versions:[latest]}'
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✓ invoke con reset command - reset connections file
 ✓ invoke con list command - contains just 1 local connection
 - invoke con add command - add new connection to the list (skipped: environment not available yet)
 - invoke con list command - ensure both connections exist  (skipped: environment not available yet)
 - invoke con target command - set a target to something unknown (skipped: environment not available yet)
 - invoke con target command - set the target to kube (skipped: environment not available yet)
 - invoke con target command - check the target is now kube (skipped: environment not available yet)
 - invoke con remove command - delete target kube (skipped: environment not available yet)
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect connection)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

18 tests, 0 failures, 6 skipped
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>