### PR TITLE
TemplateError struct added

### DIFF
--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -14,7 +14,6 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
@@ -28,9 +27,10 @@ func ListTemplates(c *cli.Context) {
 	projectStyle := c.String("projectStyle")
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	showEnabledOnly := c.Bool("showEnabledOnly")
-	templates, templatesErr := apiroutes.GetTemplates(conID, projectStyle, showEnabledOnly)
-	if templatesErr != nil {
-		log.Printf("Error getting templates: %q", templatesErr)
+	templates, err := apiroutes.GetTemplates(conID, projectStyle, showEnabledOnly)
+	if err != nil {
+		templateErr := &TemplateError{errOpListTemplates, err, err.Error()}
+		HandleTemplateError(templateErr)
 		return
 	}
 	if len(templates) > 0 {
@@ -38,7 +38,6 @@ func ListTemplates(c *cli.Context) {
 	} else {
 		fmt.Println(templates)
 	}
-
 }
 
 // ListTemplateStyles lists all template styles of which Codewind is aware.
@@ -46,7 +45,8 @@ func ListTemplateStyles(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	styles, err := apiroutes.GetTemplateStyles(conID)
 	if err != nil {
-		log.Printf("Error getting template styles: %q", err)
+		templateErr := &TemplateError{errOpListStyles, err, err.Error()}
+		HandleTemplateError(templateErr)
 		return
 	}
 	PrettyPrintJSON(styles)
@@ -57,7 +57,8 @@ func ListTemplateRepos(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	repos, err := apiroutes.GetTemplateRepos(conID)
 	if err != nil {
-		log.Printf("Error getting template repos: %q", err)
+		templateErr := &TemplateError{errOpListRepos, err, err.Error()}
+		HandleTemplateError(templateErr)
 		return
 	}
 	PrettyPrintJSON(repos)
@@ -71,7 +72,8 @@ func AddTemplateRepo(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	repos, err := apiroutes.AddTemplateRepo(conID, url, desc, name)
 	if err != nil {
-		log.Printf("Error adding template repo: %q", err)
+		templateErr := &TemplateError{errOpAddRepo, err, err.Error()}
+		HandleTemplateError(templateErr)
 		return
 	}
 	extensions, err := apiroutes.GetExtensions(conID)
@@ -92,9 +94,10 @@ func DeleteTemplateRepo(c *cli.Context) {
 			utils.OnDeleteTemplateRepo(extensions, url, repos)
 		}
 	}
-	repos, reposErr := apiroutes.DeleteTemplateRepo(conID, url)
-	if reposErr != nil {
-		log.Printf("Error deleting template repo: %q", reposErr)
+	repos, err := apiroutes.DeleteTemplateRepo(conID, url)
+	if err != nil {
+		templateErr := &TemplateError{errOpDeleteRepo, err, err.Error()}
+		HandleTemplateError(templateErr)
 		return
 	}
 	PrettyPrintJSON(repos)
@@ -103,9 +106,10 @@ func DeleteTemplateRepo(c *cli.Context) {
 // EnableTemplateRepos enables templates repo of which Codewind is aware.
 func EnableTemplateRepos(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	repos, reposErr := apiroutes.EnableTemplateRepos(conID, c.Args())
-	if reposErr != nil {
-		log.Printf("Error enabling template repos: %q", reposErr)
+	repos, err := apiroutes.EnableTemplateRepos(conID, c.Args())
+	if err != nil {
+		templateErr := &TemplateError{errOpEnableRepo, err, err.Error()}
+		HandleTemplateError(templateErr)
 		return
 	}
 	PrettyPrintJSON(repos)
@@ -114,9 +118,10 @@ func EnableTemplateRepos(c *cli.Context) {
 // DisableTemplateRepos disables templates repo of which Codewind is aware.
 func DisableTemplateRepos(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	repos, reposErr := apiroutes.DisableTemplateRepos(conID, c.Args())
-	if reposErr != nil {
-		log.Printf("Error enabling template repos: %q", reposErr)
+	repos, err := apiroutes.DisableTemplateRepos(conID, c.Args())
+	if err != nil {
+		templateErr := &TemplateError{errOpDisableRepo, err, err.Error()}
+		HandleTemplateError(templateErr)
 		return
 	}
 	PrettyPrintJSON(repos)

--- a/pkg/actions/templates_error.go
+++ b/pkg/actions/templates_error.go
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import "encoding/json"
+
+// TemplateError struct will format the error
+type TemplateError struct {
+	Op   string
+	Err  error
+	Desc string
+}
+
+const (
+	errOpListTemplates = "LIST_TEMPLATES_ERROR"
+	errOpListStyles    = "LIST_STYLES_ERROR"
+	errOpListRepos     = "LIST_REPOS_ERROR"
+	errOpAddRepo       = "ADD_REPO_ERROR"
+	errOpDeleteRepo    = "DELETE_REPO_ERROR"
+	errOpEnableRepo    = "ENABLE_REPO_ERROR"
+	errOpDisableRepo   = "DISABLE_REPO_ERROR"
+)
+
+// TemplateError : Error formatted in JSON containing an errorOp and a description
+func (te *TemplateError) Error() string {
+	type Output struct {
+		Operation   string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	tempOutput := &Output{Operation: te.Op, Description: te.Err.Error()}
+	jsonError, _ := json.Marshal(tempOutput)
+	return string(jsonError)
+}

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -27,3 +27,13 @@ func HandleDockerError(err *utils.DockerError) {
 		logr.Error(err.Desc)
 	}
 }
+
+// HandleTemplateError prints a Template error, in JSON format if the global flag is set, and as a string if not
+func HandleTemplateError(err *TemplateError) {
+	// printAsJSON is a global variable, set in commands.go
+	if printAsJSON {
+		fmt.Println(err.Error())
+	} else {
+		logr.Error(err.Desc)
+	}
+}


### PR DESCRIPTION
For [#1597](https://github.com/eclipse/codewind/issues/1597)

- Addition of templates_error.go to the actions package, containing the TemplateError struct, matching the pattern of other error structs in the CLI
- Change to templates.go to use this new struct instead of printing errors to log, allowing IDEs to parse the JSON output

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>