### PR TITLE
Remove Vol mount for registry secrets - prep for registry API

### DIFF
--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -142,8 +142,6 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 	ownerReferenceUID = uuid.NewUUID()
 
 	workspacePVC := PFEPrefix + "-pvc-" + workspaceID
-	dockerPullSecret := "codewind-" + workspaceID + "-docker-registries"
-	logr.Infof("Docker registry pull secret name: '%v'", dockerPullSecret)
 
 	// Create the Codewind deployment object
 	codewindInstance := Codewind{
@@ -159,7 +157,6 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 		WorkspaceID:        workspaceID,
 		PVCName:            workspacePVC,
 		ServiceAccountName: "codewind-" + workspaceID, //  codewind-k39vwfk0
-		PullSecret:         dockerPullSecret,
 		OwnerReferenceName: ownerReferenceName,
 		OwnerReferenceUID:  ownerReferenceUID,
 		Privileged:         true,

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -237,10 +237,8 @@ func createCodewindPVC(codewind Codewind, deployOptions *DeployOptions, storageC
 }
 
 // setPFEVolumes returns the 2 volumes & corresponding volume mounts required by the PFE container:
-// project workspace, buildah volume, and the docker registry secret (the latter of which is optional)
+// project workspace, buildah volume
 func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
-	secretMode := int32(511)
-	isOptional := true
 
 	volumes := []corev1.Volume{
 		{
@@ -254,16 +252,6 @@ func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
 		{
 			Name: "buildah-volume",
 		},
-		{
-			Name: "registry-secret",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: &secretMode,
-					SecretName:  codewind.PullSecret,
-					Optional:    &isOptional,
-				},
-			},
-		},
 	}
 
 	volumeMounts := []corev1.VolumeMount{
@@ -275,10 +263,6 @@ func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
 		{
 			Name:      "buildah-volume",
 			MountPath: "/var/lib/containers",
-		},
-		{
-			Name:      "registry-secret",
-			MountPath: "/tmp/secret",
 		},
 	}
 

--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -37,7 +37,7 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 		rbacv1.PolicyRule{
 			APIGroups: []string{""},
 			Resources: []string{"secrets"},
-			Verbs:     []string{"get", "list", "create", "watch"},
+			Verbs:     []string{"get", "list", "create", "watch", "delete"},
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{""},

--- a/pkg/remote/types.go
+++ b/pkg/remote/types.go
@@ -27,7 +27,6 @@ type Codewind struct {
 	WorkspaceID        string
 	PVCName            string
 	ServiceAccountName string
-	PullSecret         string
 	OwnerReferenceName string
 	OwnerReferenceUID  types.UID
 	Privileged         bool

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -17,7 +17,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"os"
@@ -29,7 +28,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
 )
 
 // GetImages returns the images that are to be used for PFE and the Performance dashboard in Codewind
@@ -64,28 +62,6 @@ func GetImages() (string, string, string, string) {
 		gatekeeperTag = GatekeeperImageTag
 	}
 	return pfeImage + ":" + pfeTag, performanceImage + ":" + performanceTag, keycloakImage + ":" + keycloakTag, gatekeeperImage + ":" + gatekeeperTag
-}
-
-// PatchServiceAccount takes in a list of secret names, and patches it to the specified service account
-func PatchServiceAccount(clientset *kubernetes.Clientset, codewind Codewind) error {
-	patch := ServiceAccountPatch{
-		ImagePullSecrets: &[]ImagePullSecret{
-			{
-				Name: codewind.PullSecret,
-			},
-		},
-	}
-
-	b, err := json.Marshal(patch)
-	if err != nil {
-		return err
-	}
-
-	_, err = clientset.CoreV1().ServiceAccounts(codewind.Namespace).Patch(codewind.ServiceAccountName, types.StrategicMergePatchType, b)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // generateDeployment returns a Kubernetes deployment object with the given name for the given image.


### PR DESCRIPTION
## Problem

Codewind PFE has a new API for generating deployment registry secrets.  It should no longer mount a secret during deployment of Remote.  

issue : https://github.com/eclipse/codewind/issues/1341

## Solution

1.  Remove registry-secret volume mount
2. Remove ServiceAccount patch
3. Remove PullSecret name from Codewind deployment
4. Add a "delete" rbac role to the Codewind service account so that the API will be allowed to manage the secrets.  


## Tests

Created a new deployment with changes to validate all services start and user can log in

```
INFO[0000] Checking namespace marktest204 exists        
INFO[0000] Creating marktest204 namespace               
INFO[0000] Using namespace : marktest204                
INFO[0000] Container images :                           
INFO[0000] eclipse/codewind-pfe-amd64:latest            
INFO[0000] eclipse/codewind-performance-amd64:latest    
INFO[0000] eclipse/codewind-keycloak-amd64:latest       
INFO[0000] eclipse/codewind-gatekeeper-amd64:latest     
INFO[0000] Running on openshift: false                  
INFO[0000] Attempting to discover Ingress Domain        
INFO[0000] Using ingress domain: mycluster.x.x.x.x.nip.io    
INFO[0000] Creating service account definition 'codewind-k3plw3kv' 
INFO[0000] Creating codewind-keycloak-k3plw3kv.mycluster.x.x.x.x.nip.io server Key 
INFO[0000] Creating codewind-keycloak-k3plw3kv.mycluster.x.x.x.x.nip.io server certificate 
INFO[0000] Creating Codewind Keycloak PVC               
INFO[0000] Deploying Codewind Keycloak Secrets          
INFO[0000] Deploying Codewind Keycloak TLS Secrets      
INFO[0000] Deploying Codewind Keycloak Ingress          
INFO[0000] Waiting for pod: codewind-keycloak-k3plw3kv  
INFO[0000] codewind-keycloak-k3plw3kv, phase: Pending Unschedulable  
INFO[0016] codewind-keycloak-k3plw3kv, phase: Pending ContainersNotReady  
INFO[0020] codewind-keycloak-k3plw3kv, phase: Running   
INFO[0020] Waiting for Keycloak to start                
..........
INFO[0040] Configuring Keycloak...                      
INFO[0040] https://codewind-keycloak-k3plw3kv.mycluster.x.x.x.x.nip.io 
INFO[0041] Creating Keycloak realm                      
INFO[0043] Creating Keycloak client                     
INFO[0043] Creating access role 'codewind-k3plw3kv' in realm 'codewind' 
INFO[0043] Creating Keycloak initial user               
INFO[0043] Updating Keycloak user password              
INFO[0043] Grant 'developer' access to this deployment  
INFO[0044] Adding role 'codewind-k3plw3kv' to user : '9cc56c88-9138-420c-a80c-5843b4b59c00' 
INFO[0044] Fetching client secret                       
INFO[0044] Checking if 'eclipse-codewind-x.x.dev' cluster access roles are installed 
INFO[0044] Cluster roles 'eclipse-codewind-x.x.dev' already installed 
INFO[0044] Checking if 'codewind-rolebinding-k3plw3kv' role bindings exist 
INFO[0044] Adding 'codewind-rolebinding-k3plw3kv' role binding 
INFO[0044] Creating and setting Codewind PVC codewind-pfe-pvc-k3plw3kv to 1Gi  
INFO[0044] Deploying Codewind Service                   
INFO[0044] Waiting for pod: codewind-pfe-k3plw3kv       
INFO[0044] codewind-pfe-k3plw3kv, phase: Pending Unschedulable  
INFO[0045] codewind-pfe-k3plw3kv, phase: Pending ContainersNotReady  
INFO[0049] codewind-pfe-k3plw3kv, phase: Running        
INFO[0049] Deploying Codewind Performance Dashboard     
INFO[0049] Waiting for pod: codewind-performance-k3plw3kv 
INFO[0049] codewind-performance-k3plw3kv, phase: Pending   
INFO[0049] codewind-performance-k3plw3kv, phase: Pending ContainersNotReady  
INFO[0052] codewind-performance-k3plw3kv, phase: Running   
INFO[0052] Preparing Codewind Gatekeeper resources      
INFO[0052] Creating codewind-gatekeeper-k3plw3kv.mycluster.x.x.x.x.nip.io server Key 
INFO[0052] Creating codewind-gatekeeper-k3plw3kv.mycluster.x.x.x.x.nip.io server certificate 
INFO[0052] Deploying Codewind Gatekeeper Secrets        
INFO[0052] Deploying Codewind Gatekeeper Session Secrets 
INFO[0052] Deploying Codewind Gatekeeper TLS Secrets    
INFO[0052] Deploying Codewind Gatekeeper Deployment     
INFO[0052] Deploying Codewind Gatekeeper Service        
INFO[0052] Deploying Codewind Gatekeeper Ingress        
INFO[0052] Waiting for pod: codewind-gatekeeper-k3plw3kv 
INFO[0052] codewind-gatekeeper-k3plw3kv, phase: Pending   
INFO[0052] codewind-gatekeeper-k3plw3kv, phase: Pending ContainersNotReady  
INFO[0056] codewind-gatekeeper-k3plw3kv, phase: Running   
INFO[0056] Waiting for Codewind Gatekeeper to start on https://codewind-gatekeeper-k3plw3kv.mycluster.x.x.x.x.nip.io 
.....
INFO[0060] Waiting for Codewind PFE to start            
.
INFO[0060] Codewind is available at: https://codewind-gatekeeper-k3plw3kv.mycluster.x.x.x.x.nip.io 
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>