### PR TITLE
Fix lookup of kube config file so it works on Windows

### DIFF
--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -59,7 +60,14 @@ type DeploymentResult struct {
 // DeployRemote : InstallRemote
 func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemInstError) {
 
-	kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	homeDir := ""
+	const GOOS string = runtime.GOOS
+	if GOOS == "windows" {
+		homeDir = os.Getenv("USERPROFILE")
+	} else {
+		homeDir = os.Getenv("HOME")
+	}
+	kubeconfig := filepath.Join(homeDir, ".kube", "config")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)


### PR DESCRIPTION
Fix up the lookup of the kube config file so it works on Windows.  Get the user (home) directory the same way it does in other places such as pkg/connections/connection.go, pkg/project/projectDeployment.go, etc.