### PR TITLE
[0.7.0] ensure current sync time is sent

### DIFF
--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -64,6 +64,7 @@ type (
 
 // SyncProject syncs a project with its remote connection
 func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
+	var currentSyncTime = time.Now().UnixNano() / 1000000;
 	projectPath := strings.TrimSpace(c.String("path"))
 	projectID := strings.TrimSpace(c.String("id"))
 	synctime := int64(c.Int("time"))
@@ -96,7 +97,6 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 	// Sync all the necessary project files
 	fileList, modifiedList, uploadedFilesList := syncFiles(projectPath, projectID, conURL, synctime, conInfo)
 	// Complete the upload
-	var currentSyncTime = time.Now().UnixNano() / 1000000;
 	completeStatus, completeStatusCode := completeUpload(projectID, fileList, modifiedList, conID, currentSyncTime)
 	response := SyncResponse{
 		UploadedFiles: uploadedFilesList,


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

when the cli calls project sync, it needs to send the current time as the -t value, not the last sync time.  Last sync time is only needed to identify any changed files.  The current time is needed to correctly set the values in pfe