### PR TITLE
Delete inf file after upgrade

### DIFF
--- a/pkg/project/upgrade.go
+++ b/pkg/project/upgrade.go
@@ -64,6 +64,8 @@ func UpgradeProjects(oldDir string) (*map[string]interface{}, *ProjectError) {
 					errResponse["error"] = bindErr.Desc
 					migrationStatus["failed"] = append(migrationStatus["failed"].([]interface{}), &errResponse)
 				} else {
+					// attempt to delete the inf file
+					os.Remove(path)
 					migrationStatus["migrated"] = append(migrationStatus["migrated"].([]string), name)
 				}
 			} else {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Add delete of the inf file after we have successfully migrated a project