### PR TITLE
Change ClusterRoleBindings to Rolebindings

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -779,6 +779,9 @@ func Commands() {
 		case loglevel == "error":
 			logr.SetLevel(logr.ErrorLevel)
 			break
+		case loglevel == "warn":
+			logr.SetLevel(logr.WarnLevel)
+			break
 		default:
 			logr.SetLevel(logr.InfoLevel)
 		}

--- a/pkg/remote/defaults.go
+++ b/pkg/remote/defaults.go
@@ -74,6 +74,6 @@ const (
 	// CodewindRoleBindingNamePrefix will include the workspaceID when deployed
 	CodewindRoleBindingNamePrefix = "codewind-rolebinding"
 
-	// ROKSStorageClass referencces the storage class to use on ROKS (OpenShift on IKS)
+	// ROKSStorageClass references the storage class to use on ROKS (OpenShift on IKS)
 	ROKSStorageClass = "ibmc-file-bronze"
 )

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -47,12 +47,12 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 	}
 
 	logr.Infof("Checking if '%v' role bindings exist\n", codewindRoleBindingName)
-	rolebindings, err := clientset.RbacV1().ClusterRoleBindings().Get(codewindRoleBindingName, metav1.GetOptions{})
+	rolebindings, err := clientset.RbacV1().RoleBindings(codewindInstance.Namespace).Get(codewindRoleBindingName, metav1.GetOptions{})
 	if rolebindings != nil && err == nil {
-		logr.Warnf("Cluster role binding '%v' already exist.\n", codewindRoleBindingName)
+		logr.Warnf("Role binding '%v' already exist.\n", codewindRoleBindingName)
 	} else {
-		logr.Infof("Adding '%v' cluster role binding\n", codewindRoleBindingName)
-		_, err = clientset.RbacV1().ClusterRoleBindings().Create(&codewindRoleBindings)
+		logr.Infof("Adding '%v' role binding\n", codewindRoleBindingName)
+		_, err = clientset.RbacV1().RoleBindings(codewindInstance.Namespace).Create(&codewindRoleBindings)
 		if err != nil {
 			logr.Errorf("Unable to add '%v' access roles: %v\n", codewindRoleBindingName, err)
 			return err

--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -129,11 +129,11 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 }
 
 //CreateCodewindRoleBindings : create Codewind role bindings in the deployment namespace
-func CreateCodewindRoleBindings(codewindInstance Codewind, deployOptions *DeployOptions, codewindRoleBindingName string) rbacv1.ClusterRoleBinding {
+func CreateCodewindRoleBindings(codewindInstance Codewind, deployOptions *DeployOptions, codewindRoleBindingName string) rbacv1.RoleBinding {
 	labels := map[string]string{
 		"codewindWorkspace": codewindInstance.WorkspaceID,
 	}
-	return rbacv1.ClusterRoleBinding{
+	return rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1beta1",
 			Kind:       "RoleBinding",


### PR DESCRIPTION
# Whats included: 

Change `ClusterRoleBindings` to `RoleBindings` for new Codewind remote deployments per issue : https://github.com/eclipse/codewind/issues/1301

## Results:

After deploying Codewind remote,  inspection of the resources shows the new RoleBinding in the deployment namespace instead of the older ClusterRoleBinding 

From : 
```
NAMESPACE    NAME                                                                   ROLE                        USERS   GROUPS   SERVICE ACCOUNTS    SUBJECTS
            clusterrolebinding.authorization.openshift.io/codewind-rolebinding-k3h184jx   /eclipse-codewind-x.x.dev                    marktest82/codewind-k3h184jx   
```

To:
```
NAMESPACE    NAME                                                                   ROLE                        USERS   GROUPS   SERVICE ACCOUNTS    SUBJECTS
marktest77   rolebinding.authorization.openshift.io/codewind-rolebinding-k3ij022n   /eclipse-codewind-x.x.dev                    codewind-k3ij022n   
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>