### PR TITLE
{TO BE MERGED AFTER GA} Check remote image digest vs local image digest

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -23,7 +23,7 @@ import (
 
 var tempFilePath = "codewind-docker-compose.yaml"
 
-const versionNum = "0.6.0"
+const versionNum = "0.6.1"
 
 const healthEndpoint = "/api/v1/environment"
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -23,7 +23,7 @@ import (
 
 var tempFilePath = "codewind-docker-compose.yaml"
 
-const versionNum = "x.x.dev"
+const versionNum = "0.6.0"
 
 const healthEndpoint = "/api/v1/environment"
 

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+import "encoding/json"
+
+// DockerError struct will format the error
+type DockerError struct {
+	Op   string
+	Err  error
+	Desc string
+}
+
+const (
+	errOpValidate = "docker_validate" // validate docker images
+)
+
+const (
+	textBadDigest = "Failed to validate docker image checksum"
+)
+
+// DockerError : Error formatted in JSON containing an errorOp and a description
+func (de *DockerError) Error() string {
+	type Output struct {
+		Operation   string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	tempOutput := &Output{Operation: de.Op, Description: de.Err.Error()}
+	jsonError, _ := json.Marshal(tempOutput)
+	return string(jsonError)
+}


### PR DESCRIPTION
**Problem**
See - https://github.com/eclipse/codewind-installer/pull/233
*This change is already in latest master branch of the CLI*

Version output:
```
➜  codewind-installer git:(query-image-digest-0.6.0) cwctl --version
cwctl version 0.6.1
```

Bats testing output using 0.6.0 branch: 
```
✓ invoke install command - install latest with --json
 - invoke status -j command - output = '{status:stopped,installed-versions:[latest]}' (skipped)
 ✓ invoke start command - Start dockerhub images (latest)
 ✓ invoke stop-all command - Stop dockerhub images (latest)
 ✓ invoke remove command - remove all dockerhub images
 ✓ invoke con reset command - reset connections file
 ✓ invoke con list command - contains just 1 local connection
 - invoke con add command - add new connection to the list (skipped)
 - invoke con list command - ensure both connections exist  (skipped)
 - invoke con target command - set a target to something unknown (skipped)
 - invoke con target command - set the target to kube (skipped)
 - invoke con target command - check the target is now kube (skipped)
 - invoke con remove command - delete target kube (skipped)
 ✓ invoke seckeyring update command - create a key
 ✓ invoke seckeyring update command - update a key
 ✓ invoke seckeyring validate command - validate a key
 ✓ invoke seckeyring validate command - key not found (incorrect connection)
 ✓ invoke seckeyring validate command - key not found (incorrect username)

18 tests, 0 failures, 7 skipped
```

If it fails the output is:
```
Digest: sha256:6184de35c76903a0f993c7136c47463a007bbf2f03686eaa8ff7d6adae8d3667
Status: Downloaded newer image for eclipse/codewind-pfe-amd64:latest
ERRO[0050] Validation of image 'docker.io/eclipse/codewind-pfe-amd64:latest' checksum failed - Removing image 
```
(This will exit with an exit status 1)
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>