### PR TITLE
Activate service account for remote deployments

### DIFF
--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -125,8 +125,8 @@ func generateDeployment(codewind Codewind, name string, image string, port int, 
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					//ServiceAccountName: codewind.ServiceAccountName,
-					Volumes: volumes,
+					ServiceAccountName: codewind.ServiceAccountName,
+					Volumes:            volumes,
 					Containers: []corev1.Container{
 						{
 							Name:            name,


### PR DESCRIPTION
## Problem
Codewind pods should run using custom codewind service account

Resolves : https://github.com/eclipse/codewind/issues/1265

## Solution

Adopt service account on Codewind pods.  

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>