### PR TITLE
Project Sync Fails in Che

### DIFF
--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -37,8 +37,9 @@ type ConnectionConfig struct {
 
 // Connection entry
 type Connection struct {
-	ID       string `json:"id"`
-	Label    string `json:"label"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	// Deprecated: Do not URL when calling PFE APIs, use config.PFEOriginFromConnection() which is cloud aware
 	URL      string `json:"url"`
 	AuthURL  string `json:"auth"`
 	Realm    string `json:"realm"`

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -39,7 +39,7 @@ type ConnectionConfig struct {
 type Connection struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
-	// Deprecated: Do not URL when calling PFE APIs, use config.PFEOriginFromConnection() which is cloud aware
+	// Deprecated: Do not use URL when calling PFE APIs. Use config.PFEOriginFromConnection() which is cloud aware
 	URL      string `json:"url"`
 	AuthURL  string `json:"auth"`
 	Realm    string `json:"realm"`

--- a/pkg/sechttp/httpclient.go
+++ b/pkg/sechttp/httpclient.go
@@ -36,6 +36,9 @@ func DispatchHTTPRequest(httpClient utils.HTTPClient, originalRequest *http.Requ
 		if err == nil {
 			logr.Tracef("Received HTTP Status code: %v\n", response.StatusCode)
 			return response, nil
+		} else {
+			logr.Tracef("Unable to contact server : %v\n", err)
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
## Problem

Project Sync fails in Che.  As seen in issue https://github.com/eclipse/codewind/issues/1446

## Solution 

1. Determine if running in Che or remote when selecting the hostname of the PFE service 
2. Update comments on the Connection struct to populate warning in the development IDE
3. Add logging to httpsec to pass back an error earlier

## Testing 

cwctl is able to send POST .../upload/end with correct hostname (in che this is always https://localhost:9090)

```
TRAC[0000] Request URL: PUT https://localhost:9090/api/v1/projects/14e388c0-1b49-11ea-9c40-d54b3f362761/upload 
TRAC[0001] Received HTTP Status code: 200               
TRAC[0001] Request URL: POST https://localhost:9090/api/v1/projects/14e388c0-1b49-11ea-9c40-d54b3f362761/upload/end 
TRAC[0001] Received HTTP Status code: 200               
Status: 200 OK
```


Error reporting in httpSec when url is invalid : 
```
TRAC[0000] Request URL: POST /api/v1/projects/14e388c0-1b49-11ea-9c40-d54b3f362761/upload/end 
TRAC[0000] sendRequest: REQUEST FAILED                  
TRAC[0000] Unable to access local server : {"error":"tx_connection","error_description":"Post /api/v1/projects/14e388c0-1b49-11ea-9c40-d54b3f362761/upload/end: unsupported protocol scheme \"\""} 
error dispatching request  {"error":"tx_connection","error_description":"Post /api/v1/projects/14e388c0-1b49-11ea-9c40-d54b3f362761/upload/end: unsupported protocol scheme \"\""}
Status: Post /api/v1/projects/14e388c0-1b49-11ea-9c40-d54b3f362761/upload/end: unsupported protocol scheme ""
~/.codewind/0.7.0 $ 
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>