### PR TITLE
force recreate of a network on docker-compose

### DIFF
--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -144,7 +144,7 @@ func DockerCompose(tempFilePath string, tag string) {
 	}
 	os.Setenv("PFE_EXTERNAL_PORT", port)
 
-	cmd := exec.Command("docker-compose", "-f", tempFilePath, "up", "-d")
+	cmd := exec.Command("docker-compose", "-f", tempFilePath, "up", "-d", "--force-recreate")
 	output := new(bytes.Buffer)
 	cmd.Stdout = output
 	cmd.Stderr = output


### PR DESCRIPTION
Same PR as https://github.com/eclipse/codewind-installer/pull/258

This fixes a network issue if Codewind isnt shut down properly and the plug is pulled on docker, upon restart docker will use what seems to be a cached network address ID - Thus meaning it fails to start Codewind again.

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>