### PR TITLE
Use DockerError struct for all docker errors

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -25,6 +25,7 @@ import (
 
 var homeDir = desktoputils.GetHomeDir()
 var dockerComposeFile = homeDir + "/.codewind/docker-compose.yaml"
+var printAsJSON = false
 
 const healthEndpoint = "/api/v1/environment"
 
@@ -821,6 +822,8 @@ func Commands() {
 		if c.GlobalBool("insecure") {
 			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		}
+
+		printAsJSON = c.GlobalBool("json")
 
 		// Handle Global log level flag
 

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -39,7 +39,7 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 		if printAsJSON {
 			fmt.Println(err.Error())
 		} else {
-			logr.Println(err.Desc)
+			logr.Error(err.Desc)
 		}
 		os.Exit(1)
 	}

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -25,7 +25,6 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
-	printAsJSON := c.GlobalBool("json")
 	if tag == "" {
 		tag = "latest"
 	}
@@ -36,11 +35,7 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 	images, err := utils.GetImageList()
 
 	if err != nil {
-		if printAsJSON {
-			fmt.Println(err.Error())
-		} else {
-			logr.Error(err.Desc)
-		}
+		HandleDockerError(err)
 		os.Exit(1)
 	}
 
@@ -66,7 +61,6 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 
 // DoRemoteRemove : Delete a remote Codewind deployment
 func DoRemoteRemove(c *cli.Context) {
-	printAsJSON := c.GlobalBool("json")
 	removeOptions := remote.RemoveDeploymentOptions{
 		Namespace:   c.String("namespace"),
 		WorkspaceID: c.String("workspace"),

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -25,6 +25,7 @@ import (
 //RemoveCommand to remove all codewind and project images
 func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
+	printAsJSON := c.GlobalBool("json")
 	if tag == "" {
 		tag = "latest"
 	}
@@ -32,7 +33,16 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 		"cw-",
 	}
 
-	images := utils.GetImageList()
+	images, err := utils.GetImageList()
+
+	if err != nil {
+		if printAsJSON {
+			fmt.Println(err.Error())
+		} else {
+			logr.Println(err.Desc)
+		}
+		os.Exit(1)
+	}
 
 	fmt.Println("Removing Codewind docker images..")
 

--- a/pkg/actions/start.go
+++ b/pkg/actions/start.go
@@ -16,20 +16,14 @@ import (
 	"os"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
-	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 // StartCommand : start the codewind containers
 func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint string) {
-	printAsJSON := c.GlobalBool("json")
 	status, err := utils.CheckContainerStatus()
 	if err != nil {
-		if printAsJSON {
-			fmt.Println(err.Error())
-		} else {
-			logr.Error(err.Desc)
-		}
+		HandleDockerError(err)
 		os.Exit(1)
 	}
 
@@ -45,21 +39,13 @@ func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint strin
 
 		err := utils.DockerCompose(dockerComposeFile, tag)
 		if err != nil {
-			if printAsJSON {
-				fmt.Println(err.Error())
-			} else {
-				logr.Error(err.Desc)
-			}
+			HandleDockerError(err)
 			os.Exit(1)
 		}
 
 		_, pingHealthErr := utils.PingHealth(healthEndpoint)
-		if err != nil {
-			if printAsJSON {
-				fmt.Println(pingHealthErr.Error())
-			} else {
-				logr.Error(pingHealthErr.Desc)
-			}
+		if pingHealthErr != nil {
+			HandleDockerError(pingHealthErr)
 			os.Exit(1)
 		}
 	}

--- a/pkg/actions/start.go
+++ b/pkg/actions/start.go
@@ -13,6 +13,7 @@ package actions
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	logr "github.com/sirupsen/logrus"
@@ -27,8 +28,9 @@ func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint strin
 		if printAsJSON {
 			fmt.Println(err.Error())
 		} else {
-			logr.Println(err.Desc)
+			logr.Error(err.Desc)
 		}
+		os.Exit(1)
 	}
 
 	if status {
@@ -46,8 +48,9 @@ func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint strin
 			if printAsJSON {
 				fmt.Println(err.Error())
 			} else {
-				logr.Println(err.Desc)
+				logr.Error(err.Desc)
 			}
+			os.Exit(1)
 		}
 
 		_, pingHealthErr := utils.PingHealth(healthEndpoint)
@@ -55,8 +58,9 @@ func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint strin
 			if printAsJSON {
 				fmt.Println(pingHealthErr.Error())
 			} else {
-				logr.Println(pingHealthErr.Desc)
+				logr.Error(pingHealthErr.Desc)
 			}
+			os.Exit(1)
 		}
 	}
 }

--- a/pkg/actions/status.go
+++ b/pkg/actions/status.go
@@ -94,7 +94,7 @@ func StatusCommandLocalConnection(c *cli.Context) {
 		if jsonOutput {
 			fmt.Println(err.Error())
 		} else {
-			logr.Println(err.Desc)
+			logr.Error(err.Desc)
 		}
 		os.Exit(1)
 	}
@@ -106,7 +106,7 @@ func StatusCommandLocalConnection(c *cli.Context) {
 			if jsonOutput {
 				fmt.Println(err.Error())
 			} else {
-				logr.Println(err.Desc)
+				logr.Error(err.Desc)
 			}
 			os.Exit(1)
 		}
@@ -150,7 +150,7 @@ func StatusCommandLocalConnection(c *cli.Context) {
 		if jsonOutput {
 			fmt.Println(err.Error())
 		} else {
-			logr.Println(err.Desc)
+			logr.Error(err.Desc)
 		}
 		os.Exit(1)
 	}

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -13,15 +13,26 @@ package actions
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
+	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
-//StopAllCommand to stop codewind and project containers
+// StopAllCommand to stop codewind and project containers
 func StopAllCommand(c *cli.Context, dockerComposeFile string) {
+	printAsJSON := c.GlobalBool("json")
 	tag := c.String("tag")
-	containers := utils.GetContainerList()
+	containers, err := utils.GetContainerList()
+	if err != nil {
+		if printAsJSON {
+			fmt.Println(err.Error())
+		} else {
+			logr.Println(err.Desc)
+		}
+		os.Exit(1)
+	}
 	utils.DockerComposeStop(tag, dockerComposeFile)
 
 	fmt.Println("Stopping Project containers")

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -29,7 +29,7 @@ func StopAllCommand(c *cli.Context, dockerComposeFile string) {
 		if printAsJSON {
 			fmt.Println(err.Error())
 		} else {
-			logr.Println(err.Desc)
+			logr.Error(err.Desc)
 		}
 		os.Exit(1)
 	}

--- a/pkg/actions/stop.go
+++ b/pkg/actions/stop.go
@@ -30,7 +30,7 @@ func StopCommand(c *cli.Context, dockerComposeFile string) {
 		if printAsJSON {
 			fmt.Println(err.Error())
 		} else {
-			logr.Println(err.Desc)
+			logr.Error(err.Desc)
 		}
 		os.Exit(1)
 	}

--- a/pkg/actions/stop.go
+++ b/pkg/actions/stop.go
@@ -16,22 +16,16 @@ import (
 	"os"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
-	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 //StopCommand to stop only the codewind containers
 func StopCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
-	printAsJSON := c.GlobalBool("json")
 	fmt.Println("Only stopping Codewind containers. To stop project containers, please use 'stop-all'")
 	err := utils.DockerComposeStop(tag, dockerComposeFile)
 	if err != nil {
-		if printAsJSON {
-			fmt.Println(err.Error())
-		} else {
-			logr.Error(err.Desc)
-		}
+		HandleDockerError(err)
 		os.Exit(1)
 	}
 }

--- a/pkg/actions/stop.go
+++ b/pkg/actions/stop.go
@@ -13,14 +13,25 @@ package actions
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
+	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 //StopCommand to stop only the codewind containers
 func StopCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
+	printAsJSON := c.GlobalBool("json")
 	fmt.Println("Only stopping Codewind containers. To stop project containers, please use 'stop-all'")
-	utils.DockerComposeStop(tag, dockerComposeFile)
+	err := utils.DockerComposeStop(tag, dockerComposeFile)
+	if err != nil {
+		if printAsJSON {
+			fmt.Println(err.Error())
+		} else {
+			logr.Println(err.Desc)
+		}
+		os.Exit(1)
+	}
 }

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -13,26 +13,17 @@ package actions
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
-	"github.com/urfave/cli"
+	logr "github.com/sirupsen/logrus"
 )
 
-// StopAllCommand to stop codewind and project containers
-func StopAllCommand(c *cli.Context, dockerComposeFile string) {
-	tag := c.String("tag")
-	containers, err := utils.GetContainerList()
-	if err != nil {
-		HandleDockerError(err)
-		os.Exit(1)
-	}
-	utils.DockerComposeStop(tag, dockerComposeFile)
-
-	fmt.Println("Stopping Project containers")
-	containersToRemove := utils.GetContainersToRemove(containers)
-	for _, container := range containersToRemove {
-		fmt.Println("Stopping container ", container.Names[0], "... ")
-		utils.StopContainer(container)
+// HandleDockerError prints a Docker error, in JSON format if the global flag is set, and as a string if not
+func HandleDockerError(err *utils.DockerError) {
+	// printAsJSON is a global variable, set in commands.go
+	if printAsJSON {
+		fmt.Println(err.Error())
+	} else {
+		logr.Error(err.Desc)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,8 +41,8 @@ func PFEOriginFromConnection(connection *connections.Connection) (string, *Confi
 }
 
 func getLocalHostnameAndPort() (string, *ConfigError) {
-	hostname, port := utils.GetPFEHostAndPort()
-	if hostname == "" || port == "" {
+	hostname, port, err := utils.GetPFEHostAndPort()
+	if err != nil || hostname == "" || port == "" {
 		return "", &ConfigError{errOpConfPFEHostnamePortNotFound, nil, "Hostname or port for PFE not found"}
 	}
 	val, ok := os.LookupEnv("CHE_API_EXTERNAL")

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -21,9 +21,22 @@ type DockerError struct {
 }
 
 const (
-	errOpValidate         = "docker_validate" // validate docker images
-	errOpClientCreate     = "CLIENT_CREATE_ERROR"
-	errOpContainerInspect = "CONTAINER_INSPECT_ERROR"
+	errOpValidate            = "DOCKER_VALIDATE"
+	errOpClientCreate        = "CLIENT_CREATE_ERROR"
+	errOpContainerInspect    = "CONTAINER_INSPECT_ERROR"
+	errOpContainersStopped   = "CONTAINERS_STOPPED"
+	errOpContainerError      = "CONTAINER_ERROR"
+	errOpStopContainer       = "CONTAINER_STOP_ERROR"
+	errOpDockerComposeStart  = "DOCKER_COMPOSE_START_ERROR"
+	errOpDockerComposeStop   = "DOCKER_COMPOSE_STOP_ERROR"
+	errOpDockerComposeRemove = "DOCKER_COMPOSE_REMOVE"
+	errOpImageNotFound       = "IMAGE_NOT_FOUND"
+	errOpImagePull           = "IMAGE_PULL_ERROR"
+	errOpImageTag            = "IMAGE_TAG_ERROR"
+	errOpImageRemove         = "IMAGE_REMOVE_ERROR"
+	errOpImageDigest         = "IMAGE_DIGEST_ERROR"
+	errOpContainerList       = "CONTAINER_LIST_ERROR"
+	errOpImageList           = "IMAGE_LIST_ERROR"
 )
 
 const (

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -24,7 +24,6 @@ const (
 	errOpValidate            = "DOCKER_VALIDATE"
 	errOpClientCreate        = "CLIENT_CREATE_ERROR"
 	errOpContainerInspect    = "CONTAINER_INSPECT_ERROR"
-	errOpContainersStopped   = "CONTAINERS_STOPPED"
 	errOpContainerError      = "CONTAINER_ERROR"
 	errOpStopContainer       = "CONTAINER_STOP_ERROR"
 	errOpDockerComposeStart  = "DOCKER_COMPOSE_START_ERROR"

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -96,10 +96,13 @@ func DeleteTempFile(filePath string) (bool, error) {
 }
 
 // PingHealth - pings environment api every 15 seconds to check if containers started
-func PingHealth(healthEndpoint string) bool {
+func PingHealth(healthEndpoint string) (bool, *DockerError) {
 	var started = false
 	fmt.Println("Waiting for Codewind to start")
-	hostname, port := GetPFEHostAndPort()
+	hostname, port, err := GetPFEHostAndPort()
+	if err != nil {
+		return false, err
+	}
 	for i := 0; i < 120; i++ {
 		resp, err := http.Get("http://" + hostname + ":" + port + healthEndpoint)
 		if err != nil {
@@ -118,7 +121,7 @@ func PingHealth(healthEndpoint string) bool {
 	if started != true {
 		log.Fatal("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
 	}
-	return started
+	return started, nil
 }
 
 // GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -40,14 +40,20 @@ func TestRemoveImage(t *testing.T) {
 func TestCheckImageStatusFalse(t *testing.T) {
 	// Test checks that image list can be searched
 	// False return as no images have been installed for this test
-	result := CheckImageStatus()
+	result, err := CheckImageStatus()
+	if err != nil {
+		t.Fail()
+	}
 	assert.Equal(t, result, false, "should return false: no images are installed")
 }
 
 func TestCheckContainerStatusFalse(t *testing.T) {
 	// Test checks that container list can be searched
 	// False return as no containers have been started for this test
-	result := CheckContainerStatus()
+	result, err := CheckContainerStatus()
+	if err != nil {
+		t.Fail()
+	}
 	assert.Equal(t, result, false, "should return false: no containers are started")
 }
 


### PR DESCRIPTION
### Summary

Updates `docker.go` functions to return a `DockerError` struct, and process this structure in the actions calling them.

Outputs json errors, when the`--json` global flag is set. 

Uses logrus for non-json errors, as opposed to fmt. 

Current output:


<img width="560" alt="Screenshot 2019-12-18 at 11 13 42" src="https://user-images.githubusercontent.com/31372187/71081614-79716e80-2187-11ea-90c9-59916902a594.png">

New Output (--json not set):

<img width="564" alt="Screenshot 2019-12-18 at 11 09 18" src="https://user-images.githubusercontent.com/31372187/71081567-6068bd80-2187-11ea-82d3-94674b9b672a.png">

New Output (--json set):

<img width="557" alt="Screenshot 2019-12-18 at 11 09 37" src="https://user-images.githubusercontent.com/31372187/71081572-62328100-2187-11ea-9658-521bc3e959d2.png">

### Testing

All existing tests pass locally. 

All commands that call the modified actions run successfully, and output the expected errors (shown above) when my docker is turned off.
