### PR TITLE
enabe gatekeeper tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,6 +111,8 @@ spec:
                         cd ../../$CODE_DIRECTORY_FOR_GO
                         cd pkg/config
                         go test -v
+                        cd ../gatekeeper
+                        go test -v
                         cd ../../
                     '''
                 }


### PR DESCRIPTION
**Problem**
Gatekeepers tests are currently only run locally. 

**Solution**
Enable the tests to be run in Jenkins

**Tested**
Used test PR branch that is able to run a modified Jenkinsfile https://ci.eclipse.org/codewind/job/Codewind/job/codewind-installer/job/PR-182/27/console

*Test output*
```
+ cd ../gatekeeper
+ go test -v

=== RUN   Test_GetGatekeeperEnvironment
=== RUN   Test_GetGatekeeperEnvironment/Assert_realm_is_remoteRealm
=== RUN   Test_GetGatekeeperEnvironment/Assert_realm_is_remoteRealm#01
=== RUN   Test_GetGatekeeperEnvironment/Assert_realm_is_remoteRealm#02
--- PASS: Test_GetGatekeeperEnvironment (0.00s)
    --- PASS: Test_GetGatekeeperEnvironment/Assert_realm_is_remoteRealm (0.00s)
    --- PASS: Test_GetGatekeeperEnvironment/Assert_realm_is_remoteRealm#01 (0.00s)
    --- PASS: Test_GetGatekeeperEnvironment/Assert_realm_is_remoteRealm#02 (0.00s)
PASS
ok  	github.com/eclipse/codewind-installer/pkg/gatekeeper	0.005s
+ cd ../../
```
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>