### PR TITLE
follow github redirects, when downloading templates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -175,12 +175,12 @@
   version = "v1.3.2"
 
 [[projects]]
-  digest = "1:525ebc5da920b1f2c76ae763c13f4decdc3c3bc541ff0fa18f2399d4e742177f"
+  branch = "master"
+  digest = "1:7e43bf7734c205068c33965f1d1d3d6efa343ad52dfc884c8e57524ce2f2f518"
   name = "github.com/google/go-github"
   packages = ["github"]
   pruneopts = "UT"
-  revision = "4c1ec01570ac97daecec8c2b62b07176700f093d"
-  version = "v27.0.4"
+  revision = "1a07ca55c956bb1e859c72922ddea5a7a989b378"
 
 [[projects]]
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,6 +28,10 @@
   version = "19.03.3"
 
 [[constraint]]
+  name = "github.com/google/go-github"
+  branch = "master"
+
+[[constraint]]
   name = "github.com/openshift/api"
   branch = "release-4.4"
 

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -127,7 +127,7 @@ func GetZipURL(owner, repo, branch string) (string, error) {
 
 	opt := &github.RepositoryContentGetOptions{Ref: branch}
 
-	URL, _, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt)
+	URL, _, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt, true)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Resolves: https://github.com/eclipse/codewind/issues/614

## Summary

Pulls in the latest master of `https://github.com/google/go-github`, which includes my PR to follow github redirects (https://github.com/google/go-github/pull/1336). The function now has a flag for following redirects, which this PR sets to `true`.

## Testing

Forked one of our template repos, and then renamed it. Setting `followRedirects=false` when downloading from this template returned the existing error (`301 status moved permanently`). Setting `true` successfully downloads the template.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>