### PR TITLE
Delete by container name not image

### DIFF
--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -42,18 +42,16 @@ func StopAllCommand() {
 }
 
 func getContainersToRemove(containerList []types.Container) []types.Container {
-	codewindContainerNames := []string{
-		"codewind-pfe",
-		"codewind-performance",
+	codewindContainerPrefixes := []string{
+		"/codewind-pfe",
+		"/codewind-performance",
+		"/cw-",
 	}
-
-	// Docker returns all the names with a "/" on the front
-	projectContainerPrefix := "/cw-"
 
 	containersToRemove := []types.Container{}
 	for _, container := range containerList {
-		for _, key := range codewindContainerNames {
-			if strings.Contains(container.Names[0], key) || strings.HasPrefix(container.Names[0], projectContainerPrefix) {
+		for _, prefix := range codewindContainerPrefixes {
+			if strings.HasPrefix(container.Names[0], prefix) {
 				containersToRemove = append(containersToRemove, container)
 				break
 			}

--- a/pkg/actions/stop-all_test.go
+++ b/pkg/actions/stop-all_test.go
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getContainersToRemove(t *testing.T) {
+	tests := map[string]struct {
+		containerList      []types.Container
+		expectedContainers []string
+	}{
+		"Returns the pfe and performance containers": {
+			containerList: []types.Container{
+				types.Container{
+					Names: []string{"codewind-pfe"},
+				},
+				types.Container{
+					Names: []string{"codewind-performance"},
+				},
+			},
+			expectedContainers: []string{
+				"codewind-pfe",
+				"codewind-performance",
+			},
+		},
+		"Returns project containers (cw-)": {
+			containerList: []types.Container{
+				types.Container{
+					Names: []string{"/cw-nodejsexpress"},
+				},
+				types.Container{
+					Names: []string{"/cw-springboot"},
+				},
+			},
+			expectedContainers: []string{
+				"/cw-nodejsexpress",
+				"/cw-springboot",
+			},
+		},
+		"Ignores a non-codewind container": {
+			containerList: []types.Container{
+				types.Container{
+					Names: []string{"/cw-valid-container"},
+				},
+				types.Container{
+					Names: []string{"invalid-container"},
+				},
+			},
+			expectedContainers: []string{
+				"/cw-valid-container",
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			containersToRemove := getContainersToRemove(test.containerList)
+			assert.Equal(t, len(test.expectedContainers), len(containersToRemove))
+			for _, container := range containersToRemove {
+				assert.Contains(t, test.expectedContainers, container.Names[0])
+			}
+		})
+	}
+}

--- a/pkg/actions/stop-all_test.go
+++ b/pkg/actions/stop-all_test.go
@@ -26,15 +26,15 @@ func Test_getContainersToRemove(t *testing.T) {
 		"Returns the pfe and performance containers": {
 			containerList: []types.Container{
 				types.Container{
-					Names: []string{"codewind-pfe"},
+					Names: []string{"/codewind-pfe-amd"},
 				},
 				types.Container{
-					Names: []string{"codewind-performance"},
+					Names: []string{"/codewind-performance-amd"},
 				},
 			},
 			expectedContainers: []string{
-				"codewind-pfe",
-				"codewind-performance",
+				"/codewind-pfe-amd",
+				"/codewind-performance-amd",
 			},
 		},
 		"Returns project containers (cw-)": {

--- a/pkg/actions/stop.go
+++ b/pkg/actions/stop.go
@@ -31,7 +31,7 @@ func StopCommand() {
 	for _, container := range containers {
 		for _, key := range containerArr {
 			if strings.HasPrefix(container.Image, key) {
-				fmt.Println("Stopping container ", container.Names, "... ")
+				fmt.Println("Stopping container ", container.Names[0], "... ")
 				utils.StopContainer(container)
 			}
 		}

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -116,7 +116,6 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 	cwSettingsIgnoredPathsList := retrieveIgnoredPathsList(projectPath)
 
 	err := filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
-		fmt.Println("file: " + path)
 		if err != nil {
 			panic(err)
 			// TODO - How to handle *some* files being unreadable

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -116,7 +116,7 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 	cwSettingsIgnoredPathsList := retrieveIgnoredPathsList(projectPath)
 
 	err := filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
-
+		fmt.Println("file: " + path)
 		if err != nil {
 			panic(err)
 			// TODO - How to handle *some* files being unreadable

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -343,7 +343,10 @@ func StopContainer(container types.Container) {
 	errors.CheckErr(err, 200, "")
 
 	// Check if the container will remove after it is stopped
-	isAutoRemoved, err := getContainerAutoRemovePolicy(container.ID)
+	isAutoRemoved, isAutoRemovedErr := getContainerAutoRemovePolicy(container.ID)
+	if isAutoRemovedErr != nil {
+		errors.CheckErr(err, 108, "")
+	}
 
 	// Stop the running container
 	if err := cli.ContainerStop(ctx, container.ID, nil); err != nil {

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -21,7 +21,9 @@ type DockerError struct {
 }
 
 const (
-	errOpValidate = "docker_validate" // validate docker images
+	errOpValidate         = "docker_validate" // validate docker images
+	errOpClientCreate     = "CLIENT_CREATE_ERROR"
+	errOpContainerInspect = "CONTAINER_INSPECT_ERROR"
 )
 
 const (


### PR DESCRIPTION
**Fixes https://github.com/eclipse/codewind/issues/1388**
### Summary
* Removes by container name rather than image name.
  * Appsody image names are not build by us and don't contain the `cw-` prefix.
* Adds function to get containers to remove and a test to check its functionality
* Add function to check a containers `AutoRemove` status so we only remove ones that do not `AutoRemove` themselves. 

### Testing
* Added test for getting containes to delete.
* Manually tested that `cwctl` deletes Appsody containers.

Signed-off-by: James Wallis <james.wallis1@ibm.com>