### PR TITLE
Update cluster roles during deployment

### DIFF
--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -36,7 +36,13 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 	logr.Infof("Checking if '%v' cluster access roles are installed\n", CodewindRolesName)
 	clusterRole, err := clientset.RbacV1().ClusterRoles().Get(CodewindRolesName, metav1.GetOptions{})
 	if clusterRole != nil && err == nil {
-		logr.Infof("Cluster roles '%v' already installed\n", CodewindRolesName)
+		logr.Infof("Cluster roles '%v' already installed - updating\n", CodewindRolesName)
+		_, err = clientset.RbacV1().ClusterRoles().Update(&codewindRoles)
+		if err != nil {
+			logr.Errorf("Unable to update `%v` cluster access roles: %v\n", CodewindRolesName, err)
+			return err
+		}
+		logr.Infof("Cluster roles '%v' updated complete\n", CodewindRolesName)
 	} else {
 		logr.Infof("Adding new '%v' cluster access roles\n", CodewindRolesName)
 		_, err = clientset.RbacV1().ClusterRoles().Create(&codewindRoles)


### PR DESCRIPTION
## Problem

When developing Codewind, the Kubernetes ClusterRoles used by all Codewind instances do not get updated with latest changes.  https://github.com/eclipse/codewind/issues/1402

## Solution

Codewind Remote uses cluster roles named "eclipse-codewind-{version}" which keeps roles version specific. However in development the roles are called dev.x.x and so never change requiring the roles to be deleted manually before deploying a new Codewind remote. This PR updates the cluster roles with the latest changes at deployment time.  

## Testing changes : 

**Inspecting current roles for "secrets" :** 

```
kubectl describe clusterroles eclipse-codewind-x.x.dev | grep secrets
secrets [] [] [get list create watch]
```


**New log messages seen when deploying with this PR :** 

```
INFO[0043] Checking if 'eclipse-codewind-x.x.dev' cluster access roles are installed 
INFO[0043] Cluster roles 'eclipse-codewind-x.x.dev' already installed - updating 
INFO[0043] Cluster roles 'eclipse-codewind-x.x.dev' updated complete 
```

**Checking the cluster roles for "secrets" after update:** 

```
kubectl describe clusterroles eclipse-codewind-x.x.dev | grep secrets
secrets []  []  [get list create watch delete patch update]
```

Changes to role were successful 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>