### PR TITLE
enable config test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,20 @@ spec:
             }
 
             steps {
-                echo 'Testing to be defined.'
+                echo 'Starting tests'
+
+                container('go') {
+                    sh '''
+                        export GOPATH=/go:/home/jenkins/agent
+                        export GOCACHE="off"
+
+                        cd ../../$CODE_DIRECTORY_FOR_GO
+                        cd pkg/config
+                        go test -v
+                        cd ../../
+                    '''
+                }
+                echo 'End of test stage'
             }
         }
 


### PR DESCRIPTION
**Problem**
No unit tests are currently run in Jenkins.

**Solution**
This PR will enable the first test - `config_test.go`.

**Tested**
This change has been tested on a test PR that can run a modified Jenkinsfile. https://ci.eclipse.org/codewind/job/Codewind/job/codewind-installer/job/PR-182/25/console

*Output in test script:*
```
+ cd ../../src/github.com/eclipse/codewind-installer
+ cd pkg/config
+ go test -v

=== RUN   TestPFEOriginFromConnection
=== RUN   TestPFEOriginFromConnection/get_templates_of_all_styles
--- PASS: TestPFEOriginFromConnection (0.00s)
    --- PASS: TestPFEOriginFromConnection/get_templates_of_all_styles (0.00s)
PASS
ok  	github.com/eclipse/codewind-installer/pkg/config	0.004s
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>