### PR TITLE
Create shared-workspace

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -188,7 +188,7 @@ func Commands() {
 						cli.StringFlag{Name: "kdevpass,dp", Usage: "Keycloak developer username initial password", Required: false},
 						cli.StringFlag{Name: "krealm,r", Usage: "Keycloak realm to setup", Required: false},
 						cli.StringFlag{Name: "kclient,c", Usage: "Keycloak client to setup", Required: false},
-						cli.IntFlag{Name: "wssize,g", Usage: "Workspace size (integer between 1 and 999 Gigabytes)", Required: false, Value: 1},
+						cli.IntFlag{Name: "pvcsize,p", Usage: "Codewind PVC size (integer between 1 and 999 Gigabytes)", Required: false, Value: 1},
 					},
 					Action: func(c *cli.Context) error {
 						DoRemoteInstall(c)

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -188,6 +188,7 @@ func Commands() {
 						cli.StringFlag{Name: "kdevpass,dp", Usage: "Keycloak developer username initial password", Required: false},
 						cli.StringFlag{Name: "krealm,r", Usage: "Keycloak realm to setup", Required: false},
 						cli.StringFlag{Name: "kclient,c", Usage: "Keycloak client to setup", Required: false},
+						cli.IntFlag{Name: "wssize,g", Usage: "Workspace size (integer between 1 and 999 Gigabytes)", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						DoRemoteInstall(c)

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -188,7 +188,7 @@ func Commands() {
 						cli.StringFlag{Name: "kdevpass,dp", Usage: "Keycloak developer username initial password", Required: false},
 						cli.StringFlag{Name: "krealm,r", Usage: "Keycloak realm to setup", Required: false},
 						cli.StringFlag{Name: "kclient,c", Usage: "Keycloak client to setup", Required: false},
-						cli.IntFlag{Name: "wssize,g", Usage: "Workspace size (integer between 1 and 999 Gigabytes)", Required: false},
+						cli.IntFlag{Name: "wssize,g", Usage: "Workspace size (integer between 1 and 999 Gigabytes)", Required: false, Value: 1},
 					},
 					Action: func(c *cli.Context) error {
 						DoRemoteInstall(c)

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -84,14 +84,14 @@ func DoRemoteInstall(c *cli.Context) {
 		session = strings.ToUpper(strconv.FormatInt(utils.CreateTimestamp(), 36))
 	}
 
-	if c.Int("wssize") < 0 || c.Int("wssize") > 999 {
-		logr.Error("shared-workspace size should be between 1 and 999 GB")
+	if c.Int("pvcsize") < 0 || c.Int("pvcsize") > 999 {
+		logr.Error("Codewind PVC size should be between 1 and 999 GB")
 		os.Exit(1)
 	}
 
-	sharedWorkspaceSize := c.Int("wssize")
-	if sharedWorkspaceSize < 1 {
-		sharedWorkspaceSize = 1
+	codewindPVCSize := c.Int("pvcsize")
+	if codewindPVCSize < 1 {
+		codewindPVCSize = 1
 	}
 
 	deployOptions := remote.DeployOptions{
@@ -106,7 +106,7 @@ func DoRemoteInstall(c *cli.Context) {
 		GateKeeperTLSSecure:   true,
 		KeycloakTLSSecure:     true,
 		CodewindSessionSecret: session,
-		SharedWorkspaceSize:   strconv.Itoa(sharedWorkspaceSize) + "Gi",
+		CodewindPVCSize:       strconv.Itoa(codewindPVCSize) + "Gi",
 	}
 
 	deploymentResult, remInstError := remote.DeployRemote(&deployOptions)

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -84,6 +84,16 @@ func DoRemoteInstall(c *cli.Context) {
 		session = strings.ToUpper(strconv.FormatInt(utils.CreateTimestamp(), 36))
 	}
 
+	if c.Int("wssize") < 0 || c.Int("wssize") > 999 {
+		logr.Error("shared-workspace size should be between 1 and 999 GB")
+		os.Exit(1)
+	}
+
+	sharedWorkspaceSize := c.Int("wssize")
+	if sharedWorkspaceSize < 1 {
+		sharedWorkspaceSize = 1
+	}
+
 	deployOptions := remote.DeployOptions{
 		Namespace:             c.String("namespace"),
 		IngressDomain:         c.String("ingress"),
@@ -96,6 +106,7 @@ func DoRemoteInstall(c *cli.Context) {
 		GateKeeperTLSSecure:   true,
 		KeycloakTLSSecure:     true,
 		CodewindSessionSecret: session,
+		SharedWorkspaceSize:   strconv.Itoa(sharedWorkspaceSize) + "Gi",
 	}
 
 	deploymentResult, remInstError := remote.DeployRemote(&deployOptions)

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -45,7 +45,7 @@ type DeployOptions struct {
 	GateKeeperTLSSecure   bool
 	CodewindSessionSecret string
 	ClientSecret          string
-	SharedWorkspaceSize   string
+	CodewindPVCSize       string
 }
 
 // DeploymentResult : Ingress root URLs

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -45,6 +45,7 @@ type DeployOptions struct {
 	GateKeeperTLSSecure   bool
 	CodewindSessionSecret string
 	ClientSecret          string
+	SharedWorkspaceSize   string
 }
 
 // DeploymentResult : Ingress root URLs
@@ -140,7 +141,7 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 	ownerReferenceName = "codewind" + workspaceID
 	ownerReferenceUID = uuid.NewUUID()
 
-	workspacePVC := "codewind-" + workspaceID
+	workspacePVC := PFEPrefix + "-pvc-" + workspaceID
 	dockerPullSecret := "codewind-" + workspaceID + "-docker-registries"
 	logr.Infof("Docker registry pull secret name: '%v'", dockerPullSecret)
 

--- a/pkg/remote/deploy_keycloak.go
+++ b/pkg/remote/deploy_keycloak.go
@@ -281,8 +281,8 @@ func createKeycloakPVC(codewind Codewind, deployOptions *DeployOptions, storageC
 
 	pvc := corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
-			APIVersion: "route.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   KeycloakPrefix + "-pvc-" + codewind.WorkspaceID,

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -68,7 +68,7 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 		logr.Infof("Setting storage class to %s\n", storageClass)
 	}
 
-	logr.Infof("Creating and setting Codewind PVC %v to %v ", codewindInstance.PVCName, deployOptions.SharedWorkspaceSize)
+	logr.Infof("Creating and setting Codewind PVC %v to %v ", codewindInstance.PVCName, deployOptions.CodewindPVCSize)
 	codewindWorkspacePVC := createCodewindPVC(codewindInstance, deployOptions, storageClass)
 	_, err = clientset.CoreV1().PersistentVolumeClaims(deployOptions.Namespace).Create(&codewindWorkspacePVC)
 	if err != nil {
@@ -217,7 +217,7 @@ func createCodewindPVC(codewind Codewind, deployOptions *DeployOptions, storageC
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(deployOptions.SharedWorkspaceSize),
+					corev1.ResourceStorage: resource.MustParse(deployOptions.CodewindPVCSize),
 				},
 			},
 		},

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -17,6 +17,7 @@ import (
 	logr "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -57,6 +58,22 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 			logr.Errorf("Unable to add '%v' access roles: %v\n", codewindRoleBindingName, err)
 			return err
 		}
+	}
+
+	// Determine if we're running on OpenShift on IKS (and thus need to use the ibm-file-bronze storage class)
+	storageClass := ""
+	sc, err := clientset.StorageV1().StorageClasses().Get(ROKSStorageClass, metav1.GetOptions{})
+	if err == nil && sc != nil {
+		storageClass = sc.Name
+		logr.Infof("Setting storage class to %s\n", storageClass)
+	}
+
+	logr.Infoln("Creating Codewind PVC")
+	codewindWorkspacePVC := createCodewindPVC(codewindInstance, deployOptions, storageClass)
+	_, err = clientset.CoreV1().PersistentVolumeClaims(deployOptions.Namespace).Create(&codewindWorkspacePVC)
+	if err != nil {
+		logr.Errorf("Error: Unable to create Codewind PVC: %v\n", err)
+		return err
 	}
 
 	logr.Infoln("Deploying Codewind Service")
@@ -178,21 +195,57 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 	}
 }
 
-// setPFEVolumes returns the 3 volumes & corresponding volume mounts required by the PFE container:
+func createCodewindPVC(codewind Codewind, deployOptions *DeployOptions, storageClass string) corev1.PersistentVolumeClaim {
+
+	labels := map[string]string{
+		"app":               KeycloakPrefix,
+		"codewindWorkspace": codewind.WorkspaceID,
+	}
+
+	pvc := corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PersistentVolumeClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   PFEPrefix + "-pvc-" + codewind.WorkspaceID,
+			Labels: labels,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				"ReadWriteMany",
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	// If a storage class was passed in, set it in the PVC
+	if storageClass != "" {
+		pvc.Spec.StorageClassName = &storageClass
+	}
+
+	return pvc
+}
+
+// setPFEVolumes returns the 2 volumes & corresponding volume mounts required by the PFE container:
 // project workspace, buildah volume, and the docker registry secret (the latter of which is optional)
 func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
 	secretMode := int32(511)
 	isOptional := true
 
 	volumes := []corev1.Volume{
-		// {
-		// 	Name: "shared-workspace",
-		// 	VolumeSource: corev1.VolumeSource{
-		// 		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-		// 			ClaimName: codewind.PVCName,
-		// 		},
-		// 	},
-		// },
+		{
+			Name: "shared-workspace",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: PFEPrefix + "-pvc-" + codewind.WorkspaceID,
+				},
+			},
+		},
 		{
 			Name: "buildah-volume",
 		},
@@ -209,11 +262,11 @@ func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		// {
-		// 	Name:      "shared-workspace",
-		// 	MountPath: "/codewind-workspace",
-		// 	SubPath:   codewind.WorkspaceID + "/projects",
-		// },
+		{
+			Name:      "shared-workspace",
+			MountPath: "/codewind-workspace",
+			SubPath:   codewind.WorkspaceID + "/projects",
+		},
 		{
 			Name:      "buildah-volume",
 			MountPath: "/var/lib/containers",

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -68,7 +68,7 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 		logr.Infof("Setting storage class to %s\n", storageClass)
 	}
 
-	logr.Infof("Creating Codewind PVC %v to %v ", codewindInstance.PVCName, deployOptions.SharedWorkspaceSize)
+	logr.Infof("Creating and setting Codewind PVC %v to %v ", codewindInstance.PVCName, deployOptions.SharedWorkspaceSize)
 	codewindWorkspacePVC := createCodewindPVC(codewindInstance, deployOptions, storageClass)
 	_, err = clientset.CoreV1().PersistentVolumeClaims(deployOptions.Namespace).Create(&codewindWorkspacePVC)
 	if err != nil {
@@ -198,7 +198,7 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 func createCodewindPVC(codewind Codewind, deployOptions *DeployOptions, storageClass string) corev1.PersistentVolumeClaim {
 
 	labels := map[string]string{
-		"app":               KeycloakPrefix,
+		"app":               PFEPrefix,
 		"codewindWorkspace": codewind.WorkspaceID,
 	}
 

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -208,7 +208,7 @@ func createCodewindPVC(codewind Codewind, deployOptions *DeployOptions, storageC
 			Kind:       "PersistentVolumeClaim",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   PFEPrefix + "-pvc-" + codewind.WorkspaceID,
+			Name:   codewind.PVCName,
 			Labels: labels,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -242,7 +242,7 @@ func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
 			Name: "shared-workspace",
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: PFEPrefix + "-pvc-" + codewind.WorkspaceID,
+					ClaimName: codewind.PVCName,
 				},
 			},
 		},

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -68,7 +68,7 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 		logr.Infof("Setting storage class to %s\n", storageClass)
 	}
 
-	logr.Infoln("Creating Codewind PVC")
+	logr.Infof("Creating Codewind PVC %v to %v ", codewindInstance.PVCName, deployOptions.SharedWorkspaceSize)
 	codewindWorkspacePVC := createCodewindPVC(codewindInstance, deployOptions, storageClass)
 	_, err = clientset.CoreV1().PersistentVolumeClaims(deployOptions.Namespace).Create(&codewindWorkspacePVC)
 	if err != nil {
@@ -217,7 +217,7 @@ func createCodewindPVC(codewind Codewind, deployOptions *DeployOptions, storageC
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse("1Gi"),
+					corev1.ResourceStorage: resource.MustParse(deployOptions.SharedWorkspaceSize),
 				},
 			},
 		},


### PR DESCRIPTION
## Problem

Add PFE missing PVC for codewind-workspace per issue : https://github.com/eclipse/codewind/issues/1294

## Solution

* Add PVC for the codewind-workspace,  set to RWX   (read write on anynode)
* Make size of codewind-workspace configurable at deploy time by addition of optional flag  `--wssize` 


## Result

console log line during install : 

```
INFO[0062] Creating and setting Codewind PVC codewind-pfe-pvc-k3j2rx4i to 2Gi 
```

Command options with addition of new pvcsize flag : 

```
OPTIONS:
   --namespace value, -n value     Kubernetes namespace
   --session value, --ses value    Codewind session secret
   --ingress value, -i value       Ingress Domain eg: 10.22.33.44.nip.io
   --kadminuser value, --au value  Keycloak admin user
   --kadminpass value, --ap value  Keycloak admin password
   --kdevuser value, --du value    Keycloak developer username to add
   --kdevpass value, --dp value    Keycloak developer username initial password
   --krealm value, -r value        Keycloak realm to setup
   --kclient value, -c value       Keycloak client to setup
   --pvcsize value, -g value       Workspace size (integer between 1 and 999 Gigabytes) (default: 1)

```

Additional log entry during deployment : 

Kube resources : 

```
NAME                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
codewind-keycloak-pvc-k3j2rx4i   Bound    pvc-33893533-1210-11ea-b495-00000a3301df   1Gi        RWO            glusterfs-storage   3m
codewind-pfe-pvc-k3j2rx4i        Bound    pvc-58584043-1210-11ea-b495-00000a3301df   2Gi        RWX            glusterfs-storage   2m
```

```
Name:          codewind-pfe-pvc-k3j2rx4i
Namespace:     marktest101
StorageClass:  glusterfs-storage
Status:        Bound
Volume:        pvc-58584043-1210-11ea-b495-00000a3301df
Labels:        app=codewind-pfe
               codewindWorkspace=k3j2rx4i
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/glusterfs
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      2Gi
Access Modes:  RWX
Events:
  Type       Reason                 Age    From                         Message
  ----       ------                 ----   ----                         -------
  Normal     ProvisioningSucceeded  3m19s  persistentvolume-controller  Successfully provisioned volume pvc-58584043-1210-11ea-b495-00000a3301df using kubernetes.io/glusterfs
Mounted By:  codewind-pfe-k3j2rx4i-7dbcc7d59b-4jz54
```

PFE volume mounts : 

```
  Volumes:
  shared-workspace:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  codewind-pfe-pvc-k3j2rx4i
    ReadOnly:   false


 Environment:
      PVC_NAME:                       codewind-pfe-pvc-k3j2rx4i
   
  Mounts:
      /codewind-workspace from shared-workspace (rw,path="k3j2rx4i/projects")

```



Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>