### PR TITLE
delete network removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | status      |       | 'Print the installation status of Codewind'                         |
 | stop        |       | 'Stop the running Codewind containers'                              |
 | stop-all    |       | 'Stop all of the Codewind and project containers'                   |
-| remove      | `rm`  | 'Remove Codewind/Project docker images and the codewind network'    |
+| remove      | `rm`  | 'Remove Codewind and Project docker images'                         |
 | templates   |       | 'Manage project templates'                                          |
 | version     |       | 'Print the versions of Codewind containers, for a given container'  |
 | sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -281,7 +281,7 @@ func Commands() {
 					Usage: "dockerhub image tag",
 				},
 			},
-			Usage: "Remove Codewind/Project docker images and the codewind network",
+			Usage: "Remove Codewind and Project docker images",
 			Action: func(c *cli.Context) error {
 				RemoveCommand(c, dockerComposeFile)
 				return nil

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -431,17 +431,6 @@ func getContainerAutoRemovePolicy(containerID string) (bool, *DockerError) {
 	return containerInfo.HostConfig.AutoRemove, nil
 }
 
-// RemoveNetwork will remove docker network
-func RemoveNetwork(network types.NetworkResource) {
-	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
-	errors.CheckErr(err, 200, "")
-
-	if err := cli.NetworkRemove(ctx, network.ID); err != nil {
-		errors.CheckErr(err, 111, "Cannot remove "+network.Name+". Use 'stop-all' flag to ensure all containers have been terminated")
-	}
-}
-
 // GetPFEHostAndPort will return the current hostname and port that PFE is running on
 func GetPFEHostAndPort() (string, string) {
 	// on Che, can assume PFE is always on localhost:9090

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -377,18 +377,6 @@ func GetImageList() []types.ImageSummary {
 	return images
 }
 
-// GetNetworkList from docker
-func GetNetworkList() []types.NetworkResource {
-	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.WithVersion("1.30"))
-	errors.CheckErr(err, 200, "")
-
-	networks, err := cli.NetworkList(ctx, types.NetworkListOptions{})
-	errors.CheckErr(err, 110, "")
-
-	return networks
-}
-
 // StopContainer will stop only codewind containers
 func StopContainer(container types.Container) {
 	ctx := context.Background()


### PR DESCRIPTION
**Problem**
As a result of PR https://github.com/eclipse/codewind-installer/pull/294, it now means the docker network removal code is now redundant since we are using docker compose to handle the main docker operations. 
Example of where the removed code was previously used: https://github.com/eclipse/codewind-installer/pull/294/files#diff-abbcefc9cde16857a4a209f7b66b62d7L54

**Solution**
Remove the unused code

**Testing**
1. *Bats test output*
`18 tests, 0 failures, 6 skipped`
2. Manually checking for removal of the docker network after removing Codewind
3. Removing this code also removes the error message telling the user to use the `stop-all` command to stop active project containers. I have checked the error thrown back still makes sense. eg. If a user stops only Codewind containers and attempts to remove Codewind images with active project containers they will now see`2019/12/19 09:56:49 REMOVE_IMAGE_ERROR[105]: exit status 1. Failed to remove image - Please make sure all containers are stopped`. This error will soon be overwritten by https://github.com/eclipse/codewind-installer/pull/303/files#diff-02a4c9edab65df5dfdd065f5b995d1faL353

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>