### PR TITLE
Add project remove command

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -93,6 +93,19 @@ func Commands() {
 					},
 				},
 				{
+					Name:    "remove",
+					Aliases: []string{""},
+					Usage:   "remove a project from codewind",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "id, i", Usage: "the project id", Required: true},
+						cli.BoolFlag{Name: "delete, d", Usage: "delete local project files"},
+					},
+					Action: func(c *cli.Context) error {
+						ProjectRemove(c)
+						return nil
+					},
+				},
+				{
 					Name:    "sync",
 					Aliases: []string{""},
 					Usage:   "synchronize a project to codewind for building and running",

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -77,6 +77,16 @@ func ProjectBind(c *cli.Context) {
 	os.Exit(0)
 }
 
+// ProjectUnbind : Does a project remove
+func ProjectRemove(c *cli.Context) {
+	err := project.RemoveProject(c)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
 // UpgradeProjects : Upgrades projects
 func UpgradeProjects(c *cli.Context) {
 	dir := strings.TrimSpace(c.String("workspace"))

--- a/pkg/project/getproject.go
+++ b/pkg/project/getproject.go
@@ -1,0 +1,55 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+)
+
+// Represents a project
+type (
+	Project struct {
+		ProjectID      string `json:"projectID"`
+		LocationOnDisk string `json:"locOnDisk"`
+	}
+)
+
+// Get project details from Codewind
+func GetProject(httpClient utils.HTTPClient, conID, projectID string) (*Project, error) {
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return nil, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		return nil, conErr.Err
+	}
+	req, getProjectErr := http.NewRequest("GET", conURL+"/api/v1/projects/"+projectID+"/", nil)
+	if getProjectErr != nil {
+		fmt.Println(getProjectErr)
+		return nil, getProjectErr
+	}
+
+	// send request
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	byteArray, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, readErr
+	}
+	var project Project
+	getProjectErr = json.Unmarshal(byteArray, &project)
+	if getProjectErr != nil {
+		return nil, getProjectErr
+	}
+	return &project, nil
+}

--- a/pkg/project/project_utils.go
+++ b/pkg/project/project_utils.go
@@ -17,11 +17,13 @@ import (
 )
 
 // ProjectError : A Project error
-type ProjectError struct {
-	Op   string
-	Err  error
-	Desc string
-}
+type (
+	ProjectError struct {
+		Op   string
+		Err  error
+		Desc string
+	}
+)
 
 const (
 	errBadPath       = "proj_path"     // Invalid path provided
@@ -31,6 +33,7 @@ const (
 	errOpFileLoad    = "proj_load"
 	errOpFileWrite   = "proj_write"
 	errOpFileDelete  = "proj_delete"
+	errOpGetProject  = "proj_get"
 	errOpConflict    = "proj_conflict"
 	errOpNotFound    = "proj_notfound"
 	errOpConNotFound = "connection_notfound"

--- a/pkg/project/remove.go
+++ b/pkg/project/remove.go
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package project
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+// RemoveProject : Unbind a project from Codewind and delete json connection file
+func RemoveProject(c *cli.Context) *ProjectError {
+	projectID := strings.TrimSpace(c.String("id"))
+	deleteFiles := c.Bool("delete")
+	projectPath := ""
+
+	// Get the connection for this project
+	conID, conErr := GetConnectionID(projectID)
+	if conErr != nil {
+		return conErr
+	}
+
+	// If we are deleting the source, retrieve project to find out the path
+	if deleteFiles {
+		project, projErr := GetProject(http.DefaultClient, conID, projectID)
+		if projErr != nil {
+			fmt.Println(projErr)
+			return &ProjectError{errOpGetProject, projErr, projErr.Error()}
+		}
+		projectPath = project.LocationOnDisk
+	}
+
+	// Unbind the project from codewind
+	err := Unbind(http.DefaultClient, conID, projectID)
+	if err != nil {
+		projError := errors.New("Project unbind failed")
+		return &ProjectError{errOpFileDelete, projError, projError.Error()}
+	}
+
+	// Delete the associated connection file
+	projError := RemoveConnectionFile(projectID)
+	if projError != nil {
+		return projError
+	}
+
+	// Delete the source if the flag is set
+	if deleteFiles {
+		var err = os.RemoveAll(projectPath)
+		if err != nil {
+			return &ProjectError{errOpFileDelete, err, err.Error()}
+		}
+	}
+	return nil
+}

--- a/pkg/project/unbind.go
+++ b/pkg/project/unbind.go
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package project
+
+import (
+	"net/http"
+
+	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+)
+
+// Unbind a project from Codewind
+func Unbind(httpClient utils.HTTPClient, conID, projectID string) error {
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		return conErr.Err
+	}
+	req, err := http.NewRequest("POST", conURL+"/api/v1/projects/"+projectID+"/unbind", nil)
+	if err != nil {
+		return err
+	}
+
+	// send request
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Add a new command 'cwctl project remove -i <projectID> -d'

This function will a) unbind the project from codewind b) delete the <projectID>.json connection file
and c) delete the source folder and contents if the -d flag is passed

Documentation and tests to follow.
