### PR TITLE
Remove unused environment variable from PFE

### DIFF
--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -154,10 +154,6 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 			Value: codewind.ServiceAccountName,
 		},
 		{
-			Name:  "MICROCLIMATE_RELEASE_NAME",
-			Value: "RELEASE-NAME",
-		},
-		{
 			Name:  "HOST_WORKSPACE_DIRECTORY",
 			Value: "/projects",
 		},


### PR DESCRIPTION
Removes a long outdated environment variable from PFE, `MICROCLIMATE_RELEASE_NAME`. It hasn't been used in Codewind at all, and there are no references to it in the Codewind source code.