### PR TITLE
Remove Codewind Remote

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -271,6 +271,34 @@ func Commands() {
 				RemoveCommand(c)
 				return nil
 			},
+			Subcommands: []cli.Command{
+				{
+					Name:    "remote",
+					Aliases: []string{"r"},
+					Usage:   "Removes and deletes a Codewind remote deployment from Kubernetes",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "namespace,n", Usage: "Kubernetes namespace", Required: true},
+						cli.StringFlag{Name: "workspace,w", Usage: "Codewind workspace ID", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						DoRemoteRemove(c)
+						return nil
+					},
+				},
+				{
+					Name:    "keycloak",
+					Aliases: []string{"k"},
+					Usage:   "Removes and deletes a Keycloak deployment from Kubernetes",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "namespace,n", Usage: "Kubernetes namespace", Required: true},
+						cli.StringFlag{Name: "workspace,w", Usage: "Keycloak workspace ID", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						DoRemoteKeycloakRemove(c)
+						return nil
+					},
+				},
+			},
 		},
 
 		{

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -13,9 +13,12 @@ package actions
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/eclipse/codewind-installer/pkg/remote"
 	"github.com/eclipse/codewind-installer/pkg/utils"
+	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -56,4 +59,45 @@ func RemoveCommand(c *cli.Context) {
 			utils.RemoveNetwork(network)
 		}
 	}
+}
+
+// DoRemoteRemove : Delete a remote Codewind deployment
+func DoRemoteRemove(c *cli.Context) {
+	printAsJSON := c.GlobalBool("json")
+	removeOptions := remote.RemoveDeploymentOptions{
+		Namespace:   c.String("namespace"),
+		WorkspaceID: c.String("workspace"),
+	}
+
+	_, remInstError := remote.RemoveRemote(&removeOptions)
+	if remInstError != nil {
+		if printAsJSON {
+			fmt.Println(remInstError.Error())
+		} else {
+			logr.Errorf("Error: %v - %v\n", remInstError.Op, remInstError.Desc)
+		}
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+// DoRemoteKeycloakRemove : Delete a remote Keycloak deployment
+func DoRemoteKeycloakRemove(c *cli.Context) {
+	printAsJSON := c.GlobalBool("json")
+	removeOptions := remote.RemoveDeploymentOptions{
+		Namespace:   c.String("namespace"),
+		WorkspaceID: c.String("workspace"),
+	}
+
+	_, remInstError := remote.RemoveRemoteKeycloak(&removeOptions)
+	if remInstError != nil {
+		if printAsJSON {
+			fmt.Println(remInstError.Error())
+		} else {
+			logr.Errorf("Error: %v - %v\n", remInstError.Op, remInstError.Desc)
+		}
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -162,6 +162,7 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 		WorkspaceID:        workspaceID,
 		PVCName:            workspacePVC,
 		ServiceAccountName: "codewind-" + workspaceID, //  codewind-k39vwfk0
+		ServiceAccountKC:   "keycloak-" + workspaceID, //  keycloak-k39vwfk0
 		OwnerReferenceName: ownerReferenceName,
 		OwnerReferenceUID:  ownerReferenceUID,
 		Privileged:         true,
@@ -173,21 +174,31 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 	gatekeeperURL := GatekeeperPrefix + codewindInstance.Ingress
 	keycloakURL := KeycloakPrefix + codewindInstance.Ingress
 
-	codewindServiceTemplate := CreateCodewindServiceAcct(codewindInstance, remoteDeployOptions)
-	_, err = clientset.CoreV1().ServiceAccounts(namespace).Create(&codewindServiceTemplate)
-	if err != nil {
-		logr.Errorln("Creating service account failed, exiting...")
-		logr.Errorln(err)
-		os.Exit(1)
+	// Create the Codewind service account
+	if !remoteDeployOptions.KeycloakOnly {
+		codewindServiceTemplate := CreateCodewindServiceAcct(codewindInstance, remoteDeployOptions)
+		_, err = clientset.CoreV1().ServiceAccounts(namespace).Create(&codewindServiceTemplate)
+		if err != nil {
+			logr.Errorln("Creating service account failed, exiting...")
+			logr.Errorln(err)
+			os.Exit(1)
+		}
 	}
 
+	// If we are not using an existing Keycloak, deploy one now
 	if remoteDeployOptions.KeycloakURL == "" {
+		keycloakServiceAccountTemplate := CreateKeycloakServiceAcct(codewindInstance, remoteDeployOptions)
+		_, err = clientset.CoreV1().ServiceAccounts(namespace).Create(&keycloakServiceAccountTemplate)
+		if err != nil {
+			logr.Errorln("Creating Keycloak service account failed, exiting...")
+			logr.Errorln(err)
+			os.Exit(1)
+		}
 		err = DeployKeycloak(config, clientset, codewindInstance, remoteDeployOptions, onOpenShift)
 		if err != nil {
 			logr.Errorln("Codewind Keycloak failed, exiting...")
 			os.Exit(1)
 		}
-
 		podSearch := "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + KeycloakPrefix
 		WaitForPodReady(clientset, codewindInstance, podSearch, KeycloakPrefix+"-"+codewindInstance.WorkspaceID)
 	}

--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -148,7 +148,7 @@ func generateGatekeeperDeploy(codewind Codewind, deployOptions *DeployOptions) a
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
 	envVars := setGatekeeperEnvVars(codewind, deployOptions)
-	return generateDeployment(codewind, GatekeeperPrefix, codewind.GatekeeperImage, GatekeeperContainerPort, volumes, volumeMounts, envVars, labels)
+	return generateDeployment(codewind, GatekeeperPrefix, codewind.GatekeeperImage, GatekeeperContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName)
 }
 
 func generateGatekeeperService(codewind Codewind) corev1.Service {
@@ -217,7 +217,7 @@ func generateIngressGatekeeper(codewind Codewind) extensionsv1.Ingress {
 // generateRouteGatekeeper returns an OpenShift route for the gatekeeper service
 func generateRouteGatekeeper(codewind Codewind) v1.Route {
 	labels := map[string]string{
-		"app":               PFEPrefix,
+		"app":               GatekeeperPrefix,
 		"codewindWorkspace": codewind.WorkspaceID,
 	}
 

--- a/pkg/remote/deploy_keycloak.go
+++ b/pkg/remote/deploy_keycloak.go
@@ -129,7 +129,7 @@ func generateKeycloakDeploy(codewind Codewind) appsv1.Deployment {
 	volumes := []corev1.Volume{}
 	volumes, volumeMounts := setKeycloakVolumes(codewind)
 	envVars := setKeycloakEnvVars(codewind)
-	return generateDeployment(codewind, KeycloakPrefix, codewind.KeycloakImage, KeycloakContainerPort, volumes, volumeMounts, envVars, labels)
+	return generateDeployment(codewind, KeycloakPrefix, codewind.KeycloakImage, KeycloakContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountKC)
 }
 
 func generateKeycloakService(codewind Codewind) corev1.Service {

--- a/pkg/remote/deploy_keycloak_serviceaccount.go
+++ b/pkg/remote/deploy_keycloak_serviceaccount.go
@@ -17,13 +17,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// CreateCodewindServiceAcct : Create service account
-func CreateCodewindServiceAcct(codewind Codewind, deployOptions *DeployOptions) coreV1.ServiceAccount {
-	logr.Infof("Creating service account definition '%v'", codewind.ServiceAccountName)
+// CreateKeycloakServiceAcct : Create service account
+func CreateKeycloakServiceAcct(codewind Codewind, deployOptions *DeployOptions) coreV1.ServiceAccount {
+	logr.Infof("Creating service account definition '%v'", codewind.ServiceAccountKC)
 
 	labels := map[string]string{
 		"codewindWorkspace": codewind.WorkspaceID,
-		"app":               codewind.ServiceAccountName,
+		"app":               codewind.ServiceAccountKC,
 	}
 	svc := coreV1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
@@ -31,7 +31,7 @@ func CreateCodewindServiceAcct(codewind Codewind, deployOptions *DeployOptions) 
 			Kind:       "ServiceAccount",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   codewind.ServiceAccountName,
+			Name:   codewind.ServiceAccountKC,
 			Labels: labels,
 		},
 		Secrets: nil,

--- a/pkg/remote/deploy_performance.go
+++ b/pkg/remote/deploy_performance.go
@@ -48,7 +48,7 @@ func generatePerformanceDeploy(codewind Codewind) appsv1.Deployment {
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
 	envVars := setPerformanceEnvVars(codewind)
-	return generateDeployment(codewind, PerformancePrefix, codewind.PerformanceImage, PerformanceContainerPort, volumes, volumeMounts, envVars, labels)
+	return generateDeployment(codewind, PerformancePrefix, codewind.PerformanceImage, PerformanceContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName)
 }
 
 func generatePerformanceService(codewind Codewind) corev1.Service {

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -97,7 +97,7 @@ func generatePFEDeploy(codewind Codewind, deployOptions *DeployOptions) appsv1.D
 	}
 	volumes, volumeMounts := setPFEVolumes(codewind)
 	envVars := setPFEEnvVars(codewind, deployOptions)
-	return generateDeployment(codewind, PFEPrefix, codewind.PFEImage, PFEContainerPort, volumes, volumeMounts, envVars, labels)
+	return generateDeployment(codewind, PFEPrefix, codewind.PFEImage, PFEContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName)
 }
 
 // generatePFEService : creates a Kubernetes service

--- a/pkg/remote/remove.go
+++ b/pkg/remote/remove.go
@@ -1,0 +1,516 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package remote
+
+import (
+	"path/filepath"
+
+	"github.com/eclipse/codewind-installer/pkg/remote/kube"
+	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	logr "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// RemoveDeploymentOptions : Deployment removal options
+type RemoveDeploymentOptions struct {
+	Namespace   string
+	WorkspaceID string
+}
+
+const (
+	// ResourceNotProcessed : Resource not processed
+	ResourceNotProcessed = 0
+	// ResourceFound : Resource located
+	ResourceFound = 1
+	// ResourceNotFound : Resource could not be located
+	ResourceNotFound = 2
+	// ResourceRemoved : Resource was successfully removed
+	ResourceRemoved = 3
+	// ResourceSkipped : Resource was not removed and was skipped
+	ResourceSkipped = 4
+	// ResourceRemoveFailed : Resource removal failed
+	ResourceRemoveFailed = 5
+)
+
+// RemovalResult : Status for each component
+type RemovalResult struct {
+
+	// Pods
+	StatusPODGatekeeper  int
+	StatusPODPFE         int
+	StatusPODPerformance int
+	StatusPODKeycloak    int
+
+	// Services
+	StatusServiceGatekeeper  int
+	StatusServicePFE         int
+	StatusServicePerformance int
+	StatusServiceKeycloak    int
+
+	// Deployments
+	StatusDeploymentGatekeeper  int
+	StatusDeploymentPFE         int
+	StatusDeploymentPerformance int
+	StatusDeploymentKeycloak    int
+
+	// Secrets
+	StatusSecretsCodewind int
+	StatusSecretsKeycloak int
+
+	// Service account
+	StatusServiceAccount int
+
+	// Role bindings
+	StatusRoleBindings int
+
+	// Persistent volume claims
+	StatusPVCCodewind int
+	StatusPVCKeycloak int
+
+	// Ingress/Routes
+	StatusIngressGatekeeper int
+	StatusIngressKeycloak   int
+}
+
+// RemoveRemote : Remove remote install from Kube
+func RemoveRemote(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
+
+	kubeconfig := filepath.Join(getHomeDir(), ".kube", "config")
+	namespace := remoteRemovalOptions.Namespace
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	// Determine if we're running on OpenShift or not.
+	onOpenShift := kube.DetectOpenShift(config)
+	logr.Infof("Running on openshift: %t\n", onOpenShift)
+
+	removalStatus := RemovalResult{
+		StatusPODGatekeeper:         ResourceNotProcessed,
+		StatusPODPFE:                ResourceNotProcessed,
+		StatusPODPerformance:        ResourceNotProcessed,
+		StatusServiceGatekeeper:     ResourceNotProcessed,
+		StatusServicePFE:            ResourceNotProcessed,
+		StatusServicePerformance:    ResourceNotProcessed,
+		StatusDeploymentGatekeeper:  ResourceNotProcessed,
+		StatusDeploymentPFE:         ResourceNotProcessed,
+		StatusDeploymentPerformance: ResourceNotProcessed,
+		StatusSecretsCodewind:       ResourceNotProcessed,
+		StatusServiceAccount:        ResourceNotProcessed,
+		StatusRoleBindings:          ResourceNotProcessed,
+		StatusPVCCodewind:           ResourceNotProcessed,
+		StatusIngressGatekeeper:     ResourceNotProcessed,
+	}
+
+	if err != nil {
+		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logr.Infof("Unable to retrieve Kubernetes clientset %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	// Check if namespace exists
+	logr.Infof("Checking namespace %v exists\n", namespace)
+	_, err = clientset.CoreV1().Namespaces().Get(namespace, v1.GetOptions{})
+	if err != nil {
+		logr.Errorf("Unable to locate %v namespace: %v", namespace, err)
+		return nil, &RemInstError{errOpCreateNamespace, err, err.Error()}
+	}
+	logr.Infof("Found '%v' namespace\n", namespace)
+
+	logr.Trace("Removing Codewind deployments")
+	status, err := deleteDeployment(remoteRemovalOptions, clientset, "app="+PFEPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusDeploymentPFE = status
+	status, err = deleteDeployment(remoteRemovalOptions, clientset, "app="+PerformancePrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusDeploymentPerformance = status
+	status, err = deleteDeployment(remoteRemovalOptions, clientset, "app="+GatekeeperPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusDeploymentGatekeeper = status
+
+	logr.Trace("Removing Codewind services")
+	status, err = deleteService(remoteRemovalOptions, clientset, "app="+PFEPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusServicePFE = status
+	status, err = deleteService(remoteRemovalOptions, clientset, "app="+PerformancePrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusServicePerformance = status
+	status, err = deleteService(remoteRemovalOptions, clientset, "app="+GatekeeperPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusServiceGatekeeper = status
+
+	logr.Trace("Removing Codewind secrets")
+	status, err = deleteSecrets(remoteRemovalOptions, clientset, "app="+GatekeeperPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusSecretsCodewind = status
+
+	logr.Trace("Removing Codewind PVC")
+	status, err = deletePVC(remoteRemovalOptions, clientset, "app="+PFEPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusPVCCodewind = status
+
+	logr.Trace("Removing Codewind role bindings")
+	status, err = deleteRoleBindings(remoteRemovalOptions, clientset, "codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusRoleBindings = status
+
+	logr.Trace("Removing Codewind service account")
+	status, err = deleteServiceAccount(remoteRemovalOptions, clientset, "app=codewind-"+remoteRemovalOptions.WorkspaceID+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusServiceAccount = status
+
+	if onOpenShift {
+		logr.Trace("Removing Codewind route")
+		status, err = deleteRoute(config, remoteRemovalOptions, clientset, "app="+GatekeeperPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+		removalStatus.StatusIngressGatekeeper = status
+	} else {
+		logr.Trace("Removing Codewind ingress")
+		status, err = deleteIngress(remoteRemovalOptions, clientset, "app="+GatekeeperPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+		removalStatus.StatusIngressGatekeeper = status
+	}
+
+	logr.Info("Removal summary:")
+	logr.Infof("Codewind PFE Deployment: %v", getStatus(removalStatus.StatusDeploymentPFE))
+	logr.Infof("Codewind PFE Service: %v", getStatus(removalStatus.StatusServicePFE))
+	logr.Infof("Codewind PFE PVC: %v", getStatus(removalStatus.StatusPVCCodewind))
+	logr.Infof("Codewind Performance Deployment: %v", getStatus(removalStatus.StatusDeploymentPerformance))
+	logr.Infof("Codewind Performance Service: %v", getStatus(removalStatus.StatusServicePerformance))
+	logr.Infof("Codewind Gatekeeper Deployment: %v", getStatus(removalStatus.StatusDeploymentGatekeeper))
+	logr.Infof("Codewind Gatekeeper Service: %v", getStatus(removalStatus.StatusServiceGatekeeper))
+	logr.Infof("Codewind Gatekeeper Ingress: %v", getStatus(removalStatus.StatusIngressGatekeeper))
+	logr.Infof("Codewind Role Bindings: %v", getStatus(removalStatus.StatusRoleBindings))
+	logr.Infof("Codewind Service Account: %v", getStatus(removalStatus.StatusServiceAccount))
+	logr.Infof("Kubernetes namespace: CWCTL will not remove the namespace automatically, use 'kubectl delete namespace %s' if you would like to remove it", remoteRemovalOptions.Namespace)
+
+	return &removalStatus, nil
+}
+
+// RemoveRemoteKeycloak : Remove remote keycloak install from Kube
+func RemoveRemoteKeycloak(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
+
+	kubeconfig := filepath.Join(getHomeDir(), ".kube", "config")
+	namespace := remoteRemovalOptions.Namespace
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	// Determine if we're running on OpenShift or not.
+	onOpenShift := kube.DetectOpenShift(config)
+	logr.Infof("Running on Openshift: %t\n", onOpenShift)
+
+	removalStatus := RemovalResult{
+		StatusPODKeycloak:        ResourceNotProcessed,
+		StatusServiceKeycloak:    ResourceNotProcessed,
+		StatusDeploymentKeycloak: ResourceNotProcessed,
+		StatusSecretsKeycloak:    ResourceNotProcessed,
+		StatusServiceAccount:     ResourceNotProcessed,
+		StatusPVCKeycloak:        ResourceNotProcessed,
+		StatusIngressKeycloak:    ResourceNotProcessed,
+	}
+
+	if err != nil {
+		logr.Errorf("Unable to retrieve Kubernetes Config %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logr.Errorf("Unable to retrieve Kubernetes clientset %v\n", err)
+		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	}
+
+	// Check if namespace exists
+	logr.Infof("Checking namespace %v exists\n", namespace)
+	_, err = clientset.CoreV1().Namespaces().Get(namespace, v1.GetOptions{})
+	if err != nil {
+		logr.Errorf("Unable to locate %v namespace: %v", namespace, err)
+		return nil, &RemInstError{errOpCreateNamespace, err, err.Error()}
+	}
+	logr.Infof("Found '%v' namespace\n", namespace)
+
+	logr.Trace("Removing Keycloak deployment")
+	status, err := deleteDeployment(remoteRemovalOptions, clientset, "app="+KeycloakPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusDeploymentKeycloak = status
+
+	logr.Trace("Removing Keycloak service")
+	status, err = deleteService(remoteRemovalOptions, clientset, "app="+KeycloakPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusServiceKeycloak = status
+
+	logr.Trace("Removing Keycloak secrets")
+	status, err = deleteSecrets(remoteRemovalOptions, clientset, "app="+KeycloakPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusSecretsKeycloak = status
+
+	logr.Trace("Removing Keycloak PVC")
+	status, err = deletePVC(remoteRemovalOptions, clientset, "app="+KeycloakPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusPVCKeycloak = status
+
+	logr.Trace("Removing Keycloak service account")
+	status, err = deleteServiceAccount(remoteRemovalOptions, clientset, "app=keycloak-"+remoteRemovalOptions.WorkspaceID+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+	removalStatus.StatusServiceAccount = status
+
+	if onOpenShift {
+		logr.Trace("Removing Keycloak route")
+		status, err = deleteRoute(config, remoteRemovalOptions, clientset, "app="+KeycloakPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+		removalStatus.StatusIngressKeycloak = status
+	} else {
+		logr.Trace("Removing Keycloak ingress")
+		status, err = deleteIngress(remoteRemovalOptions, clientset, "app="+KeycloakPrefix+",codewindWorkspace="+remoteRemovalOptions.WorkspaceID)
+		removalStatus.StatusIngressKeycloak = status
+	}
+
+	logr.Info("Removal summary:")
+	logr.Infof("Keycloak Deployment: %v", getStatus(removalStatus.StatusDeploymentKeycloak))
+	logr.Infof("Keycloak Service: %v", getStatus(removalStatus.StatusServiceKeycloak))
+	logr.Infof("Keycloak PVC: %v", getStatus(removalStatus.StatusPVCKeycloak))
+	logr.Infof("Keycloak Ingress: %v", getStatus(removalStatus.StatusIngressKeycloak))
+	logr.Infof("Keycloak Secrets: %v", getStatus(removalStatus.StatusSecretsKeycloak))
+	logr.Infof("Keycloak Service Account: %v", getStatus(removalStatus.StatusServiceAccount))
+	logr.Infof("Kubernetes namespace: CWCTL will not remove the namespace automatically, use 'kubectl delete namespace %s' if you would like to remove it", remoteRemovalOptions.Namespace)
+	return &removalStatus, nil
+}
+
+func getStatus(status int) string {
+	switch status {
+	case ResourceNotProcessed:
+		return "Not processed"
+	case ResourceFound:
+		return "Found"
+	case ResourceNotFound:
+		return "Not found"
+	case ResourceRemoved:
+		return "Removed"
+	case ResourceSkipped:
+		return "Skipped"
+	case ResourceRemoveFailed:
+		return "Removal failed"
+	default:
+		return ""
+	}
+}
+
+func deleteDeployment(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	deploymentList, err := clientset.AppsV1().Deployments(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if deploymentList != nil && deploymentList.Items != nil && len(deploymentList.Items) == 1 {
+		phase = ResourceFound
+		err := clientset.AppsV1().Deployments(remoteRemovalOptions.Namespace).Delete(deploymentList.Items[0].GetName(), nil)
+		if err != nil {
+			phase = ResourceRemoveFailed
+		} else {
+			phase = ResourceRemoved
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deletePod(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	podList, err := clientset.CoreV1().Pods(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if podList != nil && podList.Items != nil && len(podList.Items) == 1 {
+		phase = ResourceFound
+		err := clientset.CoreV1().Pods(remoteRemovalOptions.Namespace).Delete(podList.Items[0].GetName(), nil)
+		if err != nil {
+			phase = ResourceRemoveFailed
+		} else {
+			phase = ResourceRemoved
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deleteService(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	serviceList, err := clientset.CoreV1().Services(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if serviceList != nil && serviceList.Items != nil && len(serviceList.Items) == 1 {
+		phase = ResourceFound
+		err := clientset.CoreV1().Services(remoteRemovalOptions.Namespace).Delete(serviceList.Items[0].GetName(), nil)
+		if err != nil {
+			phase = ResourceRemoveFailed
+		} else {
+			phase = ResourceRemoved
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deleteSecrets(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	secretList, err := clientset.CoreV1().Secrets(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if secretList != nil && secretList.Items != nil && len(secretList.Items) > 0 {
+		phase = ResourceFound
+		for _, resource := range secretList.Items {
+			err := clientset.CoreV1().Secrets(remoteRemovalOptions.Namespace).Delete(resource.GetObjectMeta().GetName(), nil)
+			if err != nil {
+				phase = ResourceRemoveFailed
+			} else {
+				phase = ResourceRemoved
+			}
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deletePVC(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	resourceList, err := clientset.CoreV1().PersistentVolumeClaims(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if resourceList != nil && resourceList.Items != nil && len(resourceList.Items) > 0 {
+		phase = ResourceFound
+		for _, resource := range resourceList.Items {
+			err := clientset.CoreV1().PersistentVolumeClaims(remoteRemovalOptions.Namespace).Delete(resource.GetObjectMeta().GetName(), nil)
+			if err != nil {
+				phase = ResourceRemoveFailed
+			} else {
+				phase = ResourceRemoved
+			}
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deleteServiceAccount(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	resourceList, err := clientset.CoreV1().ServiceAccounts(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if resourceList != nil && resourceList.Items != nil && len(resourceList.Items) > 0 {
+		phase = ResourceFound
+		for _, secret := range resourceList.Items {
+			err := clientset.CoreV1().ServiceAccounts(remoteRemovalOptions.Namespace).Delete(secret.GetObjectMeta().GetName(), nil)
+			if err != nil {
+				phase = ResourceRemoveFailed
+			} else {
+				phase = ResourceRemoved
+			}
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deleteRoleBindings(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	resourceList, err := clientset.RbacV1().RoleBindings(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if resourceList != nil && resourceList.Items != nil && len(resourceList.Items) > 0 {
+		phase = ResourceFound
+		for _, resource := range resourceList.Items {
+			err := clientset.RbacV1().RoleBindings(remoteRemovalOptions.Namespace).Delete(resource.GetObjectMeta().GetName(), nil)
+			if err != nil {
+				phase = ResourceRemoveFailed
+			} else {
+				phase = ResourceRemoved
+			}
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deleteIngress(remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	resourceList, err := clientset.ExtensionsV1beta1().Ingresses(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if resourceList != nil && resourceList.Items != nil && len(resourceList.Items) > 0 {
+		phase = ResourceFound
+		for _, secret := range resourceList.Items {
+			err := clientset.ExtensionsV1beta1().Ingresses(remoteRemovalOptions.Namespace).Delete(secret.GetObjectMeta().GetName(), nil)
+			if err != nil {
+				phase = ResourceRemoveFailed
+			} else {
+				phase = ResourceRemoved
+			}
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}
+
+func deleteRoute(config *restclient.Config, remoteRemovalOptions *RemoveDeploymentOptions, clientset *kubernetes.Clientset, labelSelector string) (int, error) {
+	phase := ResourceNotProcessed
+	routev1client, err := routev1.NewForConfig(config)
+	if err != nil {
+		phase = ResourceRemoveFailed
+		return ResourceRemoveFailed, err
+	}
+	resourceList, err := routev1client.Routes(remoteRemovalOptions.Namespace).List(
+		v1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return ResourceNotFound, err
+	}
+	if resourceList != nil && resourceList.Items != nil && len(resourceList.Items) > 0 {
+		phase = ResourceFound
+		for _, secret := range resourceList.Items {
+			err := routev1client.Routes(remoteRemovalOptions.Namespace).Delete(secret.GetObjectMeta().GetName(), nil)
+			if err != nil {
+				logr.Trace(secret.GetObjectMeta().GetName())
+				phase = ResourceRemoveFailed
+			} else {
+				phase = ResourceRemoved
+			}
+		}
+	} else {
+		phase = ResourceNotFound
+	}
+	return phase, nil
+}

--- a/pkg/remote/types.go
+++ b/pkg/remote/types.go
@@ -27,6 +27,7 @@ type Codewind struct {
 	WorkspaceID        string
 	PVCName            string
 	ServiceAccountName string
+	ServiceAccountKC   string
 	OwnerReferenceName string
 	OwnerReferenceUID  types.UID
 	Privileged         bool


### PR DESCRIPTION
## Problem

Need a way for CWCTL to delete a remote Codewind deployment and remove Codewind Secrets, Deployments, PVCs, roll-bindings and service account. As mentioned in issue : https://github.com/eclipse/codewind/issues/1287

## Solution

Now that cwctl includes options to install Keycloak and Codewind separately as well as both together,  this PR adds two new commands : 

* `cwctl remove remote`   removes Codewind
* `cwctl remove keycloak` removes Keycloak

Both commands should be run when both keycloak and remote are installed together or individually to delete the appropriate resources for each deployment. 

## Example output Keycloak only: 

```
cwctl  remove keycloak  -n mark-keycloak-001-only  -w k3r4x0wy

INFO[0000] Running on Openshift: true                   
INFO[0000] Checking namespace mark-keycloak-001-only exists 
INFO[0000] Found 'mark-keycloak-001-only' namespace     
INFO[0001] Removal summary:                             
INFO[0001] Keycloak Deployment: Removed                 
INFO[0001] Keycloak Service: Removed                    
INFO[0001] Keycloak PVC: Removed                        
INFO[0001] Keycloak Ingress: Removed                    
INFO[0001] Keycloak Secrets: Removed                    
INFO[0001] Keycloak Service Account: Removed            
INFO[0001] Kubernetes namespace: CWCTL will not remove the namespace automatically, use 'kubectl delete namespace mark-keycloak-001-only' if you would like to remove it 
```

## Example output Codewind only: 

```
cwctl remove remote  -n mark-codewind-002-only  -w k3r4ynwk 

INFO[0000] Running on openshift: true                   
INFO[0000] Checking namespace mark-codewind-002-only exists 
INFO[0000] Found 'mark-codewind-002-only' namespace     
INFO[0001] Removal summary:                             
INFO[0001] Codewind PFE Deployment: Removed             
INFO[0001] Codewind PFE Service: Removed                
INFO[0001] Codewind PFE PVC: Removed                    
INFO[0001] Codewind Performance Deployment: Removed     
INFO[0001] Codewind Performance Service: Removed        
INFO[0001] Codewind Gatekeeper Deployment: Removed      
INFO[0001] Codewind Gatekeeper Service: Removed         
INFO[0001] Codewind Gatekeeper Ingress: Removed    
INFO[0001] Codewind Role Bindings: Removed              
INFO[0001] Codewind Service Account: Removed            
INFO[0001] Kubernetes namespace: CWCTL will not remove the namespace automatically, use 'kubectl delete namespace mark-codewind-002-only' if you would like to remove it 
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>