### PR TITLE
iFix - force recreate of a network on docker-compose

### DIFF
--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -142,7 +142,7 @@ func DockerCompose(tempFilePath string, tag string) {
 	}
 	os.Setenv("PFE_EXTERNAL_PORT", port)
 
-	cmd := exec.Command("docker-compose", "-f", tempFilePath, "up", "-d")
+	cmd := exec.Command("docker-compose", "-f", tempFilePath, "up", "-d", "--force-recreate")
 	output := new(bytes.Buffer)
 	cmd.Stdout = output
 	cmd.Stderr = output


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/1325**

Starting Codewind, then pulling the plug on docker without shutting down Codewind properly leaves docker wanting to connect to what seems to be a cached network id upon restart. Thus doesnt exist and therefore errors and fails to start again.
```
Starting codewind-performance ... error

ERROR: for codewind-performance  Cannot start service codewind-performance: b'network 758ccceedb9b35554c71705098408087d8a1493989adb07205ae4a8b35947766 not found'

ERROR: for codewind-performance  Cannot start service codewind-performance: b'network 758ccceedb9b35554c71705098408087d8a1493989adb07205ae4a8b35947766 not found'
Encountered errors while bringing up the project.
```

**Solution**

During docker compose, forcing the network to recreate itself will eliminate the use of older network ID's being searched for/used.

**Tested**
1) Recreated initial issue
2) Put fix in and try again
Unable to reproduce with the fix in

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>