### PR TITLE
Add authorization roles when deploying remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | remove      | `rm`  | 'Remove Codewind/Project docker images and the codewind network'    |
 | templates   |       | 'Manage project templates'                                          |
 | sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |
-| secrole     |       | 'Manage realm based ACCESS roles'                                   |
+| secrole     | `sl`  | 'Manage realm based ACCESS roles'                                   |
 | secrealm    | `sr`  | 'Manage new or existing REALM configurations'                       |
 | secclient   | `sc`  | 'Manage new or existing APPLICATION access configurations'          |
 | seckeyring  | `sk`  | 'Manage Codewind keys in the desktop keyring'                       |

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | remove      | `rm`  | 'Remove Codewind/Project docker images and the codewind network'    |
 | templates   |       | 'Manage project templates'                                          |
 | sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |
+| secrole     |       | 'Manage realm based ACCESS roles'                                   |
 | secrealm    | `sr`  | 'Manage new or existing REALM configurations'                       |
 | secclient   | `sc`  | 'Manage new or existing APPLICATION access configurations'          |
 | seckeyring  | `sk`  | 'Manage Codewind keys in the desktop keyring'                       |
@@ -347,6 +348,14 @@ Subcommands:</br>
 > --password value               Admin Password
 > --name value                   Username to query
 > --newpw value                  New replacement password
+
+`addrole/p` - Adds an existing role to a user (requires either admin_token or username/password)
+
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --name value                   Username to target
+> --role value                   Name of an existing role to add
 
 ## connections
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -182,7 +182,6 @@ func Commands() {
 						cli.StringFlag{Name: "namespace,n", Usage: "Kubernetes namespace", Required: true},
 						cli.StringFlag{Name: "session,ses", Usage: "Codewind session secret", Required: false},
 						cli.StringFlag{Name: "ingress,i", Usage: "Ingress Domain eg: 10.22.33.44.nip.io", Required: false},
-						cli.StringFlag{Name: "addkeycloak,k", Usage: "Deploy an instance of Keycloak", Required: false},
 						cli.StringFlag{Name: "kadminuser,au", Usage: "Keycloak admin user", Required: false},
 						cli.StringFlag{Name: "kadminpass,ap", Usage: "Keycloak admin password", Required: false},
 						cli.StringFlag{Name: "kdevuser,du", Usage: "Keycloak developer username to add", Required: false},
@@ -514,7 +513,30 @@ func Commands() {
 					},
 				},
 			},
-		}, {
+		},
+		{
+			Name:    "secrole",
+			Aliases: []string{"sl"},
+			Usage:   "Manage access role configuration",
+			Subcommands: []cli.Command{
+				{
+					Name:    "create",
+					Aliases: []string{"c"},
+					Usage:   "Create a new role in an existing realm (requires admin_token)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: true},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin access_token", Required: true},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "role,l", Usage: "New Role name", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityCreateRole(c)
+						return nil
+					},
+				},
+			},
+		},
+		{
 			Name:    "secclient",
 			Aliases: []string{"sc"},
 			Usage:   "Manage client access configuration",
@@ -625,6 +647,20 @@ func Commands() {
 					},
 					Action: func(c *cli.Context) error {
 						SecurityUserSetPassword(c)
+						return nil
+					},
+				}, {
+					Name:  "addrole",
+					Usage: "Adds an existing role to an existing user (requires admin_token)",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "host", Usage: "URL or ingress to Keycloak service", Required: false},
+						cli.StringFlag{Name: "realm,r", Usage: "Realm name", Required: true},
+						cli.StringFlag{Name: "accesstoken,t", Usage: "Admin Access Token", Required: false},
+						cli.StringFlag{Name: "name,n", Usage: "Existing user account name to process", Required: true},
+						cli.StringFlag{Name: "role,rl", Usage: "Existing user role name to add to the user account", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						SecurityUserAddRole(c)
 						return nil
 					},
 				},

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -87,7 +87,6 @@ func DoRemoteInstall(c *cli.Context) {
 	deployOptions := remote.DeployOptions{
 		Namespace:             c.String("namespace"),
 		IngressDomain:         c.String("ingress"),
-		InstallKeycloak:       c.Bool("addkeycloak"),
 		KeycloakUser:          c.String("kadminuser"),
 		KeycloakPassword:      c.String("kadminpass"),
 		KeycloakDevUser:       c.String("kdevuser"),

--- a/pkg/actions/security.go
+++ b/pkg/actions/security.go
@@ -59,6 +59,18 @@ func SecurityCreateRealm(c *cli.Context) {
 	os.Exit(0)
 }
 
+// SecurityCreateRole : Create a role in an existing Keycloak realm
+func SecurityCreateRole(c *cli.Context) {
+	err := security.SecRoleCreate(c)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	} else {
+		utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	}
+	os.Exit(0)
+}
+
 // SecurityClientCreate : Create a new client in Keycloak
 func SecurityClientCreate(c *cli.Context) {
 	err := security.SecClientCreate(c)
@@ -136,6 +148,18 @@ func SecurityUserSetPassword(c *cli.Context) {
 		os.Exit(1)
 	}
 	utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	os.Exit(0)
+}
+
+// SecurityUserAddRole : Add an existing role to the specified user
+func SecurityUserAddRole(c *cli.Context) {
+	err := security.SecUserAddRole(c)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	} else {
+		utils.PrettyPrintJSON(security.Result{Status: "OK"})
+	}
 	os.Exit(0)
 }
 

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -34,7 +34,6 @@ import (
 type DeployOptions struct {
 	Namespace             string
 	IngressDomain         string
-	InstallKeycloak       bool
 	KeycloakUser          string
 	KeycloakPassword      string
 	KeycloakDevUser       string

--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -286,6 +286,14 @@ func setGatekeeperEnvVars(codewind Codewind, deployOptions *DeployOptions) []cor
 			Value: "CODEWIND_PFE_" + codewind.WorkspaceID,
 		},
 		{
+			Name:  "WORKSPACE_ID",
+			Value: codewind.WorkspaceID,
+		},
+		{
+			Name:  "ACCESS_ROLE",
+			Value: "codewind-" + codewind.WorkspaceID,
+		},
+		{
 			Name: "CLIENT_SECRET",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret-codewind-client" + "-" + codewind.WorkspaceID}, Key: "client_secret"}},

--- a/pkg/security/role.go
+++ b/pkg/security/role.go
@@ -126,7 +126,7 @@ func getRoleByName(c *cli.Context, roleName string) (*Role, *SecError) {
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 
-	// Parse the result
+	// parse the result
 	var role *Role
 	err = json.Unmarshal([]byte(body), &role)
 	if err != nil {

--- a/pkg/security/role.go
+++ b/pkg/security/role.go
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package security
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+// Role : Access role
+type Role struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Composite   bool   `json:"composite"`
+	ClientRole  bool   `json:"clientRole"`
+	ContainerID string `json:"containerId"`
+}
+
+// SecRoleCreate : Create a new role in Keycloak
+func SecRoleCreate(c *cli.Context) *SecError {
+
+	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
+	realmName := strings.TrimSpace(c.String("realm"))
+	roleName := strings.TrimSpace(c.String("role"))
+	accesstoken := strings.TrimSpace(c.String("accesstoken"))
+
+	// build REST request
+	url := hostname + "/auth/admin/realms/" + realmName + "/roles"
+
+	// Role : Access role
+	type NewRole struct {
+		Name        string `json:"name"`
+		Composite   bool   `json:"composite"`
+		ClientRole  bool   `json:"clientRole"`
+		ContainerID string `json:"containerId"`
+	}
+
+	tempRole := &NewRole{
+		Name:        roleName,
+		Composite:   false,
+		ClientRole:  false,
+		ContainerID: realmName,
+	}
+	jsonRole, err := json.Marshal(tempRole)
+
+	payload := strings.NewReader(string(jsonRole))
+	req, err := http.NewRequest("POST", url, payload)
+	if err != nil {
+		return &SecError{errOpConnection, err, err.Error()}
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Cache-Control", "no-cache")
+	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Authorization", "Bearer "+accesstoken)
+
+	// send request
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return &SecError{errOpConnection, err, err.Error()}
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		secErr := errors.New("HTTP " + res.Status)
+		return &SecError{errOpConnection, secErr, secErr.Error()}
+	}
+
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if string(body) != "" {
+		keycloakAPIError := parseKeycloakError(string(body), res.StatusCode)
+		keycloakAPIError.Error = errOpResponseFormat
+		kcError := errors.New(keycloakAPIError.ErrorDescription)
+		return &SecError{keycloakAPIError.Error, kcError, kcError.Error()}
+	}
+	return nil
+}
+
+func getRoleByName(c *cli.Context, roleName string) (*Role, *SecError) {
+
+	hostname := strings.TrimSpace(strings.ToLower(c.String("host")))
+	accesstoken := strings.TrimSpace(c.String("accesstoken"))
+	realmName := strings.TrimSpace(c.String("realm"))
+
+	requestedRole := roleName
+	if requestedRole == "" {
+		requestedRole = strings.TrimSpace(c.String("role"))
+	}
+	// build REST request
+	url := hostname + "/auth/admin/realms/" + realmName + "/roles/" + requestedRole
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, &SecError{errOpConnection, err, err.Error()}
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Cache-Control", "no-cache")
+	req.Header.Add("cache-control", "no-cache")
+	req.Header.Add("Authorization", "Bearer "+accesstoken)
+
+	// send request
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, &SecError{errOpConnection, err, err.Error()}
+	}
+
+	// check we received a valid response
+	if res.StatusCode != http.StatusOK {
+		unableToReadErr := errors.New("Bad response")
+		return nil, &SecError{errOpConnection, unableToReadErr, unableToReadErr.Error()}
+	}
+
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+
+	// Parse the result
+	var role *Role
+	err = json.Unmarshal([]byte(body), &role)
+	if err != nil {
+		return nil, &SecError{errOpResponseFormat, err, textUnableToParse}
+	}
+
+	// found role
+	return role, nil
+}


### PR DESCRIPTION
## Problem

Need a way to restrict access to a Codewind Remote deployment for cases where a shared authentication service is being used

##  Solution

* During deployment install a new realm role is created named as codewind-xxxxxx where xxxxxx is the workspace ID
* The new role is then added to the user granting them access to that deployment
* a new command has been added to create a role manually (secrole add) 
* a new subcommand has been added to grant an existing role to an existing user  (secuser addrole) 
* adds the WORKSPACE_ID and ACCESS_ROLE to the Gatekeeper pods config map where GATEKEEPER will then block authenticated users unless they have the required role

## Result 

When performing a deployment the progress is summarised : 

INFO[0000] Checking namespace marktest exists           
INFO[0000] Using namespace : marktest                   
INFO[0000] Container images :                           
INFO[0000] eclipse/codewind-pfe-amd64:latest            
INFO[0000] eclipse/codewind-performance-amd64:latest    
INFO[0000] eclipse/codewind-keycloak-amd64:latest       
INFO[0000] eclipse/codewind-gatekeeper-amd64:latest     
INFO[0000] Running on openshift: false                  
INFO[0000] Attempting to discover Ingress Domain        
INFO[0000] Using ingress domain: {MYDOMAIN}.nip.io    
INFO[0000] Docker registry pull secret name: 'codewind-k3eewy7e-
docker-registries' 
INFO[0000] Creating service account definition 'codewind-k3eewy7
e' 
INFO[0000] Creating codewind-keycloak-k3eewy7e.{MYDOMAIN}.nip.
io server Key 
INFO[0000] Creating codewind-keycloak-k3eewy7e.{MYDOMAIN}.nip.
io server certificate 
INFO[0000] Deploying Codewind Keycloak Secrets          
INFO[0000] Deploying Codewind Keycloak TLS Secrets      
INFO[0000] Deploying Codewind Keycloak Ingress          
INFO[0000] Waiting for Keycloak to start                
..............
INFO[0026] Configuring Keycloak...                      
INFO[0026] https://codewind-keycloak-k3eewy7e.{MYDOMAIN}.nip.io 
INFO[0027] Creating Keycloak realm                      
INFO[0028] Creating Keycloak client                     

```
INFO[0028] Creating access role 'codewind-k3eewy7e' in realm 'codewind' 
INFO[0028] Creating Keycloak initial user               
INFO[0028] Updating Keycloak user password              
INFO[0029] Grant 'developer' access to this deployment  
INFO[0029] Adding role 'codewind-k3eewy7e' to user : '7deee5f2-d25e-4489-a078-2e3cb2d0b779'
```

INFO[0029] Fetching client secret                       
INFO[0029] Checking if 'eclipse-codewind-x.x.dev' cluster access roles are installed 
INFO[0029] Cluster roles 'eclipse-codewind-x.x.dev' already installed 
INFO[0029] Checking if 'codewind-rolebinding-k3eewy7e' role bindings exist 
INFO[0029] Adding 'codewind-rolebinding-k3eewy7e' cluster role binding 
INFO[0029] Deploying Codewind Service                   
INFO[0029] Deploying Codewind Performance Dashboard     
INFO[0029] Preparing Codewind Gatekeeper resources      
INFO[0029] Creating codewind-gatekeeper-k3eewy7e.{MYDOMAIN}.nip.io server Key 
INFO[0029] Creating codewind-gatekeeper-k3eewy7e.{MYDOMAIN}.nip.io server certificate 
INFO[0029] Deploying Codewind Gatekeeper Secrets        
INFO[0029] Deploying Codewind Gatekeeper Session Secrets 
INFO[0029] Deploying Codewind Gatekeeper TLS Secrets    
INFO[0029] Deploying Codewind Gatekeeper Deployment     
INFO[0029] Deploying Codewind Gatekeeper Service        
INFO[0029] Deploying Codewind Gatekeeper Ingress        
INFO[0029] Waiting for Codewind Gatekeeper to start on https://codewind-gatekeeper-k3eewy7e.{MYDOMAIN}.nip.io 
........
INFO[0036] Waiting for Codewind PFE to start            
.
INFO[0037] Codewind is available at: https://codewind-gatekeeper-k3eewy7e.{MYDOMAIN}.nip.io 

