### PR TITLE
update the imports to sync Gopkg.toml with Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -684,6 +684,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",


### PR DESCRIPTION
**Problem**
Master build is failing due to Gopkg.toml & Gopkg.lock being out of sync. This is due to a recent change that has gone into master.

```
➜  codewind-installer git:(master) dep status
Gopkg.lock is out of sync with imports and/or Gopkg.toml. Run `dep check` for details.
PROJECT  MISSING PACKAGES
input-digest mismatch
```

**Solution**
Sync the files by running `dep ensure -v`.

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>