### PR TITLE
{WIP}set logging stream to stdout for logr.info

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -13,7 +13,6 @@ package actions
 
 import (
 	"crypto/tls"
-	"log"
 	"net/http"
 	"os"
 
@@ -746,7 +745,7 @@ func Commands() {
 			break
 		default:
 			logr.SetLevel(logr.InfoLevel)
-			log.SetOutput(os.Stdout)
+			logr.SetOutput(os.Stdout)
 		}
 
 		return nil

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -13,6 +13,7 @@ package actions
 
 import (
 	"crypto/tls"
+	"log"
 	"net/http"
 	"os"
 
@@ -745,6 +746,7 @@ func Commands() {
 			break
 		default:
 			logr.SetLevel(logr.InfoLevel)
+			log.SetOutput(os.Stdout)
 		}
 
 		return nil

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -743,6 +743,9 @@ func Commands() {
 		case loglevel == "error":
 			logr.SetLevel(logr.ErrorLevel)
 			break
+		case loglevel == "warn":
+			logr.SetLevel(logr.WarnLevel)
+			break
 		default:
 			logr.SetLevel(logr.InfoLevel)
 			logr.SetOutput(os.Stdout)

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -157,7 +157,7 @@ func DownloadFile(URL, destination string) error {
 
 	// Write body to file
 	_, err = io.Copy(file, resp.Body)
-	logr.Infof("Downloaded file from '%s' to '%s'\n", URL, destination)
+	logr.Tracef("Downloaded file from '%s' to '%s'\n", URL, destination)
 
 	return err
 }
@@ -204,7 +204,7 @@ func UnZip(filePath, destination string) error {
 			errors.CheckErr(err, 404, "")
 		}
 	}
-	logr.Infof("Extracted file from '%s' to '%s'\n", filePath, destination)
+	logr.Tracef("Extracted file from '%s' to '%s'\n", filePath, destination)
 	return nil
 }
 


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/1276**
By default logrus sends output down stderr. For logr.info we need to send it to stdout.
Seen in logrus docs:
```
 // Output to stdout instead of the default stderr
  // Can be any io.Writer, see below for File example
  log.SetOutput(os.Stdout)
```

**Solution**
Set the output stream for default log level (info) to be stdout.

This will only effect `logrus` logging. No json output should be effected by this change or by `logrus`

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>