### PR TITLE
add go report card label

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Prebuilt binary files are available for download [on Eclipse](https://download.e
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 [![Build Status](https://ci.eclipse.org/codewind/buildStatus/icon?job=Codewind%2Fcodewind-installer%2Fmaster)](https://ci.eclipse.org/codewind/job/Codewind/job/codewind-installer/job/master/)
 [![Chat](https://img.shields.io/static/v1.svg?label=chat&message=mattermost&color=145dbf)](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind)
+[![Go Report Card](https://goreportcard.com/badge/github.com/eclipse/codewind-installer)](https://goreportcard.com/report/github.com/eclipse/codewind-installer)
 
 ## Table of Contents
 


### PR DESCRIPTION
https://github.com/eclipse/codewind/issues/1517 
Add go report card to the README after a good response from the original suggestion
![image](https://user-images.githubusercontent.com/42477259/70895445-e26db080-1fe6-11ea-881c-220dd955816f.png)

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>