### PR TITLE
Set file permissions for files extracted from tar files.

### DIFF
--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -242,6 +242,7 @@ func UnTar(pathToTarFile, destination string) error {
 			if _, err := io.Copy(fileToOverwrite, tarReader); err != nil {
 				log.Fatal(err)
 			}
+			os.Chmod(target, os.FileMode(header.Mode))
 		default:
 			log.Printf("Can't extract to %s: unknown typeflag %c\n", target, header.Typeflag)
 		}


### PR DESCRIPTION
This PR ensures we set the permissions on extracted files from tar's (such as those for appsody) to the permissions they had when the tar file was created.

This is for issue: https://github.com/eclipse/codewind/issues/1057

You can test this manually with:
```
go run cmd/cli/main.go project create /tmp/testproject -u https://github.com/appsody/stacks/releases/download/java-microprofile-v0.2.21/incubator.java-microprofile.v0.2.21.templates.default.tar.gz
```
and confirm the permissions in the newly created folder match the permissions you see if you download the tar file separately and run:
```
tar --gzip -tvf incubator.java-microprofile.v0.2.21.templates.default.tar.gz
```