### PR TITLE
Check remote image digest vs local image digest

### DIFF
--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -57,8 +57,10 @@ func InstallCommand(c *cli.Context) {
 				if jsonOutput {
 					fmt.Println(dockerError)
 				} else {
-					logr.Errorf("Validation of image %v checksum failed. Please retry manually", imageArr[i]+tag)
+					logr.Errorf("Validation of image '%v' checksum failed. Please clear your system and try again", imageArr[i]+tag)
 				}
+				// Clean up the second bad image
+				utils.RemoveImage(imageID)
 				os.Exit(1)
 			}
 		}

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -40,6 +40,7 @@ func InstallCommand(c *cli.Context) {
 
 	for i := 0; i < len(imageArr); i++ {
 		utils.PullImage(imageArr[i]+tag, jsonOutput)
+		utils.ValidateImageDigest(imageArr[i] + tag)
 		utils.TagImage(imageArr[i]+tag, targetArr[i]+tag)
 	}
 

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -48,7 +48,7 @@ func InstallCommand(c *cli.Context) {
 			utils.RemoveImage(imageID)
 
 			// pull image again
-			utils.PullImage(imageArr[i]+tag, jsonOutput) // only do this once?!
+			utils.PullImage(imageArr[i]+tag, jsonOutput)
 
 			// validate the new image
 			_, dockerError = utils.ValidateImageDigest(imageArr[i] + tag)

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -43,7 +43,8 @@ func InstallCommand(c *cli.Context) {
 		imageID, dockerError := utils.ValidateImageDigest(imageArr[i] + tag)
 
 		if dockerError != nil {
-			//try again
+			logr.Warnf("%v checksum validaton failed. Trying to pull image again", imageArr[i]+tag)
+			// remove bad image
 			utils.RemoveImage(imageID)
 
 			// pull image again
@@ -52,19 +53,16 @@ func InstallCommand(c *cli.Context) {
 			// validate the new image
 			_, dockerError = utils.ValidateImageDigest(imageArr[i] + tag)
 
-			// **********************
-
-			logr.Errorf("IM BEING CALLED AGAIN %d", i)
 			if dockerError != nil {
 				if jsonOutput {
 					fmt.Println(dockerError)
 				} else {
-					logr.Errorf("Validation of image %v checksum failed again", imageArr[i]+tag)
+					logr.Errorf("Validation of image %v checksum failed. Please retry manually", imageArr[i]+tag)
 				}
 				os.Exit(1)
 			}
 		}
-		// ****************
+
 		utils.TagImage(imageArr[i]+tag, targetArr[i]+tag)
 	}
 

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -57,7 +57,7 @@ func InstallCommand(c *cli.Context) {
 				if jsonOutput {
 					fmt.Println(dockerError)
 				} else {
-					logr.Errorf("Validation of image '%v' checksum failed. Please clear your system and try again", imageArr[i]+tag)
+					logr.Errorf("Validation of image '%v' checksum failed - Removing image", imageArr[i]+tag)
 				}
 				// Clean up the second bad image
 				utils.RemoveImage(imageID)

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -43,7 +43,7 @@ func InstallCommand(c *cli.Context) {
 		imageID, dockerError := utils.ValidateImageDigest(imageArr[i] + tag)
 
 		if dockerError != nil {
-			logr.Warnf("%v checksum validaton failed. Trying to pull image again", imageArr[i]+tag)
+			logr.Warnf("%v checksum validation failed. Trying to pull image again", imageArr[i]+tag)
 			// remove bad image
 			utils.RemoveImage(imageID)
 

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -43,7 +43,7 @@ func InstallCommand(c *cli.Context) {
 		imageID, dockerError := utils.ValidateImageDigest(imageArr[i] + tag)
 
 		if dockerError != nil {
-			logr.Warnf("%v checksum validation failed. Trying to pull image again", imageArr[i]+tag)
+			logr.Tracef("%v checksum validation failed. Trying to pull image again", imageArr[i]+tag)
 			// remove bad image
 			utils.RemoveImage(imageID)
 

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -220,7 +220,7 @@ func ValidateImageDigest(image string) (string, *DockerError) {
 				if strings.Contains(imageRepo, strings.Replace(string(digest), "\"", "", -1)) {
 					length := len(strings.Replace(string(digest), "\"", "", -1))
 					last10 := strings.Replace(string(digest), "\"", "", -1)[length-10 : length]
-					logr.Infof("Validation for image digest ..%v succeeded\n", last10)
+					logr.Tracef("Validation for image digest ..%v succeeded\n", last10)
 					return "", nil
 				} else {
 					logr.Traceln("Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download")

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -230,7 +230,6 @@ func ValidateImageDigest(image string) (string, *DockerError) {
 			}
 		}
 	}
-
 	return "", nil
 }
 

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -198,12 +198,12 @@ func ValidateImageDigest(image string) (string, *DockerError) {
 	// call docker api for image digest
 	queryDigest, err := cli.DistributionInspect(ctx, image, "")
 	if err != nil {
-		fmt.Println(err)
+		logr.Error(err)
 	}
 
 	// turn digest -> []byte -> string
 	digest, _ := json.Marshal(queryDigest.Descriptor.Digest)
-	fmt.Println("Query image digest is.. ", queryDigest.Descriptor.Digest)
+	logr.Traceln("Query image digest is.. ", queryDigest.Descriptor.Digest)
 
 	// get local image digest
 	imageList := GetImageList()
@@ -220,10 +220,10 @@ func ValidateImageDigest(image string) (string, *DockerError) {
 				if strings.Contains(imageRepo, strings.Replace(string(digest), "\"", "", -1)) {
 					length := len(strings.Replace(string(digest), "\"", "", -1))
 					last10 := strings.Replace(string(digest), "\"", "", -1)[length-10 : length]
-					fmt.Printf("Validation for image digest ..%v succeeded\n", last10)
+					logr.Infof("Validation for image digest ..%v succeeded\n", last10)
 					return "", nil
 				} else {
-					logr.Warnln("Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download")
+					logr.Traceln("Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download")
 					valError := goErr.New(textBadDigest)
 					return image.ID, &DockerError{errOpValidate, valError, valError.Error()}
 				}

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -289,7 +289,6 @@ func CheckImageStatus() bool {
 	if imageCount >= 2 {
 		imageStatus = true
 	}
-
 	return imageStatus
 }
 

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -221,7 +221,6 @@ func ValidateImageDigest(image string) (string, *DockerError) {
 					length := len(strings.Replace(string(digest), "\"", "", -1))
 					last10 := strings.Replace(string(digest), "\"", "", -1)[length-10 : length]
 					logr.Tracef("Validation for image digest ..%v succeeded\n", last10)
-					return "", nil
 				} else {
 					logr.Traceln("Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download")
 					valError := goErr.New(textBadDigest)

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -201,7 +201,7 @@ func ValidateImageDigest(image string) (string, *DockerError) {
 		fmt.Println(err)
 	}
 
-	// turn digest -> byte -> string
+	// turn digest -> []byte -> string
 	digest, _ := json.Marshal(queryDigest.Descriptor.Digest)
 	fmt.Println("Query image digest is.. ", queryDigest.Descriptor.Digest)
 

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -1,0 +1,28 @@
+package utils
+
+import "encoding/json"
+
+type DockerError struct {
+	Op   string
+	Err  error
+	Desc string
+}
+
+const (
+	errOpValidate = "docker_validate" // validate docker images
+)
+
+const (
+	textBadDigest = "Failed to validate docker image checksum"
+)
+
+// DockerError : Error formatted in JSON containing an errorOp and a description
+func (se *DockerError) Error() string {
+	type Output struct {
+		Operation   string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	tempOutput := &Output{Operation: se.Op, Description: se.Err.Error()}
+	jsonError, _ := json.Marshal(tempOutput)
+	return string(jsonError)
+}

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -17,12 +17,12 @@ const (
 )
 
 // DockerError : Error formatted in JSON containing an errorOp and a description
-func (se *DockerError) Error() string {
+func (de *DockerError) Error() string {
 	type Output struct {
 		Operation   string `json:"error"`
 		Description string `json:"error_description"`
 	}
-	tempOutput := &Output{Operation: se.Op, Description: se.Err.Error()}
+	tempOutput := &Output{Operation: de.Op, Description: de.Err.Error()}
 	jsonError, _ := json.Marshal(tempOutput)
 	return string(jsonError)
 }

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package utils
 
 import "encoding/json"

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -8,10 +8,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
 package utils
 
 import "encoding/json"
 
+// DockerError struct will format the error
 type DockerError struct {
 	Op   string
 	Err  error


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/1148 & https://github.com/eclipse/codewind/issues/1181**

On occasion we have seen a bad download of an image or docker compose failing to find the correct images it is expected. As a result, we are seeing the issues linked above. 

**Solution**
This PR is the first step towards helping prevent this problem occurring. 
1) Pull the image down from dockerhub
2) Query dockerhub for that image digest
3) Check the queried digest against the local image digest to ensure they match
4) If they don't match, remove the image and try again 1 more time
5) If it fails a second time then exit with an error code 1

**Testing**
1) Manual testing using trace level logging - using a duff image digest to check against
- Non JSON output
```
...
6ddfa8d9c209: Pull complete 
Digest: sha256:2a9114b65163adde9a8954e47fb78816f18d68f58424ce8c7b9c108afa7f8a87
Status: Downloaded newer image for eclipse/codewind-pfe-amd64:latest
TRAC[0046] Query image digest is..  sha256:2a9114b65163adde9a8954e47fb78816f18d68f58424ce8c7b9c108afa7f8a87
TRAC[0046] Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download 
TRAC0046] docker.io/eclipse/codewind-pfe-amd64:latest checksum validaton failed. Trying to pull image again 
latest: Pulling from eclipse/codewind-pfe-amd64
8ba884070f61: Pull complete 
...
6ddfa8d9c209: Pull complete 
Digest: sha256:2a9114b65163adde9a8954e47fb78816f18d68f58424ce8c7b9c108afa7f8a87
Status: Downloaded newer image for eclipse/codewind-pfe-amd64:latest
TRAC[0091] Query image digest is..  sha256:2a9114b65163adde9a8954e47fb78816f18d68f58424ce8c7b9c108afa7f8a87
TRAC[0091] Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download 
ERRO[0091] Validation of image 'docker.io/eclipse/codewind-pfe-amd64:latest' checksum failed. Please clear your system and try again 
exit status 1
```

- JSON output
```
{"status":"Pull complete","progressDetail":{},"id":"d417a7da0271"}
{"status":"Digest: sha256:3e76483bd75417f78ed2cf11c677a8d43c1f026fcaa8c38f75bce82d0a2d7de6"}
{"status":"Status: Downloaded newer image for eclipse/codewind-pfe-amd64:latest"}
TRAC[0043] Query image digest is..  sha256:3e76483bd75417f78ed2cf11c677a8d43c1f026fcaa8c38f75bce82d0a2d7de6 
TRAC[0043] Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download 
TRAC[0043] docker.io/eclipse/codewind-pfe-amd64:latest checksum validation failed. Trying to pull image again 
{"status":"Pulling from eclipse/codewind-pfe-amd64","id":"latest"}
...
{"status":"Pull complete","progressDetail":{},"id":"d417a7da0271"}
{"status":"Digest: sha256:3e76483bd75417f78ed2cf11c677a8d43c1f026fcaa8c38f75bce82d0a2d7de6"}
{"status":"Status: Downloaded newer image for eclipse/codewind-pfe-amd64:latest"}
TRAC[0096] Query image digest is..  sha256:3e76483bd75417f78ed2cf11c677a8d43c1f026fcaa8c38f75bce82d0a2d7de6 
TRAC[0096] Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download 
{"error":"docker_validate","error_description":"Failed to validate docker image checksum"}
exit status 1
```

2) BATS testing - This code will be tested during the install stage of any image
```
 ✓ invoke install command - install latest with --json
 ✓ invoke status -j command - output = '{status:stopped,installed-versions:[latest]}'
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✓ invoke con reset command - reset connections file
 ✓ invoke con list command - contains just 1 local connection
 - invoke con add command - add new connection to the list (skipped: environment not available yet)
 - invoke con list command - ensure both connections exist  (skipped: environment not available yet)
 - invoke con target command - set a target to something unknown (skipped: environment not available yet)
 - invoke con target command - set the target to kube (skipped: environment not available yet)
 - invoke con target command - check the target is now kube (skipped: environment not available yet)
 - invoke con remove command - delete target kube (skipped: environment not available yet)
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect connection)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

18 tests, 0 failures, 6 skipped
```
Signed-off-by: Liam Hampton liam.hampton@ibm.com