### PR TITLE
Trim Codewind roles and update secret verbs

### DIFF
--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -37,7 +37,7 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 		rbacv1.PolicyRule{
 			APIGroups: []string{""},
 			Resources: []string{"secrets"},
-			Verbs:     []string{"get", "list", "create", "watch", "delete"},
+			Verbs:     []string{"get", "list", "create", "watch", "delete", "delete", "patch", "update"},
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{""},
@@ -48,11 +48,6 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 			APIGroups: []string{""},
 			Resources: []string{"services"},
 			Verbs:     []string{"get", "list", "create", "delete", "patch"},
-		},
-		rbacv1.PolicyRule{
-			APIGroups: []string{""},
-			Resources: []string{"nodes"},
-			Verbs:     []string{"get", "list"},
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{""},
@@ -78,26 +73,6 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 			APIGroups: []string{"extensions", "apps"},
 			Resources: []string{"replicasets", "replicasets/finalizers"},
 			Verbs:     []string{"get", "list", "update", "delete"},
-		},
-		rbacv1.PolicyRule{
-			APIGroups: []string{"apiextensions.k8s.io"},
-			Resources: []string{"customresourcedefinitions"},
-			Verbs:     []string{"get", "list", "update", "delete"},
-		},
-		rbacv1.PolicyRule{
-			APIGroups: []string{"certificates.k8s.io"},
-			Resources: []string{"certificatesigningrequests"},
-			Verbs:     []string{"delete", "get", "list", "watch", "create"},
-		},
-		rbacv1.PolicyRule{
-			APIGroups: []string{"certificates.k8s.io"},
-			Resources: []string{"certificatesigningrequests/approval", "certificatesigningrequests/status"},
-			Verbs:     []string{"update"},
-		},
-		rbacv1.PolicyRule{
-			APIGroups: []string{"authorization.k8s.io"},
-			Resources: []string{"subjectaccessreviews"},
-			Verbs:     []string{"create"},
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{"rbac.authorization.k8s.io"},

--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -37,7 +37,7 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 		rbacv1.PolicyRule{
 			APIGroups: []string{""},
 			Resources: []string{"secrets"},
-			Verbs:     []string{"get", "list", "create", "watch", "delete", "delete", "patch", "update"},
+			Verbs:     []string{"get", "list", "create", "watch", "delete", "patch", "update"},
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{""},


### PR DESCRIPTION
The roles that we assign Codewind come from Microclimate and are much more than we actually need, so this PR trims them down a bit:
- Removes any roles needed for managing CRDs or certificates right now
    - This originates from the `microclimate-devops` service account which interacted with those resources
- Updates the secret verbs to add ones necessary for Helm 3 (see https://github.com/eclipse/codewind/pull/1358)