### PR TITLE
Update PFE Environment variables (Ingress)

### DIFF
--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -161,7 +161,7 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 		},
 		{
 			Name:  "INGRESS_PREFIX",
-			Value: codewind.RequestedIngress, // provides access to project containers
+			Value: codewind.Namespace + "." + codewind.RequestedIngress, // provides access to project containers
 		},
 		{
 			Name:  "ON_OPENSHIFT",

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -157,7 +157,7 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 		},
 		{
 			Name:  "CHE_INGRESS_HOST",
-			Value: codewind.Ingress,
+			Value: GatekeeperPrefix + codewind.Ingress,
 		},
 		{
 			Name:  "INGRESS_PREFIX",


### PR DESCRIPTION
## Problem

Unable to access launched Codewind and Appsody projects in Codewind Remote

issue https://github.com/eclipse/codewind/issues/1307

Turbine uses the PFE environment variable INGRESS_PREFIX when constructing a project Ingress and is expecting the URL to include the namespace.

## Solution 

Updates the INGRESS_PREFIX variable to include the namespace.
Updates the CHE_INGRESS_HOST variable to point to the Gatekeeper Ingress URL.

## Pod environment : 

Example of environment after deploying with this PR : 

```
Environment:
      TEKTON_PIPELINE:                tekton-pipelines
      IN_K8:                          true
      PORTAL_HTTPS:                   true
      KUBE_NAMESPACE:                 marktest204
      TILLER_NAMESPACE:               marktest204
      CHE_WORKSPACE_ID:               k3jwx9hj
      PVC_NAME:                       codewind-k3jwx9hj
      SERVICE_NAME:                   codewind-k3jwx9hj
      SERVICE_ACCOUNT_NAME:           codewind-k3jwx9hj
      MICROCLIMATE_RELEASE_NAME:      RELEASE-NAME
      HOST_WORKSPACE_DIRECTORY:       /projects
      CONTAINER_WORKSPACE_DIRECTORY:  /codewind-workspace
      OWNER_REF_NAME:                 codewindk3jwx9hj
      OWNER_REF_UID:                  c43d7d13-4977-4645-82c2-0c81357a0a2c
      CODEWIND_PERFORMANCE_SERVICE:   codewind-performance-k3jwx9hj
      CHE_INGRESS_HOST:               codewind-gatekeeper-k3jwx9hj.apps.{mycluster}.x.x.x.x.nip.io
      INGRESS_PREFIX:                 marktest204.apps.{mycluster}.x.x.x.x.nip.io
      ON_OPENSHIFT:                   true
      CODEWIND_AUTH_REALM:            codewind
      CODEWIND_AUTH_HOST:             codewind-keycloak-k3jwx9hj.apps.{mycluster}.x.x.x.x.nip.io
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>