### PR TITLE
pr revert fix

### DIFF
--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -13,6 +13,7 @@ package project
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -172,7 +173,7 @@ func ValidateProject(c *cli.Context) *ProjectError {
 	if extensionType == "" {
 		writeCwSettingsIfNotInProject(conID, projectPath, buildType)
 	}
-	logr.Infoln(string(projectInfo))
+	fmt.Println(string(projectInfo))
 	return nil
 }
 


### PR DESCRIPTION
**Problem**
Reverting previous PR's left 1 line of code behind that preventing the CLI from compiling. 
```
➜  codewind-installer git:(master) go run cmd/cli/main.go                                                           
# github.com/eclipse/codewind-installer/pkg/project
pkg/project/create.go:175:2: undefined: logr
```

**Solution**
Revert the `logr` statement back to `fmt`. The initial change form `fmt`-> `logr` can be seen here:
https://github.com/eclipse/codewind-installer/pull/209/files#diff-d823d43b71167b0d77cd4bc32f7cf6b3L176
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>