### PR TITLE
Add directoryList to the upload/end API request body

### DIFF
--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -134,7 +134,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 	SetConnection(conID, projectID)
 
 	// Sync all the project files
-	_, _, uploadedFilesList := syncFiles(projectPath, projectID, conURL, 0, conInfo)
+	_, _, _, uploadedFilesList := syncFiles(projectPath, projectID, conURL, 0, conInfo)
 
 	// Call bind/end to complete
 	completeStatus, completeStatusCode := completeBind(projectID, conURL, conInfo)


### PR DESCRIPTION
Part of: https://github.com/eclipse/codewind/issues/1560
Should be merged in before the PFE part, this won't effect anything in PFE until `directoryList` is used.
### Summary
* Collect the directory layout of a project (in addition to the existing file layout) into a `directoryList` variable.
* Add the `directoryList` into the payload for the `/upload/end` call in `sync.go`.

### Testing
* Manual testing to ensure that it is sent correctly.

Signed-off-by: James Wallis <james.wallis1@ibm.com>