### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/where-to-report-issues.md
+++ b/.github/ISSUE_TEMPLATE/where-to-report-issues.md
@@ -1,0 +1,16 @@
+---
+name: "⚠️ Where to report issues?"
+about: File issues in the main Eclipse Codewind repository at https://github.com/eclipse/codewind/issues
+title: Issues need to be filed in the main Eclipse Codewind repository
+labels: ''
+assignees: ''
+
+---
+
+## Where to report issues
+
+This repository is not used for issue tracking of the Codewind plugin for VSCode
+
+🚨 Please don't submit new issues here. 🚨
+
+All issues for the Codewind plugin for VSCode are managed at [https://github.com/eclipse/codewind/issues](https://github.com/eclipse/codewind/issues)

--- a/.github/ISSUE_TEMPLATE/where-to-report-issues.md
+++ b/.github/ISSUE_TEMPLATE/where-to-report-issues.md
@@ -13,4 +13,4 @@ This repository is not used for issue tracking of the Codewind plugin for VSCode
 
 🚨 Please don't submit new issues here. 🚨
 
-All issues for the Codewind plugin for VSCode are managed at [https://github.com/eclipse/codewind/issues](https://github.com/eclipse/codewind/issues)
+All issues for the Codewind Installer are managed at [https://github.com/eclipse/codewind/issues](https://github.com/eclipse/codewind/issues)


### PR DESCRIPTION
**Problem**
We do not have any templates. This template will direct people to submit issues on the main Codewind repository instead of opening them on the installer repository

**Solution**
Use the template that is also seen on the `codewind-vscode` repository https://github.com/eclipse/codewind-vscode/issues/new/choose
 
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>