### PR TITLE
1504 - check destination is empty before downloading project

### DIFF
--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -186,7 +186,7 @@ func writeCwSettingsIfNotInProject(conID string, projectPath string, BuildType s
 	}
 }
 
-// CheckProjectPathDoesNotExist stops the process if the given path is empty, or already exists
+// checkProjectPathDoesNotExist stops the process if the given local filepath already exists, or is an empty string
 func checkProjectPathDoesNotExist(projectPath string) {
 	if projectPath == "" {
 		log.Fatal("destination not set")
@@ -194,10 +194,9 @@ func checkProjectPathDoesNotExist(projectPath string) {
 	if utils.PathExists(projectPath) {
 		log.Fatal("Project is already at given path")
 	}
-
 }
 
-// CheckProjectPathExists will stop the process and return an error if path does not exist or is invalid
+// checkProjectPathExists stops the process if the given local filepath does not exist, or is an empty string
 func checkProjectPathExists(projectPath string) {
 	if projectPath == "" {
 		log.Fatal("Project path not given")

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -54,9 +54,7 @@ type (
 func DownloadTemplate(c *cli.Context) *ProjectError {
 	destination := c.Args().Get(0)
 
-	if destination == "" {
-		log.Fatal("destination not set")
-	}
+	checkProjectPathDoesNotExist(destination)
 
 	projectDir := path.Base(destination)
 
@@ -139,7 +137,7 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 func ValidateProject(c *cli.Context) *ProjectError {
 	projectPath := c.Args().Get(0)
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	checkProjectPath(projectPath)
+	checkProjectPathExists(projectPath)
 	validationStatus := "success"
 	// result could be ProjectType or string, so define as an interface
 	var validationResult interface{}
@@ -188,8 +186,19 @@ func writeCwSettingsIfNotInProject(conID string, projectPath string, BuildType s
 	}
 }
 
-// checkProjectPath will stop the process and return an error if path does not exist or is invalid
-func checkProjectPath(projectPath string) {
+// CheckProjectPathDoesNotExist stops the process if the given path is empty, or already exists
+func checkProjectPathDoesNotExist(projectPath string) {
+	if projectPath == "" {
+		log.Fatal("destination not set")
+	}
+	if utils.PathExists(projectPath) {
+		log.Fatal("Project is already at given path")
+	}
+
+}
+
+// CheckProjectPathExists will stop the process and return an error if path does not exist or is invalid
+func checkProjectPathExists(projectPath string) {
 	if projectPath == "" {
 		log.Fatal("Project path not given")
 	}

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -54,7 +54,7 @@ type (
 func DownloadTemplate(c *cli.Context) *ProjectError {
 	destination := c.Args().Get(0)
 
-	checkProjectPathDoesNotExist(destination)
+	checkProjectDirIsEmpty(destination)
 
 	projectDir := path.Base(destination)
 
@@ -186,13 +186,21 @@ func writeCwSettingsIfNotInProject(conID string, projectPath string, BuildType s
 	}
 }
 
-// checkProjectPathDoesNotExist stops the process if the given local filepath already exists, or is an empty string
-func checkProjectPathDoesNotExist(projectPath string) {
+// checkProjectDirIsEmpty stops the process if the given local filepath already exists, or is an empty string
+func checkProjectDirIsEmpty(projectPath string) {
 	if projectPath == "" {
 		log.Fatal("destination not set")
 	}
+
+	// if the project dir already exists, continue if empty and exit if not
 	if utils.PathExists(projectPath) {
-		log.Fatal("Project is already at given path")
+		dirIsEmpty, err := utils.DirIsEmpty(projectPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if !dirIsEmpty {
+			log.Fatal("Non empty project at given path")
+		}
 	}
 }
 

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -276,6 +276,21 @@ func PathExists(path string) bool {
 	return false
 }
 
+// DirIsEmpty returns true if the directory at the given path if empty
+func DirIsEmpty(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}
+
 // ReplaceInFiles the placeholder string "[PROJ_NAME_PLACEHOLDER]" with a generated name based on the project directory
 func ReplaceInFiles(projectPath string, oldStr string, newStr string) error {
 


### PR DESCRIPTION
Resolves: 
https://github.com/eclipse/codewind/issues/1504
https://github.com/eclipse/codewind/issues/1475

## Summary 

When cwctl is called to download a template to a users filesystem (`cwctl project create ...`, there is no check as to whether a project already existed at that destination. As described in this issue, this means a new project can be added to an existing project.

This adds a check on this, and stops the process if the local filepath is non-empty.

Note: This file should be returning errors, in the same way as more recent functionality, as opposed to calling log.fatal. However, I wanted to keep code changes into 0.7.0 to a minimum. I would like to make those changes into master however, as well as looking at extending our testing in this area.

## Testing


Download a template, using:

```
cwctl --json 
project create /Users/james.cockbain@ibm.com/Documents/workspace/proj5 
--conid local 
--url https://github.com/codewind-resources/nodeExpressTemplate
```

Call the command again. Process exits with this message: 
```
2019/12/13 09:49:08 Project is already at given path
```
Imported my built cwctl into vscode-plugin, when following recreation steps from https://github.com/eclipse/codewind/issues/1504 the following error is returned and project not created: 

![Screenshot 2019-12-13 at 12 16 34](https://user-images.githubusercontent.com/31372187/70799838-a2b68700-1da2-11ea-995c-e67963cccd48.png)

