### PR TITLE
Use Keycloak embedded H2 DB

### DIFF
--- a/pkg/remote/deploy_keycloak.go
+++ b/pkg/remote/deploy_keycloak.go
@@ -260,6 +260,10 @@ func setKeycloakEnvVars(codewind Codewind) []corev1.EnvVar {
 			Name:  "PROXY_ADDRESS_FORWARDING",
 			Value: "true",
 		},
+		{
+			Name:  "DB_VENDOR",
+			Value: "h2",
+		},
 	}
 }
 


### PR DESCRIPTION
## Problem:

Keycloak is allowed to discover database services during install. If a cluster has DB services installed already,  deploying a new Keycloak pod will try to use those DB services instead of using the embedded H2 database. Since cwctl does not install or configure the many different types of databases Keycloak supports (cwctl only configures the embedded H2 database) this may cause the Keycloak pod to not start up. 

As seen on okd 3.11 in issue : https://github.com/eclipse/codewind/issues/1420

## Solution:

Rather than allow Keycloak to discover the database type, this PR sets the Codewind Keycloak pod to use the H2 database out of the box because that is the only one we configure during deployment. 

## Tests

Tested a new deployment - 

```
cwctl --insecure install remote \
  --namespace mark-codewind104  \
  --kadminuser admin \
  --kadminpass passw0rd  \
  --krealm codewind \
  --kclient codewind  \
  --kdevuser developer \
  --kdevpass passw0rd \
  --ingress "apps.mycluster-x.x.x.x.nip.io" --konly 

INFO[0000] Checking namespace mark-codewind104 exists   
INFO[0000] Using namespace : mark-codewind104           
INFO[0000] Container images :                           
INFO[0000] eclipse/codewind-pfe-amd64:latest            
INFO[0000] eclipse/codewind-performance-amd64:latest    
INFO[0000] eclipse/codewind-keycloak-amd64:latest       
INFO[0000] eclipse/codewind-gatekeeper-amd64:latest     
INFO[0000] Running on openshift: true                   
INFO[0000] Using ingress domain: apps.mycluster-x.x.x.x.nip.io 
INFO[0000] Creating service account definition 'keycloak-k3y5nhkr' 
INFO[0000] Creating codewind-keycloak-k3y5nhkr.apps.mycluster-x.x.x.x.nip.io server Key 
INFO[0000] Creating codewind-keycloak-k3y5nhkr.apps.mycluster-x.x.x.x.nip.io server certificate 
INFO[0000] Creating Codewind Keycloak PVC               
INFO[0000] Deploying Codewind Keycloak Secrets          
INFO[0000] Deploying Codewind Keycloak TLS Secrets      
INFO[0000] Waiting for pod: codewind-keycloak-k3y5nhkr  
INFO[0000] codewind-keycloak-k3y5nhkr, phase: Pending Unschedulable  
INFO[0008] codewind-keycloak-k3y5nhkr, phase: Pending ContainersNotReady  
INFO[0018] codewind-keycloak-k3y5nhkr, phase: Running   
INFO[0018] Waiting for Keycloak to start                
.......
INFO[0052] Configuring Keycloak...                      
INFO[0052] https://codewind-keycloak-k3y5nhkr.apps.mycluster-x.x.x.x.nip.io 
INFO[0054] Creating Keycloak realm                      
INFO[0055] Keycloak is available at: https://codewind-keycloak-k3y5nhkr.apps.mycluster-x.x.x.x.nip.io 
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>