### PR TITLE
upgrade go version v1.11 -> v1.12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,11 @@ spec:
                         GOOS=linux GOARCH=ppc64le go build -o cwctl-ppc64le
                         chmod -v +x cwctl-*
 
+                        # clean up the cache directory
+                        cd ../../
+                        rm -rf .cache
+                        cd cmd/cli
+
                         # move the built binaries to the top level direcotory
                         mv cwctl-* ../../
                         cd ../../
@@ -129,6 +134,9 @@ spec:
                         cd ../desktop_utils
                         go test -v
                         cd ../../
+
+                        # clean up the cache directory
+                        rm -rf .cache
                     '''
                 }
                 echo 'End of test stage'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ kind: Pod
 spec:
   containers:
   - name: go
-    image: golang:1.11-stretch
+    image: golang:1.12-stretch
     tty: true
     command:
     - cat
@@ -73,10 +73,16 @@ spec:
                         dep status
                         dep ensure -v
 
+                        # go cache setup
+                        mkdir .cache
+                        cd .cache
+                        mkdir go-build
+                        cd ../
+
                         # now compile the code
                         cd cmd/cli
                         export HOME=$JENKINS_HOME
-                        export GOCACHE="off"
+                        export GOCACHE=/home/jenkins/agent/$CODE_DIRECTORY_FOR_GO/.cache/go-build
                         export GOARCH=amd64
                         GOOS=darwin go build -ldflags="-s -w" -o cwctl-macos
                         GOOS=windows go build -ldflags="-s -w" -o cwctl-win.exe
@@ -107,7 +113,13 @@ spec:
                 container('go') {
                     sh '''
                         export GOPATH=/go:/home/jenkins/agent
-                        export GOCACHE="off"
+                        
+                        # go cache setup
+                        mkdir .cache
+                        cd .cache
+                        mkdir go-build
+                        cd ../
+                        export GOCACHE=/home/jenkins/agent/$CODE_DIRECTORY_FOR_GO/.cache/go-build
 
                         cd ../../$CODE_DIRECTORY_FOR_GO
                         cd pkg/config


### PR DESCRIPTION
**Problem https://github.com/eclipse/codewind/issues/1625**
The current build process uses Go v1.11 which is now 2 versions outdated. We have previously been limited to this version due to `GOCACHE` not being able to be turned off in any version later than v1.11. 

**Solution**
Create a `./cache/go-build` directory inside the current directory where the Jenkins machine has write permissions. Follow this up by giving the `GOCACHE` envar an absolute path to this directory.

After the binaries are built and test being completed, clean up the `.cache/go-build` directory so it is not left on the machine.

**Tested**
Only commiters have the permissions to run an edited Jenkinsfile, therefore this has been tested on a test PR - https://github.com/eclipse/codewind-installer/pull/310

*Jenkins output can be seen here*
https://ci.eclipse.org/codewind/job/Codewind/job/codewind-installer/job/PR-310/17/console