### PR TITLE
Allow deployments to be created as unprivileged

### DIFF
--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -148,7 +148,7 @@ func generateGatekeeperDeploy(codewind Codewind, deployOptions *DeployOptions) a
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
 	envVars := setGatekeeperEnvVars(codewind, deployOptions)
-	return generateDeployment(codewind, GatekeeperPrefix, codewind.GatekeeperImage, GatekeeperContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName)
+	return generateDeployment(codewind, GatekeeperPrefix, codewind.GatekeeperImage, GatekeeperContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName, false)
 }
 
 func generateGatekeeperService(codewind Codewind) corev1.Service {

--- a/pkg/remote/deploy_keycloak.go
+++ b/pkg/remote/deploy_keycloak.go
@@ -129,7 +129,7 @@ func generateKeycloakDeploy(codewind Codewind) appsv1.Deployment {
 	volumes := []corev1.Volume{}
 	volumes, volumeMounts := setKeycloakVolumes(codewind)
 	envVars := setKeycloakEnvVars(codewind)
-	return generateDeployment(codewind, KeycloakPrefix, codewind.KeycloakImage, KeycloakContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountKC)
+	return generateDeployment(codewind, KeycloakPrefix, codewind.KeycloakImage, KeycloakContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountKC, false)
 }
 
 func generateKeycloakService(codewind Codewind) corev1.Service {

--- a/pkg/remote/deploy_performance.go
+++ b/pkg/remote/deploy_performance.go
@@ -48,7 +48,7 @@ func generatePerformanceDeploy(codewind Codewind) appsv1.Deployment {
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
 	envVars := setPerformanceEnvVars(codewind)
-	return generateDeployment(codewind, PerformancePrefix, codewind.PerformanceImage, PerformanceContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName)
+	return generateDeployment(codewind, PerformancePrefix, codewind.PerformanceImage, PerformanceContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName, false)
 }
 
 func generatePerformanceService(codewind Codewind) corev1.Service {

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -103,7 +103,7 @@ func generatePFEDeploy(codewind Codewind, deployOptions *DeployOptions) appsv1.D
 	}
 	volumes, volumeMounts := setPFEVolumes(codewind)
 	envVars := setPFEEnvVars(codewind, deployOptions)
-	return generateDeployment(codewind, PFEPrefix, codewind.PFEImage, PFEContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName)
+	return generateDeployment(codewind, PFEPrefix, codewind.PFEImage, PFEContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName, true)
 }
 
 // generatePFEService : creates a Kubernetes service

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -79,7 +79,7 @@ func getHomeDir() string {
 
 // generateDeployment returns a Kubernetes deployment object with the given name for the given image.
 // Additionally, volume/volumemounts and env vars can be specified.
-func generateDeployment(codewind Codewind, name string, image string, port int, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar, labels map[string]string, serviceAccountName string) appsv1.Deployment {
+func generateDeployment(codewind Codewind, name string, image string, port int, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar, labels map[string]string, serviceAccountName string, privileged bool) appsv1.Deployment {
 
 	//blockOwnerDeletion := true
 	//controller := true
@@ -122,7 +122,7 @@ func generateDeployment(codewind Codewind, name string, image string, port int, 
 							Image:           image,
 							ImagePullPolicy: ImagePullPolicy,
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: &codewind.Privileged,
+								Privileged: &privileged,
 							},
 							VolumeMounts: volumeMounts,
 							Env:          envVars,


### PR DESCRIPTION
For https://github.com/eclipse/codewind/issues/1437

As part of a holdover from the code that's used to deploy Codewind on Che, `cwctl` remote deploy code is creating every deployment as privileged, when only PFE needs to be privileged.

This PR adds a a new boolean parameter to `generateDeployment` called `privileged`, when set to true it creates a privileged deployment, otherwise it creates an unprivileged one

**Keycloak**
```
johns-mbp-3:codewind-installer johncollier$ printf "$(k get po codewind-keycloak-k3yr3bx4-8fd96469-4tstd -o jsonpath="{.spec.containers[0].securityContext.privileged}")\n"
false
```

**PFE**
```
johns-mbp-3:codewind-installer johncollier$ printf "$(k get po codewind-pfe-k3yr3bx4-6974c78b79-lbgms -o jsonpath="{.spec.containers[0].securityContext.privileged}")\n"
true
```