### PR TITLE
{wip} Remote install - Wait for pods to startup before accessing services

### DIFF
--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -94,7 +94,7 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 		// insert the namespace
 		requestedNamespace, err := clientset.CoreV1().Namespaces().Create(&deploymentNamespace)
 		if err != nil || requestedNamespace == nil {
-			logr.Error("Unable to create %v namespace: %v", namespace, err)
+			logr.Errorf("Unable to create %v namespace: %v", namespace, err)
 			return nil, &RemInstError{errOpCreateNamespace, err, err.Error()}
 		}
 	}
@@ -181,6 +181,9 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 		os.Exit(1)
 	}
 
+	podSearch := "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + KeycloakPrefix
+	WaitForPodReady(clientset, codewindInstance, podSearch, KeycloakPrefix+"-"+codewindInstance.WorkspaceID)
+
 	err = SetupKeycloak(codewindInstance, remoteDeployOptions)
 	if err != nil {
 		logr.Errorln("Codewind Keycloak configuration failed, exiting...")
@@ -193,17 +196,26 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 		os.Exit(1)
 	}
 
+	podSearch = "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + PFEPrefix
+	WaitForPodReady(clientset, codewindInstance, podSearch, PFEPrefix+"-"+codewindInstance.WorkspaceID)
+
 	err = DeployPerformance(clientset, codewindInstance, remoteDeployOptions)
 	if err != nil {
 		logr.Errorln("Codewind deployment failed, exiting...")
 		os.Exit(1)
 	}
 
+	podSearch = "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + PerformancePrefix
+	WaitForPodReady(clientset, codewindInstance, podSearch, PerformancePrefix+"-"+codewindInstance.WorkspaceID)
+
 	err = DeployGatekeeper(config, clientset, codewindInstance, remoteDeployOptions)
 	if err != nil {
 		logr.Errorln("Codewind Gatekeeper deployment failed, exiting...")
 		os.Exit(1)
 	}
+
+	podSearch = "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + GatekeeperPrefix
+	WaitForPodReady(clientset, codewindInstance, podSearch, GatekeeperPrefix+"-"+codewindInstance.WorkspaceID)
 
 	gatekeeperURL := GatekeeperPrefix + codewindInstance.Ingress
 	keycloakURL := KeycloakPrefix + codewindInstance.Ingress

--- a/pkg/remote/deploy_keycloak.go
+++ b/pkg/remote/deploy_keycloak.go
@@ -36,15 +36,7 @@ func DeployKeycloak(config *restclient.Config, clientset *kubernetes.Clientset, 
 	serverKey, serverCert, err := createCertificate(KeycloakPrefix+codewindInstance.Ingress, "Codewind Keycloak")
 	keycloakTLSSecret := createKeycloakTLSSecret(codewindInstance, serverKey, serverCert)
 
-	// Determine if we're running on OpenShift on IKS (and thus need to use the ibm-file-bronze storage class)
-	storageClass := ""
-	sc, err := clientset.StorageV1().StorageClasses().Get(ROKSStorageClass, metav1.GetOptions{})
-	if err == nil && sc != nil {
-		storageClass = sc.Name
-		logr.Infof("Setting storage class to %s\n", storageClass)
-	}
-
-	keycloakPVC := createKeycloakPVC(codewindInstance, deployOptions, storageClass)
+	keycloakPVC := createKeycloakPVC(codewindInstance, deployOptions, "")
 
 	logr.Infoln("Creating Codewind Keycloak PVC")
 	_, err = clientset.CoreV1().PersistentVolumeClaims(deployOptions.Namespace).Create(&keycloakPVC)


### PR DESCRIPTION
## Problem

CWCTL should wait for the pod phase to change to Running before attempting to access its services. Issue :  https://github.com/eclipse/codewind/issues/1308

## Solution 

Ensure pod status is Running before attempting to access any of its services. 

## Example output

```
INFO[0000] Waiting for pod: codewind-keycloak-k3k55nkc  
INFO[0000] codewind-keycloak-k3k55nkc, phase: Pending Unschedulable  
INFO[0000] codewind-keycloak-k3k55nkc, phase: Pending ContainersNotReady  
INFO[0004] codewind-keycloak-k3k55nkc, phase: Running   
INFO[0004] Waiting for Keycloak to start                
...........
INFO[0028] Configuring Keycloak...                            
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>