### PR TITLE
Set codewind permissions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -683,6 +683,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -16,15 +16,13 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	"github.com/eclipse/codewind-installer/pkg/errors"
 	logr "github.com/sirupsen/logrus"
-
 	"github.com/urfave/cli"
 )
 
 var tempFilePath = "codewind-docker-compose.yaml"
-
-const versionNum = "x.x.dev"
 
 const healthEndpoint = "/api/v1/environment"
 
@@ -32,7 +30,7 @@ const healthEndpoint = "/api/v1/environment"
 func Commands() {
 	app := cli.NewApp()
 	app.Name = "cwctl"
-	app.Version = versionNum
+	app.Version = appconstants.VersionNum
 	app.Usage = "Start, Stop and Remove Codewind"
 
 	// Global Flags

--- a/pkg/appconstants/version.go
+++ b/pkg/appconstants/version.go
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package appconstants
+
+// VersionNum : CLI Version number
+const VersionNum = "x.x.dev"

--- a/pkg/remote/defaults.go
+++ b/pkg/remote/defaults.go
@@ -11,7 +11,10 @@
 
 package remote
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"github.com/eclipse/codewind-installer/pkg/appconstants"
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 	// PFEPrefix is the prefix all PFE-related resources: deployment, service, and ingress/route
@@ -64,4 +67,10 @@ const (
 
 	// GatekeeperContainerPort is the port at which the Gatekeeper is exposed
 	GatekeeperContainerPort = 9096
+
+	// CodewindRolesName will include the workspaceID when deployed
+	CodewindRolesName = "eclipse-codewind-" + appconstants.VersionNum
+
+	// CodewindRoleBindingNamePrefix will include the workspaceID when deployed
+	CodewindRoleBindingNamePrefix = "codewind-rolebinding"
 )

--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -16,7 +16,6 @@ import (
 
 	v1 "github.com/openshift/api/route/v1"
 	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
-	log "github.com/sirupsen/logrus"
 	logr "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +29,7 @@ import (
 // DeployGatekeeper : Deploy gatekeepers
 func DeployGatekeeper(config *restclient.Config, clientset *kubernetes.Clientset, codewindInstance Codewind, deployOptions *DeployOptions) error {
 
-	log.Infoln("Preparing Codewind Gatekeeper resources")
+	logr.Infoln("Preparing Codewind Gatekeeper resources")
 
 	gatekeeperSecrets := createGatekeeperSecrets(codewindInstance, deployOptions)
 	gatekeeperService := createGatekeeperService(codewindInstance)
@@ -40,39 +39,39 @@ func DeployGatekeeper(config *restclient.Config, clientset *kubernetes.Clientset
 	serverKey, serverCert, err := createCertificate(GatekeeperPrefix+codewindInstance.Ingress, "Codewind Gatekeeper")
 	gatekeeperTLSSecret := createGatekeeperTLSSecret(codewindInstance, serverKey, serverCert)
 
-	log.Infoln("Deploying Codewind Gatekeeper Secrets")
+	logr.Infoln("Deploying Codewind Gatekeeper Secrets")
 
 	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&gatekeeperSecrets)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Gatekeeper secrets: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Gatekeeper secrets: %v\n", err)
 		return err
 	}
 
-	log.Infoln("Deploying Codewind Gatekeeper Session Secrets")
+	logr.Infoln("Deploying Codewind Gatekeeper Session Secrets")
 	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&gatekeeperSessionSecret)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind secrets: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind secrets: %v\n", err)
 		return err
 	}
 
-	log.Infoln("Deploying Codewind Gatekeeper TLS Secrets")
+	logr.Infoln("Deploying Codewind Gatekeeper TLS Secrets")
 	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&gatekeeperTLSSecret)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Gatekeeper TLS secrets: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Gatekeeper TLS secrets: %v\n", err)
 		return err
 	}
 
-	log.Infoln("Deploying Codewind Gatekeeper Deployment")
+	logr.Infoln("Deploying Codewind Gatekeeper Deployment")
 	_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Create(&gatekeeperDeploy)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Gatekeeper deployment: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Gatekeeper deployment: %v\n", err)
 		return err
 	}
 
-	log.Infoln("Deploying Codewind Gatekeeper Service")
+	logr.Infoln("Deploying Codewind Gatekeeper Service")
 	_, err = clientset.CoreV1().Services(deployOptions.Namespace).Create(&gatekeeperService)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Gatekeeper service: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Gatekeeper service: %v\n", err)
 		return err
 	}
 
@@ -83,12 +82,12 @@ func DeployGatekeeper(config *restclient.Config, clientset *kubernetes.Clientset
 		route := createRouteGatekeeper(codewindInstance)
 		routev1client, err := routev1.NewForConfig(config)
 		if err != nil {
-			log.Printf("Error retrieving route client for OpenShift: %v\n", err)
+			logr.Printf("Error retrieving route client for OpenShift: %v\n", err)
 			os.Exit(1)
 		}
 		_, err = routev1client.Routes(codewindInstance.Namespace).Create(&route)
 		if err != nil {
-			log.Printf("Error: Unable to create route for Codewind: %v\n", err)
+			logr.Printf("Error: Unable to create route for Codewind: %v\n", err)
 			os.Exit(1)
 		}
 	} else {
@@ -96,7 +95,7 @@ func DeployGatekeeper(config *restclient.Config, clientset *kubernetes.Clientset
 		ingress := createIngressGatekeeper(codewindInstance)
 		_, err = clientset.ExtensionsV1beta1().Ingresses(codewindInstance.Namespace).Create(&ingress)
 		if err != nil {
-			log.Printf("Error: Unable to create ingress for Codewind Gatekeeper: %v\n", err)
+			logr.Printf("Error: Unable to create ingress for Codewind Gatekeeper: %v\n", err)
 			os.Exit(1)
 		}
 	}

--- a/pkg/remote/deploy_keycloak.go
+++ b/pkg/remote/deploy_keycloak.go
@@ -16,7 +16,6 @@ import (
 
 	v1 "github.com/openshift/api/route/v1"
 	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
-	log "github.com/sirupsen/logrus"
 	logr "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,27 +35,27 @@ func DeployKeycloak(config *restclient.Config, clientset *kubernetes.Clientset, 
 	serverKey, serverCert, err := createCertificate(KeycloakPrefix+codewindInstance.Ingress, "Codewind Keycloak")
 	keycloakTLSSecret := createKeycloakTLSSecret(codewindInstance, serverKey, serverCert)
 
-	log.Infoln("Deploying Codewind Keycloak Secrets")
+	logr.Infoln("Deploying Codewind Keycloak Secrets")
 	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&keycloakSecrets)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Keycloak secrets: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Keycloak secrets: %v\n", err)
 		return err
 	}
 	_, err = clientset.CoreV1().Services(deployOptions.Namespace).Create(&keycloakService)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Keycloak service: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Keycloak service: %v\n", err)
 		return err
 	}
 	_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Create(&keycloakDeploy)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Keycloak deployment: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Keycloak deployment: %v\n", err)
 		return err
 	}
 
-	log.Infoln("Deploying Codewind Keycloak TLS Secrets")
+	logr.Infoln("Deploying Codewind Keycloak TLS Secrets")
 	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(&keycloakTLSSecret)
 	if err != nil {
-		log.Errorf("Error: Unable to create Codewind Keycloak TLS secrets: %v\n", err)
+		logr.Errorf("Error: Unable to create Codewind Keycloak TLS secrets: %v\n", err)
 		return err
 	}
 
@@ -66,12 +65,12 @@ func DeployKeycloak(config *restclient.Config, clientset *kubernetes.Clientset, 
 		route := createKeycloakRoute(codewindInstance)
 		routev1client, err := routev1.NewForConfig(config)
 		if err != nil {
-			log.Printf("Error retrieving route client for OpenShift: %v\n", err)
+			logr.Printf("Error retrieving route client for OpenShift: %v\n", err)
 			os.Exit(1)
 		}
 		_, err = routev1client.Routes(deployOptions.Namespace).Create(&route)
 		if err != nil {
-			log.Printf("Error: Unable to create route for Codewind: %v\n", err)
+			logr.Printf("Error: Unable to create route for Codewind: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -80,7 +79,7 @@ func DeployKeycloak(config *restclient.Config, clientset *kubernetes.Clientset, 
 		ingress := createIngressKeycloak(codewindInstance)
 		_, err = clientset.ExtensionsV1beta1().Ingresses(deployOptions.Namespace).Create(&ingress)
 		if err != nil {
-			log.Printf("Error: Unable to create ingress for Codewind Keycloak: %v\n", err)
+			logr.Printf("Error: Unable to create ingress for Codewind Keycloak: %v\n", err)
 			os.Exit(1)
 		}
 	}

--- a/pkg/remote/deploy_performance.go
+++ b/pkg/remote/deploy_performance.go
@@ -25,7 +25,7 @@ func DeployPerformance(clientset *kubernetes.Clientset, codewind Codewind, deplo
 	performanceService := createPerformanceService(codewind)
 	performanceDeploy := createPerformanceDeploy(codewind)
 
-	log.Infoln("Deploying Codewind Performance Dashboard...")
+	log.Infoln("Deploying Codewind Performance Dashboard")
 	_, err := clientset.CoreV1().Services(deployOptions.Namespace).Create(&performanceService)
 	if err != nil {
 		log.Errorf("Error: Unable to create Codewind Performance service: %v\n", err)

--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package remote
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCodewindRoles : create Codewind roles
+func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
+	ourRoles := []rbacv1.PolicyRule{
+		rbacv1.PolicyRule{
+			APIGroups: []string{"extensions", ""},
+			Resources: []string{"ingresses", "ingresses/status", "podsecuritypolicies"},
+			Verbs:     []string{"delete", "create", "patch", "get", "list", "update", "watch", "use"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs:     []string{"delete", "create", "patch", "get", "list"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "pods/portforward", "pods/log", "pods/exec"},
+			Verbs:     []string{"get", "list", "create", "delete", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list", "create", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"serviceaccounts"},
+			Verbs:     []string{"get", "patch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{"get", "list", "create", "delete", "patch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs:     []string{"get", "list"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get", "list", "create", "update", "delete", "patch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"persistentvolumeclaims", "persistentvolumeclaims/finalizers", "persistentvolumeclaims/status"},
+			Verbs:     []string{"*"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"icp.ibm.com"},
+			Resources: []string{"images"},
+			Verbs:     []string{"get", "list", "create", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"apps", "extensions"},
+			Resources: []string{"deployments"},
+			Verbs:     []string{"watch", "get", "list", "create", "update", "delete", "patch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"extensions", "apps"},
+			Resources: []string{"replicasets", "replicasets/finalizers"},
+			Verbs:     []string{"get", "list", "update", "delete"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"apiextensions.k8s.io"},
+			Resources: []string{"customresourcedefinitions"},
+			Verbs:     []string{"get", "list", "update", "delete"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"certificates.k8s.io"},
+			Resources: []string{"certificatesigningrequests"},
+			Verbs:     []string{"delete", "get", "list", "watch", "create"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"certificates.k8s.io"},
+			Resources: []string{"certificatesigningrequests/approval", "certificatesigningrequests/status"},
+			Verbs:     []string{"update"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"authorization.k8s.io"},
+			Resources: []string{"subjectaccessreviews"},
+			Verbs:     []string{"create"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"rolebindings", "roles", "clusterroles"},
+			Verbs:     []string{"create", "get", "patch", "list"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"create", "patch", "update"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"route.openshift.io"},
+			Resources: []string{"routes", "routes/custom-host"},
+			Verbs:     []string{"get", "list", "create", "delete", "watch", "patch", "update"},
+		},
+	}
+	return rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: deployOptions.Namespace,
+			Name:      CodewindRolesName,
+		},
+		Rules: ourRoles,
+	}
+}
+
+//CreateCodewindRoleBindings : create Codewind role bindings in the deployment namespace
+func CreateCodewindRoleBindings(codewindInstance Codewind, deployOptions *DeployOptions, codewindRoleBindingName string) rbacv1.ClusterRoleBinding {
+	return rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: codewindRoleBindingName,
+		},
+		Subjects: []rbacv1.Subject{
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      codewindInstance.ServiceAccountName,
+				Namespace: deployOptions.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     CodewindRolesName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+}

--- a/pkg/remote/deploy_pfe_serviceaccount.go
+++ b/pkg/remote/deploy_pfe_serviceaccount.go
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package remote
+
+import (
+	logr "github.com/sirupsen/logrus"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateCodewindServiceAcct : Create service account
+func CreateCodewindServiceAcct(codewind Codewind, deployOptions *DeployOptions) coreV1.ServiceAccount {
+	logr.Infof("Creating service account definition '%v'", codewind.ServiceAccountName)
+
+	labels := map[string]string{
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+	svc := coreV1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   codewind.ServiceAccountName,
+			Labels: labels,
+		},
+		Secrets: nil,
+	}
+	return svc
+}


### PR DESCRIPTION
## Problem

Codewind remote needs to run with permissions in order manage project containers, project services and access the Docker registry secret.

## Solution

This PR adds the following enhancements : 

* Add required cluster roles to Kube during deploy (1 per cluster)
> these are serial numbered with the same version number as the CLI 

* Add cluster role bindings to Kube during deploy (1 per PFE deployment) 
> these are named with a serial number that matches the CLI version number

* Add a Service Account in the namespace (1 per PFE deployment) 

* Sets the Docker Registry secret name to match the API in PFE
> the API in PFE is going to create the secret
  
* Remove duplicate imports (log + logr)

* Clean up console output

## Sample output of a deployment : 


INFO[0000] Using namespace : marktest                   
INFO[0000] Container images :                           
INFO[0000] eclipse/codewind-pfe-amd64:latest            
INFO[0000] eclipse/codewind-performance-amd64:latest    
INFO[0000] eclipse/codewind-keycloak-amd64:latest       
INFO[0000] eclipse/codewind-gatekeeper-amd64:latest     
INFO[0000] Running on openshift: false                  
INFO[0000] Attempting to discover Ingress Domain        
INFO[0000] Using ingress domain: <MY_IP_ADDR>.nip.io    
INFO[0000] Docker registry pull secret name: 'codewind-k3a3wrnh-docker-registries' 
INFO[0000] Creating codewind-keycloak-k3a3wrnh.<MY_IP_ADDR>.nip.io server Key 
INFO[0000] Creating codewind-keycloak-k3a3wrnh.<MY_IP_ADDR>.nip.io server certificate 
INFO[0000] Deploying Codewind Keycloak Secrets          
INFO[0000] Deploying Codewind Keycloak TLS Secrets      
INFO[0000] Deploying Codewind Keycloak Ingress          
INFO[0000] Waiting for Keycloak to start                
.............
INFO[0024] Configuring Keycloak...                      
INFO[0024] https://codewind-keycloak-k3a3wrnh.<MY_IP_ADDR>.nip.io 
INFO[0025] Creating Keycloak realm                      
INFO[0026] Creating Keycloak client                     
INFO[0027] Creating Keycloak initial user               
INFO[0027] Updating Keycloak user password              
INFO[0027] Fetching client secret                       
INFO[0027] Checking if 'eclipse-codewind-x.x.dev' cluster access roles are installed 
INFO[0027] Cluster roles 'eclipse-codewind-x.x.dev' already installed 
INFO[0027] Checking if 'codewind-rolebinding-k3a3wrnh' role bindings exist 
INFO[0027] Adding 'codewind-rolebinding-k3a3wrnh' cluster role binding 
INFO[0027] Deploying Codewind Service                   
INFO[0027] Deploying Codewind Performance Dashboard     
INFO[0027] Preparing Codewind Gatekeeper resources      
INFO[0027] Creating codewind-gatekeeper-k3a3wrnh.<MY_IP_ADDR>.nip.io server Key 
INFO[0027] Creating codewind-gatekeeper-k3a3wrnh.<MY_IP_ADDR>.nip.io server certificate 
INFO[0027] Deploying Codewind Gatekeeper Secrets        
INFO[0027] Deploying Codewind Gatekeeper Session Secrets 
INFO[0027] Deploying Codewind Gatekeeper TLS Secrets    
INFO[0027] Deploying Codewind Gatekeeper Deployment     
INFO[0027] Deploying Codewind Gatekeeper Service        
INFO[0027] Deploying Codewind Gatekeeper Ingress        
INFO[0027] Waiting for Codewind Gatekeeper to start on https://codewind-gatekeeper-k3a3wrnh.<MY_IP_ADDR>.nip.io 
........
INFO[0035] Waiting for Codewind PFE to start            
INFO[0035] Codewind is available at: https://codewind-gatekeeper-k3a3wrnh.<MY_IP_ADDR>.nip.io 
