### PR TITLE
Validate saved secret when updating a secret

### DIFF
--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -43,6 +43,17 @@ func SecKeyUpdate(connectionID string, username string, password string) *SecErr
 	if err != nil {
 		return &SecError{errOpKeyring, err, err.Error()}
 	}
+
+	/// check password can be retrieved
+	secret, secErr := SecKeyGetSecret(conID, uName)
+	if err != nil {
+		return secErr
+	}
+	if secret != pass {
+		secErr := errors.New("Saved password does not match retrieved password")
+		return &SecError{errOpPasswordRead, secErr, secErr.Error()}
+	}
+
 	return nil
 }
 

--- a/pkg/security/security_utils.go
+++ b/pkg/security/security_utils.go
@@ -48,6 +48,7 @@ const (
 	errOpKeyring        = "sec_keyring"         // Keyring operations
 	errOpConConfig      = "sec_con_config"      // Connection configuration errors
 	errOpCLICommand     = "sec_cli_options"     // Invalid command line options
+	errOpPasswordRead   = "sec_password_read"   // Unable to fetch password
 )
 
 const (


### PR DESCRIPTION
## Enhancement

Validate that after setting a password or secret in the platform keychain that it can be retrieved again.
This change removes the need to run seckeyring validate right after setting the secret. 

And will help troubleshoot issues like : https://github.com/eclipse/codewind/issues/1356

## Test results : 

Ran security tests manually to validate code change : 

```
=== RUN   Test_Authenticate
=== RUN   Test_Authenticate/Expect_authentication_failure_-_invalid_credentials
=== RUN   Test_Authenticate/Expect_authentication_success_-_obtain_access_token_from_service
=== RUN   Test_Authenticate/Expect_authentication_success_-_obtain_access_token_using_refresh_token
=== RUN   Test_Authenticate/Expect_authentication_failure_-_unable_to_obtain_access_token_using_expired_refresh_token
=== RUN   Test_Authenticate/Cleanup_stored_access_token_and_refresh_token
--- PASS: Test_Authenticate (0.43s)
    --- PASS: Test_Authenticate/Expect_authentication_failure_-_invalid_credentials (0.03s)
    --- PASS: Test_Authenticate/Expect_authentication_success_-_obtain_access_token_from_service (0.27s)
    --- PASS: Test_Authenticate/Expect_authentication_success_-_obtain_access_token_using_refresh_token (0.03s)
    --- PASS: Test_Authenticate/Expect_authentication_failure_-_unable_to_obtain_access_token_using_expired_refresh_token (0.03s)
    --- PASS: Test_Authenticate/Cleanup_stored_access_token_and_refresh_token (0.07s)
=== RUN   Test_Keychain
=== RUN   Test_Keychain/Secret_can_not_be_retrieved_for_an_unknown_account
=== RUN   Test_Keychain/A_new_key_can_be_created_in_the_platform_keychain
=== RUN   Test_Keychain/The_secret_can_be_retrieved_from_the_keychain
=== RUN   Test_Keychain/An_existing_key_in_the_keychain_can_be_updated
=== RUN   Test_Keychain/Retrieved_secret_matches_the_saved_secret
=== RUN   Test_Keychain/Test_keyring_entry_can_be_removed
--- PASS: Test_Keychain (0.31s)
    --- PASS: Test_Keychain/Secret_can_not_be_retrieved_for_an_unknown_account (0.03s)
    --- PASS: Test_Keychain/A_new_key_can_be_created_in_the_platform_keychain (0.08s)
    --- PASS: Test_Keychain/The_secret_can_be_retrieved_from_the_keychain (0.03s)
    --- PASS: Test_Keychain/An_existing_key_in_the_keychain_can_be_updated (0.07s)
    --- PASS: Test_Keychain/Retrieved_secret_matches_the_saved_secret (0.03s)
    --- PASS: Test_Keychain/Test_keyring_entry_can_be_removed (0.03s)
PASS
ok      github.com/eclipse/codewind-installer/pkg/security      0.847s
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>