### PR TITLE
Persist Keycloak Data for remote deployment

### DIFF
--- a/pkg/remote/defaults.go
+++ b/pkg/remote/defaults.go
@@ -73,4 +73,7 @@ const (
 
 	// CodewindRoleBindingNamePrefix will include the workspaceID when deployed
 	CodewindRoleBindingNamePrefix = "codewind-rolebinding"
+
+	// ROKSStorageClass referencces the storage class to use on ROKS (OpenShift on IKS)
+	ROKSStorageClass = "ibmc-file-bronze"
 )

--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -103,28 +103,40 @@ func DeployGatekeeper(config *restclient.Config, clientset *kubernetes.Clientset
 }
 
 func createGatekeeperTLSSecret(codewind Codewind, pemPrivateKey string, pemPublicCert string) corev1.Secret {
+	labels := map[string]string{
+		"app":               GatekeeperPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
 	secrets := map[string]string{
 		"tls.crt": pemPublicCert,
 		"tls.key": pemPrivateKey,
 	}
 	name := "secret-codewind-tls"
-	return generateSecrets(codewind, name, secrets)
+	return generateSecrets(codewind, name, secrets, labels)
 }
 
 func createGatekeeperSessionSecret(codewind Codewind, deployOptions *DeployOptions) corev1.Secret {
+	labels := map[string]string{
+		"app":               GatekeeperPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
 	secrets := map[string]string{
 		"session_secret": deployOptions.CodewindSessionSecret,
 	}
 	name := "secret-codewind-session"
-	return generateSecrets(codewind, name, secrets)
+	return generateSecrets(codewind, name, secrets, labels)
 }
 
 func createGatekeeperSecrets(codewind Codewind, deployOptions *DeployOptions) corev1.Secret {
+	labels := map[string]string{
+		"app":               GatekeeperPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
 	secrets := map[string]string{
 		"client_secret": deployOptions.ClientSecret,
 	}
 	name := "secret-codewind-client"
-	return generateSecrets(codewind, name, secrets)
+	return generateSecrets(codewind, name, secrets, labels)
 }
 
 func createGatekeeperDeploy(codewind Codewind, deployOptions *DeployOptions) appsv1.Deployment {

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -76,7 +76,7 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 // createPFEDeploy : creates a Kubernetes deploy resource
 func createPFEDeploy(codewind Codewind, deployOptions *DeployOptions) appsv1.Deployment {
 	labels := map[string]string{
-		"app":               "codewind-pfe",
+		"app":               PFEPrefix,
 		"codewindWorkspace": codewind.WorkspaceID,
 	}
 	volumes, volumeMounts := setPFEVolumes(codewind)
@@ -87,7 +87,7 @@ func createPFEDeploy(codewind Codewind, deployOptions *DeployOptions) appsv1.Dep
 // createPFEService : creates a Kubernetes service
 func createPFEService(codewind Codewind) corev1.Service {
 	labels := map[string]string{
-		"app":               "codewind-pfe",
+		"app":               PFEPrefix,
 		"codewindWorkspace": codewind.WorkspaceID,
 	}
 	return generateService(codewind, PFEPrefix, PFEContainerPort, labels)

--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -130,13 +130,17 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 
 //CreateCodewindRoleBindings : create Codewind role bindings in the deployment namespace
 func CreateCodewindRoleBindings(codewindInstance Codewind, deployOptions *DeployOptions, codewindRoleBindingName string) rbacv1.ClusterRoleBinding {
+	labels := map[string]string{
+		"codewindWorkspace": codewindInstance.WorkspaceID,
+	}
 	return rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1beta1",
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: codewindRoleBindingName,
+			Name:   codewindRoleBindingName,
+			Labels: labels,
 		},
 		Subjects: []rbacv1.Subject{
 			rbacv1.Subject{

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -151,7 +151,7 @@ func generateDeployment(codewind Codewind, name string, image string, port int, 
 	return deployment
 }
 
-func generateSecrets(codewind Codewind, name string, secrets map[string]string) corev1.Secret {
+func generateSecrets(codewind Codewind, name string, secrets map[string]string, labels map[string]string) corev1.Secret {
 	secret := corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -160,6 +160,7 @@ func generateSecrets(codewind Codewind, name string, secrets map[string]string) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "-" + codewind.WorkspaceID,
 			Namespace: codewind.Namespace,
+			Labels:    labels,
 		},
 		StringData: secrets,
 	}


### PR DESCRIPTION

## Problem 

Codewind-Keycloak data is lost after restarting pod.  As logged in Issue https://github.com/eclipse/codewind/issues/1024

## Solution 

* Store Keycloak H2 database in persistent storage by creating a PVC and Volume mount for the Keycloak POD
* Use default storage class but prefer "ibmc-file-bronze" for ROKS where available (public cloud)
* Updates labels of deployed Kube assets 

## Manual tests : 

PVC created : 
```
NAMESPACE    NAME                                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
marktest77   persistentvolumeclaim/codewind-keycloak-pvc-k3fungr2   Bound    pvc-14e263bd-104a-11ea-b495-00000a3301df   1Gi        RWO            glusterfs-storage   14m
```

Configured Kube,  deleted pod, new pod scheduled, on startup pod retained configuration.



Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>