### PR TITLE
Use docker-compose to bring down containers/remove images

### DIFF
--- a/integration.bats
+++ b/integration.bats
@@ -20,6 +20,7 @@
 @test "invoke start command - Start dockerhub images (latest)" {
   cd cmd/cli/
   run go run main.go start -t latest
+  sleep 10
   echo "status = ${status}"
   echo "output trace = ${output}"
   [ "$status" -eq 0 ]

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -15,27 +15,15 @@ import (
 	"crypto/tls"
 	"net/http"
 	"os"
-	"runtime"
 
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
+	desktoputils "github.com/eclipse/codewind-installer/pkg/desktop_utils"
 	"github.com/eclipse/codewind-installer/pkg/errors"
 	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
-// Get home directory
-func getHomeDir() string {
-	homeDir := ""
-	const GOOS string = runtime.GOOS
-	if GOOS == "windows" {
-		homeDir = os.Getenv("USERPROFILE")
-	} else {
-		homeDir = os.Getenv("HOME")
-	}
-	return homeDir
-}
-
-var homeDir = getHomeDir()
+var homeDir = desktoputils.GetHomeDir()
 var dockerComposeFile = homeDir + "/.codewind/docker-compose.yaml"
 
 const healthEndpoint = "/api/v1/environment"

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -15,6 +15,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"os"
+	"runtime"
 
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	"github.com/eclipse/codewind-installer/pkg/errors"
@@ -22,7 +23,20 @@ import (
 	"github.com/urfave/cli"
 )
 
-var tempFilePath = "codewind-docker-compose.yaml"
+// Get home directory
+func getHomeDir() string {
+	homeDir := ""
+	const GOOS string = runtime.GOOS
+	if GOOS == "windows" {
+		homeDir = os.Getenv("USERPROFILE")
+	} else {
+		homeDir = os.Getenv("HOME")
+	}
+	return homeDir
+}
+
+var homeDir = getHomeDir()
+var dockerComposeFile = homeDir + "/.codewind/docker-compose.yaml"
 
 const healthEndpoint = "/api/v1/environment"
 
@@ -228,7 +242,7 @@ func Commands() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				StartCommand(c, tempFilePath, healthEndpoint)
+				StartCommand(c, dockerComposeFile, healthEndpoint)
 				return nil
 			},
 		},
@@ -256,7 +270,7 @@ func Commands() {
 			Name:  "stop",
 			Usage: "Stop the running Codewind containers",
 			Action: func(c *cli.Context) error {
-				StopCommand()
+				StopCommand(c, dockerComposeFile)
 				return nil
 			},
 		},
@@ -265,7 +279,7 @@ func Commands() {
 			Name:  "stop-all",
 			Usage: "Stop all of the Codewind and project containers",
 			Action: func(c *cli.Context) error {
-				StopAllCommand()
+				StopAllCommand(c, dockerComposeFile)
 				return nil
 			},
 		},
@@ -281,7 +295,7 @@ func Commands() {
 			},
 			Usage: "Remove Codewind/Project docker images and the codewind network",
 			Action: func(c *cli.Context) error {
-				RemoveCommand(c)
+				RemoveCommand(c, dockerComposeFile)
 				return nil
 			},
 			Subcommands: []cli.Command{

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -33,30 +33,30 @@ func InstallCommand(c *cli.Context) {
 	jsonOutput := c.Bool("json") || c.GlobalBool("json")
 
 	imageArr := [2]string{
-		"docker.io/eclipse/codewind-pfe-amd64:",
-		"docker.io/eclipse/codewind-performance-amd64:",
+		"docker.io/eclipse/codewind-pfe-amd64:" + tag,
+		"docker.io/eclipse/codewind-performance-amd64:" + tag,
 	}
 
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i]+tag, jsonOutput)
-		imageID, dockerError := utils.ValidateImageDigest(imageArr[i] + tag)
+		utils.PullImage(imageArr[i], jsonOutput)
+		imageID, dockerError := utils.ValidateImageDigest(imageArr[i])
 
 		if dockerError != nil {
-			logr.Tracef("%v checksum validation failed. Trying to pull image again", imageArr[i]+tag)
+			logr.Tracef("%v checksum validation failed. Trying to pull image again", imageArr[i])
 			// remove bad image
 			utils.RemoveImage(imageID)
 
 			// pull image again
-			utils.PullImage(imageArr[i]+tag, jsonOutput)
+			utils.PullImage(imageArr[i], jsonOutput)
 
 			// validate the new image
-			_, dockerError = utils.ValidateImageDigest(imageArr[i] + tag)
+			_, dockerError = utils.ValidateImageDigest(imageArr[i])
 
 			if dockerError != nil {
 				if jsonOutput {
 					fmt.Println(dockerError)
 				} else {
-					logr.Errorf("Validation of image '%v' checksum failed - Removing image", imageArr[i]+tag)
+					logr.Errorf("Validation of image '%v' checksum failed - Removing image", imageArr[i])
 				}
 				// Clean up the second bad image
 				utils.RemoveImage(imageID)

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -32,11 +32,10 @@ func InstallCommand(c *cli.Context) {
 	tag := c.String("tag")
 	jsonOutput := c.Bool("json") || c.GlobalBool("json")
 
-	imageArr := [2]string{"docker.io/eclipse/codewind-pfe-amd64:",
-		"docker.io/eclipse/codewind-performance-amd64:"}
-
-	targetArr := [2]string{"codewind-pfe-amd64:",
-		"codewind-performance-amd64:"}
+	imageArr := [2]string{
+		"docker.io/eclipse/codewind-pfe-amd64:",
+		"docker.io/eclipse/codewind-performance-amd64:",
+	}
 
 	for i := 0; i < len(imageArr); i++ {
 		utils.PullImage(imageArr[i]+tag, jsonOutput)
@@ -64,11 +63,9 @@ func InstallCommand(c *cli.Context) {
 				os.Exit(1)
 			}
 		}
-
-		utils.TagImage(imageArr[i]+tag, targetArr[i]+tag)
 	}
 
-	fmt.Println("Image Tagging Successful")
+	fmt.Println("Image Install Successful")
 }
 
 // DoRemoteInstall : Deploy a remote PFE and support containers

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -49,7 +49,6 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 	}
 
 	utils.DockerComposeRemove(dockerComposeFile, tag)
-	utils.DeleteTempFile(dockerComposeFile) // Remove docker-compose.yaml from /.codewind
 }
 
 // DoRemoteRemove : Delete a remote Codewind deployment

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -23,14 +23,11 @@ import (
 )
 
 //RemoveCommand to remove all codewind and project images
-func RemoveCommand(c *cli.Context) {
+func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
 	imageArr := []string{
-		"eclipse/codewind-pfe-amd64:" + tag,
-		"eclipse/codewind-performance-amd64:" + tag,
 		"cw-",
 	}
-	networkName := "codewind"
 
 	images := utils.GetImageList()
 
@@ -51,14 +48,8 @@ func RemoveCommand(c *cli.Context) {
 		}
 	}
 
-	networks := utils.GetNetworkList()
-
-	for _, network := range networks {
-		if strings.Contains(network.Name, networkName) {
-			fmt.Print("Removing docker network: ", network.Name, "... ")
-			utils.RemoveNetwork(network)
-		}
-	}
+	utils.DockerComposeRemove(dockerComposeFile, tag)
+	utils.DeleteTempFile(dockerComposeFile) // Remove docker-compose.yaml from /.codewind
 }
 
 // DoRemoteRemove : Delete a remote Codewind deployment

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -25,6 +25,9 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
+	if tag == "" {
+		tag = "latest"
+	}
 	imageArr := []string{
 		"cw-",
 	}

--- a/pkg/actions/start.go
+++ b/pkg/actions/start.go
@@ -20,7 +20,6 @@ import (
 
 // StartCommand : start the codewind containers
 func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint string) {
-	tag := c.String("tag")
 	status := utils.CheckContainerStatus()
 
 	if status {

--- a/pkg/actions/start.go
+++ b/pkg/actions/start.go
@@ -18,8 +18,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-//StartCommand to start the codewind conainers
-func StartCommand(c *cli.Context, tempFilePath string, healthEndpoint string) {
+// StartCommand : start the codewind containers
+func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint string) {
+	tag := c.String("tag")
 	status := utils.CheckContainerStatus()
 
 	if status {
@@ -29,13 +30,9 @@ func StartCommand(c *cli.Context, tempFilePath string, healthEndpoint string) {
 		debug := c.Bool("debug")
 		fmt.Println("Debug:", debug)
 
-		// Stop all running project containers and remove codewind networks
-		StopAllCommand()
-
-		utils.CreateTempFile(tempFilePath)
-		utils.WriteToComposeFile(tempFilePath, debug)
-		utils.DockerCompose(tempFilePath, tag)
-		utils.DeleteTempFile(tempFilePath) // Remove installer-docker-compose.yaml
+		utils.CreateTempFile(dockerComposeFile)
+		utils.WriteToComposeFile(dockerComposeFile, debug)
+		utils.DockerCompose(dockerComposeFile, tag)
 		utils.PingHealth(healthEndpoint)
 	}
 }

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -17,11 +17,13 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/urfave/cli"
 )
 
 //StopAllCommand to stop codewind and project containers
-func StopAllCommand() {
-	containers := utils.GetContainerList()
+func StopAllCommand(c *cli.Context, dockerComposeFile string) {
+	tag := c.String("tag")
+	containers, err := utils.GetContainerList()
 
 	fmt.Println("Stopping Codewind and Project containers")
 	containersToRemove := getContainersToRemove(containers)
@@ -30,21 +32,14 @@ func StopAllCommand() {
 		utils.StopContainer(container)
 	}
 
-	networkName := "codewind"
-	networks := utils.GetNetworkList()
-	fmt.Println("Removing Codewind docker networks..")
-	for _, network := range networks {
-		if strings.Contains(network.Name, networkName) {
-			fmt.Print("Removing docker network: ", network.Name, "... ")
-			utils.RemoveNetwork(network)
-		}
-	}
+	utils.DockerComposeStop(tag, dockerComposeFile)
+
 }
 
 func getContainersToRemove(containerList []types.Container) []types.Container {
 	codewindContainerPrefixes := []string{
-		"/codewind-pfe",
-		"/codewind-performance",
+		// "/codewind-pfe",
+		// "/codewind-performance",
 		"/cw-",
 	}
 

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -24,15 +24,14 @@ import (
 func StopAllCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
 	containers := utils.GetContainerList()
+	utils.DockerComposeStop(tag, dockerComposeFile)
 
-	fmt.Println("Stopping Codewind and Project containers")
+	fmt.Println("Stopping Project containers")
 	containersToRemove := getContainersToRemove(containers)
 	for _, container := range containersToRemove {
 		fmt.Println("Stopping container ", container.Names[0], "... ")
 		utils.StopContainer(container)
 	}
-
-	utils.DockerComposeStop(tag, dockerComposeFile)
 
 }
 

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -38,8 +38,6 @@ func StopAllCommand(c *cli.Context, dockerComposeFile string) {
 
 func getContainersToRemove(containerList []types.Container) []types.Container {
 	codewindContainerPrefixes := []string{
-		// "/codewind-pfe",
-		// "/codewind-performance",
 		"/cw-",
 	}
 

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -23,7 +23,7 @@ import (
 //StopAllCommand to stop codewind and project containers
 func StopAllCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
-	containers, err := utils.GetContainerList()
+	containers := utils.GetContainerList()
 
 	fmt.Println("Stopping Codewind and Project containers")
 	containersToRemove := getContainersToRemove(containers)

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -32,7 +32,6 @@ func StopAllCommand(c *cli.Context, dockerComposeFile string) {
 		fmt.Println("Stopping container ", container.Names[0], "... ")
 		utils.StopContainer(container)
 	}
-
 }
 
 func getContainersToRemove(containerList []types.Container) []types.Container {

--- a/pkg/actions/stop-all_test.go
+++ b/pkg/actions/stop-all_test.go
@@ -23,20 +23,6 @@ func Test_getContainersToRemove(t *testing.T) {
 		containerList      []types.Container
 		expectedContainers []string
 	}{
-		"Returns the pfe and performance containers": {
-			containerList: []types.Container{
-				types.Container{
-					Names: []string{"/codewind-pfe-amd"},
-				},
-				types.Container{
-					Names: []string{"/codewind-performance-amd"},
-				},
-			},
-			expectedContainers: []string{
-				"/codewind-pfe-amd",
-				"/codewind-performance-amd",
-			},
-		},
 		"Returns project containers (cw-)": {
 			containerList: []types.Container{
 				types.Container{

--- a/pkg/actions/stop.go
+++ b/pkg/actions/stop.go
@@ -21,6 +21,6 @@ import (
 //StopCommand to stop only the codewind containers
 func StopCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
-	utils.DockerComposeStop(tag, dockerComposeFile)
 	fmt.Println("Only stopping Codewind containers. To stop project containers, please use 'stop-all'")
+	utils.DockerComposeStop(tag, dockerComposeFile)
 }

--- a/pkg/actions/stop.go
+++ b/pkg/actions/stop.go
@@ -13,27 +13,14 @@ package actions
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/urfave/cli"
 )
 
 //StopCommand to stop only the codewind containers
-func StopCommand() {
-	containerArr := [2]string{}
-	containerArr[0] = "codewind-pfe"
-	containerArr[1] = "codewind-performance"
-
-	containers := utils.GetContainerList()
-
+func StopCommand(c *cli.Context, dockerComposeFile string) {
+	tag := c.String("tag")
+	utils.DockerComposeStop(tag, dockerComposeFile)
 	fmt.Println("Only stopping Codewind containers. To stop project containers, please use 'stop-all'")
-
-	for _, container := range containers {
-		for _, key := range containerArr {
-			if strings.HasPrefix(container.Image, key) {
-				fmt.Println("Stopping container ", container.Names[0], "... ")
-				utils.StopContainer(container)
-			}
-		}
-	}
 }

--- a/pkg/desktop_utils/get_home_dir.go
+++ b/pkg/desktop_utils/get_home_dir.go
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package desktoputils
+
+// *** When moving to go 12 we should use func UserHomeDir() instead of this function ***
+
+import (
+	"os"
+	"runtime"
+)
+
+// GetHomeDir of current system
+func GetHomeDir() string {
+	homeDir := ""
+	const GOOS string = runtime.GOOS
+	if GOOS == "windows" {
+		homeDir = os.Getenv("USERPROFILE")
+	} else {
+		homeDir = os.Getenv("HOME")
+	}
+	return homeDir
+}

--- a/pkg/desktop_utils/get_home_dir_test.go
+++ b/pkg/desktop_utils/get_home_dir_test.go
@@ -12,20 +12,13 @@
 package desktoputils
 
 import (
-	"os"
-	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// *** When moving to go 12 we should use func UserHomeDir() instead of this function ***
-
-// GetHomeDir of current system
-func GetHomeDir() string {
-	homeDir := ""
-	const GOOS string = runtime.GOOS
-	if GOOS == "windows" {
-		homeDir = os.Getenv("USERPROFILE")
-	} else {
-		homeDir = os.Getenv("HOME")
-	}
-	return homeDir
+// Test to make sure GetHomeDir() does not return a nil value
+func Test_GetHomeDir(t *testing.T) {
+	result := GetHomeDir()
+	assert.NotNil(t, result, "should return home dir of system or blank string")
 }

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -106,7 +106,7 @@ const (
 )
 
 // DockerCompose to set up the Codewind environment
-func DockerCompose(dockerComposeFile string, tag string) *DockerError {
+func DockerCompose(dockerComposeFile string, tag string) {
 	setupDockerComposeEnvs(tag)
 
 	cmd := exec.Command("docker-compose", "-f", dockerComposeFile, "up", "-d", "--force-recreate")
@@ -130,13 +130,10 @@ func DockerCompose(dockerComposeFile string, tag string) *DockerError {
 		DeleteTempFile(dockerComposeFile)
 		os.Exit(1)
 	}
-	return nil
 }
 
-//*************************************************************************************************************************************************************************************************
-// DockerCompose to set up the Codewind environment
-func DockerComposeStop(tag, dockerComposeFile string) *DockerError {
-
+// DockerComposeStop to stop Codewind containers
+func DockerComposeStop(tag, dockerComposeFile string) {
 	setupDockerComposeEnvs(tag)
 
 	cmd := exec.Command("docker-compose", "-f", dockerComposeFile, "rm", "--stop", "-f")
@@ -152,14 +149,12 @@ func DockerComposeStop(tag, dockerComposeFile string) *DockerError {
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
-		//DeleteTempFile(dockerComposeFile)
 		os.Exit(1)
 	}
-	return nil
 }
 
-func DockerComposeRemove(dockerComposeFile, tag string) *DockerError {
-
+// DockerComposeRemove to remove Codewind images
+func DockerComposeRemove(dockerComposeFile, tag string) {
 	setupDockerComposeEnvs(tag)
 	cmd := exec.Command("docker-compose", "-f", dockerComposeFile, "down", "--rmi", "all")
 	output := new(bytes.Buffer)
@@ -174,14 +169,12 @@ func DockerComposeRemove(dockerComposeFile, tag string) *DockerError {
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
-		//DeleteTempFile(dockerComposeFile)
 		os.Exit(1)
 	}
-	return nil
 }
 
+// setupDockerComposeEnvs for docker-compose to use
 func setupDockerComposeEnvs(tag string) {
-	// Set env variables for the docker compose file
 	home := os.Getenv("HOME")
 
 	const GOARCH string = runtime.GOARCH
@@ -214,8 +207,6 @@ func setupDockerComposeEnvs(tag string) {
 	}
 	os.Setenv("PFE_EXTERNAL_PORT", port)
 }
-
-//*************************************************************************************************************************************************************************************************
 
 // PullImage - pull pfe/performance images from dockerhub
 func PullImage(image string, jsonOutput bool) {

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -140,7 +140,7 @@ func DockerComposeStop(tag, dockerComposeFile string) {
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
 		DeleteTempFile(dockerComposeFile)
-		errors.CheckErr(err, 101, "Is docker-compose installed?")
+		errors.CheckErr(err, 101, "")
 	}
 	fmt.Printf("Please wait whilst containers shutdown... %s \n", output.String())
 	cmd.Wait()
@@ -160,7 +160,7 @@ func DockerComposeRemove(dockerComposeFile, tag string) {
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
 		DeleteTempFile(dockerComposeFile)
-		errors.CheckErr(err, 101, "Is docker-compose installed?")
+		errors.CheckErr(err, 101, "")
 	}
 	fmt.Printf("Please wait whilst images are removed... %s \n", output.String())
 	cmd.Wait()

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -117,7 +117,10 @@ func DockerCompose(dockerComposeFile string, tag string) {
 		errors.CheckErr(err, 101, "Is docker-compose installed?")
 	}
 	fmt.Printf("Please wait whilst containers initialize... %s \n", output.String())
-	cmd.Wait()
+	if err := cmd.Wait(); err != nil {
+		DeleteTempFile(dockerComposeFile)
+		errors.CheckErr(err, 101, "docker-compose command failed to execute correctly") // TODO - replace with new docker error
+	}
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
@@ -142,7 +145,9 @@ func DockerComposeStop(tag, dockerComposeFile string) {
 		errors.CheckErr(err, 101, "")
 	}
 	fmt.Printf("Please wait whilst containers shutdown... %s \n", output.String())
-	cmd.Wait()
+	if err := cmd.Wait(); err != nil {
+		errors.CheckErr(err, 101, "docker-compose stop command failed to execute correctly") //TODO - replace with new docker error
+	}
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
@@ -161,7 +166,9 @@ func DockerComposeRemove(dockerComposeFile, tag string) {
 		errors.CheckErr(err, 101, "")
 	}
 	fmt.Printf("Please wait whilst images are removed... %s \n", output.String())
-	cmd.Wait()
+	if err := cmd.Wait(); err != nil {
+		errors.CheckErr(err, 101, "docker-compose remove command failed to execute correctly") //TODO - replace with new docker error
+	}
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -34,9 +34,12 @@ import (
 	logr "github.com/sirupsen/logrus"
 )
 
+const pfeImageName = "eclipse/codewind-pfe"
+const performanceImageName = "eclipse/codewind-performance"
+
 var baseImageNameArr = [2]string{
-	"eclipse/codewind-pfe",
-	"eclipse/codewind-performance",
+	pfeImageName,
+	performanceImageName,
 }
 
 // codewind-docker-compose.yaml data
@@ -184,8 +187,8 @@ func DockerComposeRemove(dockerComposeFile, tag string) {
 // setupDockerComposeEnvs for docker-compose to use
 func setupDockerComposeEnvs(tag, command string) {
 	home := os.Getenv("HOME")
-	os.Setenv("PFE_IMAGE_NAME", baseImageNameArr[0])
-	os.Setenv("PERFORMANCE_IMAGE_NAME", baseImageNameArr[1])
+	os.Setenv("PFE_IMAGE_NAME", pfeImageName)
+	os.Setenv("PERFORMANCE_IMAGE_NAME", performanceImageName)
 
 	const GOARCH string = runtime.GOARCH
 	const GOOS string = runtime.GOOS
@@ -447,7 +450,7 @@ func GetPFEHostAndPort() (string, string) {
 	} else if CheckContainerStatus() {
 		containerList := GetContainerList()
 		for _, container := range containerList {
-			if strings.HasPrefix(container.Image, baseImageNameArr[0]) { //checks pfe
+			if strings.HasPrefix(container.Image, pfeImageName) {
 				for _, port := range container.Ports {
 					if port.PrivatePort == internalPFEPort {
 						return port.IP, strconv.Itoa(int(port.PublicPort))

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -139,7 +139,6 @@ func DockerComposeStop(tag, dockerComposeFile string) {
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
-		DeleteTempFile(dockerComposeFile)
 		errors.CheckErr(err, 101, "")
 	}
 	fmt.Printf("Please wait whilst containers shutdown... %s \n", output.String())
@@ -159,7 +158,6 @@ func DockerComposeRemove(dockerComposeFile, tag string) {
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
-		DeleteTempFile(dockerComposeFile)
 		errors.CheckErr(err, 101, "")
 	}
 	fmt.Printf("Please wait whilst images are removed... %s \n", output.String())

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -108,7 +108,6 @@ const (
 // DockerCompose to set up the Codewind environment
 func DockerCompose(dockerComposeFile string, tag string) {
 	setupDockerComposeEnvs(tag)
-
 	cmd := exec.Command("docker-compose", "-f", dockerComposeFile, "up", "-d", "--force-recreate")
 	output := new(bytes.Buffer)
 	cmd.Stdout = output
@@ -135,7 +134,6 @@ func DockerCompose(dockerComposeFile string, tag string) {
 // DockerComposeStop to stop Codewind containers
 func DockerComposeStop(tag, dockerComposeFile string) {
 	setupDockerComposeEnvs(tag)
-
 	cmd := exec.Command("docker-compose", "-f", dockerComposeFile, "rm", "--stop", "-f")
 	output := new(bytes.Buffer)
 	cmd.Stdout = output

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -51,8 +51,8 @@ func CreateTempFile(filePath string) bool {
 }
 
 // WriteToComposeFile the contents of the docker compose yaml
-func WriteToComposeFile(tempFilePath string, debug bool) bool {
-	if tempFilePath == "" {
+func WriteToComposeFile(dockerComposeFile string, debug bool) bool {
+	if dockerComposeFile == "" {
 		return false
 	}
 
@@ -71,12 +71,12 @@ func WriteToComposeFile(tempFilePath string, debug bool) bool {
 	errors.CheckErr(err, 203, "")
 
 	if debug == true {
-		fmt.Printf("==> %s structure is: \n%s\n\n", tempFilePath, string(marshalledData))
+		fmt.Printf("==> %s structure is: \n%s\n\n", dockerComposeFile, string(marshalledData))
 	} else {
-		fmt.Println("==> environment structure written to " + tempFilePath)
+		fmt.Println("==> environment structure written to " + dockerComposeFile)
 	}
 
-	err = ioutil.WriteFile(tempFilePath, marshalledData, 0644)
+	err = ioutil.WriteFile(dockerComposeFile, marshalledData, 0644)
 	errors.CheckErr(err, 204, "")
 	return true
 }


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/1148**
We currently mix technologies. We use `docker-compose up` to bring up containers but we then use docker API's to shut down the containers and remove the images. This leaves cached data from the `docker-compose up` and seems to be causing the issue 
```
ERROR: for codewind-performance  b'no such image: sha256:f0a....
```

**Solution in this PR**
1) Remove the re-tagging of images so the image name is consistently `eclipse/codewind-...` throughout. This will also mean that if `start` fails because of a wrong tag being specified, it will attempt to pull down the image from docker hub if it doesnt already exist on the host machine. Will fix this issue https://github.com/eclipse/codewind/issues/462
2) Rename `codewind-docker-compose.yaml` -> `docker-compose.yaml`
3) On first start of Codewind, write the `docker-compose.yaml` to the `./codewind` directory and keep it stored in here. No longer delete it so it can be used by other `docker-compose` commands
4) Use `docker-compose -f <compose-file> rm --stop -f` to stop only the `codewind-pfe` & `codewind-performance` containers. Project containers will continue to be stopped using a docker API since they are not specified in the `docker-compose.yaml` services
5) Use `docker-compose -f <compose-file> down --rmi all` to remove `eclipse/codewind-pfe` & `eclipse/codewind-performance` images. Project images will continue to be removed using the docker API as they are not specified in the `docker-compose.yaml` services
6) Since this will use `docker-compose` to remove the images, the `remove` command *should* have a tag specified. If no tag is provided it will default to `latest`

**Tested**
*Operating Systems*
1) MacOS - `install/start/stop/stop-all/remove` working
2) Windows - `install/start/stop/stop-all/remove` working
3) Linux - `install/start/stop/stop-all/remove` working

*Bats test output*
`18 tests, 0 failures, 6 skipped`

**Extra**
- Better error checking and handling will be provided in a follow up PR from @jcockbain 
- The logic of the stopping of the containers in this PR also fixes https://github.com/eclipse/codewind/issues/1502
Signed-off-by: Liam Hampton liam.hampton@ibm.com