### PR TITLE
Add InsecureSkipVerify for sync

### DIFF
--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -14,6 +14,7 @@ package project
 import (
 	"bytes"
 	"compress/zlib"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -70,6 +71,8 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 	if err != nil {
 		return nil, &ProjectError{errBadPath, err, err.Error()}
 	}
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	if !ConnectionFileExists(projectID) {
 		fmt.Println("Project connection file does not exist, creating default local connection")


### PR DESCRIPTION
This PR disables SSL and hostname verification when running sync commands with `cwctl`, to address the issues seen in https://github.com/eclipse/codewind/issues/1411:

```
[December 6, 13:31:06.552] [382.601] Calling cwctl project sync with: { [project] [sync] [-p] [/Users/johncollier/codewind-workspace/gogogogo] [-i] [de50de70-1855-11ea-a7bf-c1d85e939f8a] [-t] [1575656874215] }
[December 6, 13:31:07.963] [384.012] Successfully ran installer command: [project] [sync] [-p] [/Users/johncollier/codewind-workspace/gogogogo] [-i] [de50de70-1855-11ea-a7bf-c1d85e939f8a] [-t] [1575656874215]
[December 6, 13:31:07.964] [384.013] Output:Status: 200 OK

[December 6, 13:31:07.964] [384.013] Updating timestamp to latest: 1575657066553
```

**However**, sync is **still** broken after fixing this. It seems that while the sync command runs fine now, the files still aren't getting synced to PFE