### PR TITLE
cwctl version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | stop-all    |       | 'Stop all of the Codewind and project containers'                   |
 | remove      | `rm`  | 'Remove Codewind/Project docker images and the codewind network'    |
 | templates   |       | 'Manage project templates'                                          |
-| version     |       | 'Print the versions of Codewind containers, for a given container'  |                                       |
+| version     |       | 'Print the versions of Codewind containers, for a given container'  |
 | sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |
 | secrole     | `sl`  | 'Manage realm based ACCESS roles'                                   |
 | secrealm    | `sr`  | 'Manage new or existing REALM configurations'                       |
@@ -235,13 +235,13 @@ Subcommands:</br>
 ### version
 
 > **Flags:**
-> --conid  value                Connection ID (see the connections cmd)
+> --conid value                 Connection ID (see the connections cmd)
 
 ## sectoken
 
 Subcommands:</br>
 
-`get/g` - Authenticate and obtain åan access_token.
+`get/g` - Authenticate and obtain an access_token.
 
 >**Note 1:**: The preferred way to authenticate is by supplying just the connection ID (conid) and username. In this mode the command will use the stored password from the platform keyring
 >**Note 2:**: If you dont have a connection ID (conid) you must supply use the host, realm and client flags

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | stop-all    |       | 'Stop all of the Codewind and project containers'                   |
 | remove      | `rm`  | 'Remove Codewind/Project docker images and the codewind network'    |
 | templates   |       | 'Manage project templates'                                          |
+| version     |       | 'Print the versions of Codewind containers, for a given container'  |                                       |
 | sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |
 | secrole     | `sl`  | 'Manage realm based ACCESS roles'                                   |
 | secrealm    | `sr`  | 'Manage new or existing REALM configurations'                       |
@@ -231,11 +232,16 @@ Subcommands:</br>
 
 `list/ls` - List available templates
 
+### version
+
+> **Flags:**
+> --conid  value                Connection ID (see the connections cmd)
+
 ## sectoken
 
 Subcommands:</br>
 
-`get/g` - Authenticate and obtain an access_token.
+`get/g` - Authenticate and obtain åan access_token.
 
 >**Note 1:**: The preferred way to authenticate is by supplying just the connection ID (conid) and username. In this mode the command will use the stored password from the platform keyring
 >**Note 2:**: If you dont have a connection ID (conid) you must supply use the host, realm and client flags

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -756,6 +756,18 @@ func Commands() {
 				return nil
 			},
 		},
+		{
+			Name:    "version",
+			Aliases: []string{"v"},
+			Usage:   "Get versions of remotely deployed Codewind containers",
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "conid", Usage: "The connection ID", Required: true},
+			},
+			Action: func(c *cli.Context) error {
+				GetVersions(c)
+				return nil
+			},
+		},
 	}
 
 	app.Before = func(c *cli.Context) error {

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/urfave/cli"
+)
+
+// GetVersions : Gets versions of Codewind containers
+func GetVersions(c *cli.Context) {
+	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
+	containerVersions, err := apiroutes.GetContainerVersions(connectionID, http.DefaultClient)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	utils.PrettyPrintJSON(containerVersions)
+}

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/eclipse/codewind-installer/pkg/appconstants"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+)
+
+type (
+	// ContainerVersions : The versions of the Codewind containers that are running
+	ContainerVersions struct {
+		CwctlVersion       string
+		PerformanceVersion string
+		GatekeeperVersion  string
+		PFEVersion         string
+	}
+
+	// CodewindVersion : The version of the Codewind container that is running
+	CodewindVersion struct {
+		Version string `json:"codewind_version"`
+	}
+)
+
+// GetContainerVersions  :  Gets the versions of each Codewind container, for a given connection ID
+func GetContainerVersions(conID string, httpClient utils.HTTPClient) (ContainerVersions, error) {
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return ContainerVersions{}, conInfoErr.Err
+	}
+
+	var containerVersions ContainerVersions
+	PFEVersion, err := GetPFEVersionFromConnection(conInfo, http.DefaultClient)
+	if err != nil {
+		return ContainerVersions{}, err
+	}
+
+	GatekeeperVersion, err := GetGatekeeperVersionFromConnection(conInfo, http.DefaultClient)
+	if err != nil {
+		return ContainerVersions{}, err
+	}
+
+	PerformanceVersion, err := GetPerformanceVersionFromConnection(conInfo, http.DefaultClient)
+	if err != nil {
+		return ContainerVersions{}, err
+	}
+
+	containerVersions.CwctlVersion = appconstants.VersionNum
+	containerVersions.PFEVersion = PFEVersion
+	containerVersions.GatekeeperVersion = GatekeeperVersion
+	containerVersions.PerformanceVersion = PerformanceVersion
+
+	return containerVersions, nil
+}
+
+// GetPFEVersionFromConnection : Gets the version of the PFE container, deployed to the connection with the given ID
+func GetPFEVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
+	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environmen", nil)
+	if err != nil {
+		return "", err
+	}
+
+	version, err := getVersionFromEnvAPI(req, connection, HTTPClient)
+	if err != nil {
+		return "", err
+	}
+	return version, err
+}
+
+// GetGatekeeperVersionFromConnection : Gets the version of the Gatekeeper container, deployed to the connection with the given ID
+func GetGatekeeperVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
+	req, err := http.NewRequest("GET", connection.URL+"/api/v1/gatekeeper/environment", nil)
+	if err != nil {
+		return "", err
+	}
+
+	version, err := getVersionFromEnvAPI(req, connection, HTTPClient)
+	if err != nil {
+		return "", err
+	}
+	return version, err
+}
+
+// GetPerformanceVersionFromConnection : Gets the version of the Performance container, deployed to the connection with the given ID
+func GetPerformanceVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
+	req, err := http.NewRequest("GET", connection.URL+"/performance/api/v1/environment", nil)
+	if err != nil {
+		return "", err
+	}
+
+	version, err := getVersionFromEnvAPI(req, connection, HTTPClient)
+	if err != nil {
+		return "", err
+	}
+	return version, err
+}
+
+func getVersionFromEnvAPI(req *http.Request, connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
+	client := &http.Client{}
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, connection)
+	if httpSecError != nil {
+		return "", httpSecError
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", nil
+	}
+
+	defer resp.Body.Close()
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var codewindVersion CodewindVersion
+	err = json.Unmarshal(byteArray, &codewindVersion)
+	if err != nil {
+		return "", err
+	}
+
+	return codewindVersion.Version, nil
+}

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -31,7 +31,7 @@ type (
 		PFEVersion         string
 	}
 
-	// EnvResponse : The response from the remote environment API
+	// EnvResponse : The relevent response fields from the remote environment API
 	EnvResponse struct {
 		Version        string `json:"codewind_version"`
 		ImageBuildTime string `json:"image_build_time"`
@@ -61,6 +61,7 @@ func GetContainerVersions(conID string, httpClient utils.HTTPClient) (ContainerV
 		return ContainerVersions{}, err
 	}
 
+	// Get cwctl version from inside the code
 	containerVersions.CwctlVersion = appconstants.VersionNum
 	containerVersions.PFEVersion = PFEVersion
 	containerVersions.GatekeeperVersion = GatekeeperVersion
@@ -71,7 +72,7 @@ func GetContainerVersions(conID string, httpClient utils.HTTPClient) (ContainerV
 
 // GetPFEVersionFromConnection : Get the version of the PFE container, deployed to the connection with the given ID
 func GetPFEVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
-	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environmen", nil)
+	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environment", nil)
 	if err != nil {
 		return "", err
 	}
@@ -117,6 +118,7 @@ func getVersionFromEnvAPI(req *http.Request, connection *connections.Connection,
 	if httpSecError != nil {
 		return "", httpSecError
 	}
+	// Set version field to empty string, if API call not successful
 	if resp.StatusCode != http.StatusOK {
 		return "", nil
 	}
@@ -134,7 +136,7 @@ func getVersionFromEnvAPI(req *http.Request, connection *connections.Connection,
 	}
 	codewindVersion := env.Version
 
-	if env.ImageBuildTime != "nil" {
+	if env.ImageBuildTime != "" {
 		codewindVersion = codewindVersion + "-" + env.ImageBuildTime
 	}
 

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -37,7 +37,7 @@ type (
 	}
 )
 
-// GetContainerVersions  :  Gets the versions of each Codewind container, for a given connection ID
+// GetContainerVersions : Get the versions of each Codewind container, for a given connection ID
 func GetContainerVersions(conID string, httpClient utils.HTTPClient) (ContainerVersions, error) {
 	conInfo, conInfoErr := connections.GetConnectionByID(conID)
 	if conInfoErr != nil {
@@ -68,9 +68,9 @@ func GetContainerVersions(conID string, httpClient utils.HTTPClient) (ContainerV
 	return containerVersions, nil
 }
 
-// GetPFEVersionFromConnection : Gets the version of the PFE container, deployed to the connection with the given ID
+// GetPFEVersionFromConnection : Get the version of the PFE container, deployed to the connection with the given ID
 func GetPFEVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
-	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environmen", nil)
+	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environment", nil)
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +82,7 @@ func GetPFEVersionFromConnection(connection *connections.Connection, HTTPClient 
 	return version, err
 }
 
-// GetGatekeeperVersionFromConnection : Gets the version of the Gatekeeper container, deployed to the connection with the given ID
+// GetGatekeeperVersionFromConnection : Get the version of the Gatekeeper container, deployed to the connection with the given ID
 func GetGatekeeperVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
 	req, err := http.NewRequest("GET", connection.URL+"/api/v1/gatekeeper/environment", nil)
 	if err != nil {
@@ -96,7 +96,7 @@ func GetGatekeeperVersionFromConnection(connection *connections.Connection, HTTP
 	return version, err
 }
 
-// GetPerformanceVersionFromConnection : Gets the version of the Performance container, deployed to the connection with the given ID
+// GetPerformanceVersionFromConnection : Get the version of the Performance container, deployed to the connection with the given ID
 func GetPerformanceVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
 	req, err := http.NewRequest("GET", connection.URL+"/performance/api/v1/environment", nil)
 	if err != nil {

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -113,8 +113,7 @@ func GetPerformanceVersionFromConnection(connection *connections.Connection, HTT
 }
 
 func getVersionFromEnvAPI(req *http.Request, connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
-	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, connection)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(HTTPClient, req, connection)
 	if httpSecError != nil {
 		return "", httpSecError
 	}

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -31,9 +31,10 @@ type (
 		PFEVersion         string
 	}
 
-	// CodewindVersion : The version of the Codewind container that is running
-	CodewindVersion struct {
-		Version string `json:"codewind_version"`
+	// EnvResponse : The response from the remote environment API
+	EnvResponse struct {
+		Version        string `json:"codewind_version"`
+		ImageBuildTime string `json:"image_build_time"`
 	}
 )
 
@@ -70,7 +71,7 @@ func GetContainerVersions(conID string, httpClient utils.HTTPClient) (ContainerV
 
 // GetPFEVersionFromConnection : Get the version of the PFE container, deployed to the connection with the given ID
 func GetPFEVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
-	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environment", nil)
+	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environmen", nil)
 	if err != nil {
 		return "", err
 	}
@@ -126,11 +127,16 @@ func getVersionFromEnvAPI(req *http.Request, connection *connections.Connection,
 		return "", err
 	}
 
-	var codewindVersion CodewindVersion
-	err = json.Unmarshal(byteArray, &codewindVersion)
+	var env EnvResponse
+	err = json.Unmarshal(byteArray, &env)
 	if err != nil {
 		return "", err
 	}
+	codewindVersion := env.Version
 
-	return codewindVersion.Version, nil
+	if env.ImageBuildTime != "nil" {
+		codewindVersion = codewindVersion + "-" + env.ImageBuildTime
+	}
+
+	return codewindVersion, nil
 }


### PR DESCRIPTION
## Summary

Adds a `cwctl` version command, which for a given connection ID returns the deployed versions of each Codewind container. Details of this are given at https://github.com/codewind-resources/design-documentation/blob/master/codewindServer/Versioning.

This PR is dependant on: https://github.com/eclipse/codewind/pull/1359

## Testing
A remote Codewind was deployed to docker desktop Kubernetes. The version command returned the versions for each container, and the time of each image build. 

Units tests will be added once we've worked on mocking DispatchHTTPRequest().