### PR TITLE
make project create consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,38 +183,33 @@ Subcommands:</br>
 > --path,-p value Project Path
 
 `bind` - Bind a project to Codewind for building and running
-
 > **Flags:**
-> --name,-n value Project name
-> --language,-l value Project language
-> --type,-t value Project Type
-> --path,-p value Project Path
-> --conid value Connection ID
+> --name,-n value               Project name
+> --language,-l value           Project language
+> --type,-t value               Project Type
+> --path,-p value               Project Path
+> --conid value                 Connection ID
 
 `sync` - Synchronize a bound project to its connection
-
 > **Flags:**
-> --path,-p value Project Path
-> --id,-i value Project ID
-> --time,-t value Time of last project sync
+> --path,-p value               Project Path
+> --id,-i value                 Project ID
+> --time,-t value               Time of last project sync
 
 `connection/con` - Manage the connection targets for a project
 
 `set,s` - Sets the connection for a projectID
-
 > **Flags:**
-> --id,i value Project ID
-> --conid value Connection ID
+> --id,i value                  Project ID
+> --conid value                 Connection ID
 
 `get,g` - Gets connections for a projectID
-
 > **Flags:**
-> --id,i value Project ID
+> --id,i value                  Project ID
 
 `remove,r` - Removes the connection from a projectID
-
 > **Flags:**
-> --id,i value Project ID
+> --id,i value                  Project ID
 
 ## install
 
@@ -224,20 +219,19 @@ Subcommands:</br>
 Subcommands:</br>
 
 `remote` - Install a remote deployment of Codewind
-
 > **Flags:**
-> --namespace,-n value Kubernetes namespace to install into
-> --session,-ses value Codewind session secret to encrypt session store
-> --ingress,-i value Ingress Domain eg: 10.22.33.44.nip.io
-> --kadminuser,-au value Keycloak admin user
-> --kadminpass,-ap value Keycloak admin password
-> --kdevuser,-du value Keycloak developer username
-> --kdevpass,-dp value Keycloak developer username initial password
-> --krealm,-r value Keycloak realm to setup
-> --kclient,-c value Keycloak client to setup
-> --pvcsize,-p value Codewind PVC size (integer between 1 and 999 Gigabytes)
-> --kurl value Don't deploy a new Keycloak pod, use an existing one at this URL
-> --konly Install a deployment of Keycloak only
+> --namespace,-n value          Kubernetes namespace to install into
+> --session,-ses value          Codewind session secret to encrypt session store
+> --ingress,-i value            Ingress Domain eg: 10.22.33.44.nip.io
+> --kadminuser,-au value        Keycloak admin user
+> --kadminpass,-ap value        Keycloak admin password
+> --kdevuser,-du value          Keycloak developer username
+> --kdevpass,-dp value          Keycloak developer username initial password
+> --krealm,-r value             Keycloak realm to setup
+> --kclient,-c value            Keycloak client to setup
+> --pvcsize,-p value            Codewind PVC size (integer between 1 and 999 Gigabytes)
+> --kurl value                  Don't deploy a new Keycloak pod, use an existing one at this URL
+> --konly                       Install a deployment of Keycloak only
 
 ### start
 
@@ -250,11 +244,11 @@ Subcommands:</br>
 
 ### stop
 
-> **Note:** No additional flags
+>**Note:** No additional flags
 
 ### stop-all
 
-> **Note:** No additional flags
+>**Note:** No additional flags
 
 ### remove
 
@@ -263,7 +257,7 @@ Subcommands:</br>
 
 ### templates
 
-> **Note:** No additional flags
+>**Note:** No additional flags
 
 Subcommands:</br>
 
@@ -272,7 +266,7 @@ Subcommands:</br>
 ### version
 
 > **Flags:**
-> --conid value Connection ID (see the connections cmd)
+> --conid value                 Connection ID (see the connections cmd)
 
 ## sectoken
 
@@ -280,18 +274,18 @@ Subcommands:</br>
 
 `get/g` - Authenticate and obtain an access_token.
 
-> **Note 1:**: The preferred way to authenticate is by supplying just the connection ID (conid) and username. In this mode the command will use the stored password from the platform keyring
-> **Note 2:**: If you dont have a connection ID (conid) you must supply use the host, realm and client flags
-> **Note 3:**: You can use a combination of both the connection ID (conid) and host/realm/client flags. In this mode, the host/realm/client flags take precedence override the connection defaults
-> **Note 4:**: The password flag is optional when used with the connection ID (conid) flag and when a password already exists in the platform keyring. Including the password flag will update the keychain password after a successful login or add a password to the keychain if one does not exist
+>**Note 1:**: The preferred way to authenticate is by supplying just the connection ID (conid) and username. In this mode the command will use the stored password from the platform keyring
+>**Note 2:**: If you dont have a connection ID (conid) you must supply use the host, realm and client flags
+>**Note 3:**: You can use a combination of both the connection ID (conid) and host/realm/client flags. In this mode, the host/realm/client flags take precedence override the connection defaults
+>**Note 4:**: The password flag is optional when used with the connection ID (conid) flag and when a password already exists in the platform keyring. Including the password flag will update the keychain password after a successful login or add a password to the keychain if one does not exist
 
 > **Flags:**
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm
-> --username value Account Username
-> --password value Account Password
-> --client value Client
-> --conid value Connection ID (see the connections cmd)
+> --host value                  URL or ingress to Keycloak service
+> --realm value                 Application realm
+> --username value              Account Username
+> --password value              Account Password
+> --client value                Client
+> --conid  value                Connection ID (see the connections cmd)
 
 ## sectoken
 
@@ -302,7 +296,7 @@ Subcommands:</br>
 Refresh tokens are automatically stored in the platform keychain. This command will use the refresh token to obtain a new access token from the authentication service. The access_token can then be used by curl or socket connections when accessing Codewind.
 
 > **Flags:**
-> --conid value Connection ID (see the connections cmd)
+> --conid  value                Connection ID (see the connections cmd)
 
 ## secrealm
 
@@ -311,9 +305,9 @@ Subcommands:</br>
 `create/c` - Create a new realm (requires either admin_token or username/password)
 
 > **Flags:**
-> --host value URL or ingress to Keycloak service
-> --newrealm value Application realm to be created
-> --accesstoken value Admin access_token
+> --host value                   URL or ingress to Keycloak service
+> --newrealm value               Application realm to be created
+> --accesstoken value            Admin access_token
 
 ## secclient
 
@@ -321,29 +315,29 @@ Subcommands:</br>
 
 `create/c` - Create a new client in an existing Keycloak realm (requires either admin_token or username/password)
 
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm where client should be created
-> --newclient value New client ID to create
-> --redirect value Allowed redirect callback URL eg: `http://127.0.0.1:9090/*`
-> --accesstoken value Admin access_token
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm where client should be created
+> --newclient value              New client ID to create
+> --redirect value               Allowed redirect callback URL eg: `http://127.0.0.1:9090/*`
+> --accesstoken value            Admin access_token
 
 `get/g` - Get client id (requires either admin_token or username/password)
 
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm
-> --clientid value Client ID to retrieve
-> --accesstoken value Admin access_token
-> --username value Admin Username
-> --password value Admin Password
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --clientid value               Client ID to retrieve
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
 
 `secret/s` - Get client secret (requires either admin_token or username/password)
 
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm
-> --clientid value Client ID to retrieve
-> --accesstoken value Admin access_token
-> --username value Admin Username
-> --password value Admin Password
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --clientid value               Client ID to retrieve
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
 
 ## seckeyring
 
@@ -351,14 +345,14 @@ Subcommands:</br>
 
 `update/u` - Add new or update existing Codewind credentials key in keyring
 
-> --conid `<value>` Connection ID (see the connections cmd)
-> --username `<value>` Username
-> --password `<value>` Password
+> --conid  `<value>`              Connection ID (see the connections cmd)
+> --username `<value>`            Username
+> --password `<value>`            Password
 
 `validate/v` - Checks if credentials key exist in the keyring
 
-> --conid `<value>` Connection ID (see the connections cmd)
-> --username `<value>` Username
+> --conid  `<value>`              Connection ID (see the connections cmd)
+> --username `<value>`            Username
 
 ## secuser
 
@@ -366,39 +360,39 @@ Subcommands:</br>
 
 `create/c` - Create a new user in an existing Keycloak realm (requires either admin_token or username/password)
 
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm
-> --accesstoken value Admin access_token
-> --username value Admin Username
-> --password value Admin Password
-> --name value Username to add
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+> --name value                   Username to add
 
 `get/g` - Gets an existing Keycloak user from an existing realm (requires either admin_token or username/password)
 
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm
-> --accesstoken value Admin access_token
-> --username value Admin Username
-> --password value Admin Password
-> --name value Username to query
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+> --name value                   Username to query
 
 `setpw/p` - Reset an existing users password (requires either admin_token or username/password)
 
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm
-> --accesstoken value Admin access_token
-> --username value Admin Username
-> --password value Admin Password
-> --name value Username to query
-> --newpw value New replacement password
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --username value               Admin Username
+> --password value               Admin Password
+> --name value                   Username to query
+> --newpw value                  New replacement password
 
 `addrole/p` - Adds an existing role to a user (requires either admin_token or username/password)
 
-> --host value URL or ingress to Keycloak service
-> --realm value Application realm
-> --accesstoken value Admin access_token
-> --name value Username to target
-> --role value Name of an existing role to add
+> --host value                   URL or ingress to Keycloak service
+> --realm value                  Application realm
+> --accesstoken value            Admin access_token
+> --name value                   Username to target
+> --role value                   Name of an existing role to add
 
 ## connections
 
@@ -407,33 +401,33 @@ Subcommands:</br>
 `add/a` - Add a new connection to the list
 
 > **Flags:**
-> --label value A displayable name
-> --url value The ingress URL of the PFE instance
+> --label value     A displayable name
+> --url value       The ingress URL of the PFE instance
 
 `update/u` - Update an existing connection
 
 > **Flags:**
-> --conid value The Connection ID to update
-> --label value A displayable name
-> --url value The ingress URL of the PFE instance
+> --conid value     The Connection ID to update
+> --label value     A displayable name
+> --url value       The ingress URL of the PFE instance
 
 `get/g` - Get a connection using its ID
 
 > **Flags:**
-> --conid value The Connection ID to retrieve
+> --conid value     The Connection ID to retrieve
 
 `remove/rm` - Remove a connection from the list
 
 > **Flags:**
-> --conid value A Connection ID
+> --conid value     A Connection ID
 
 `list/ls` - List known connections
 
-> **Note:** No additional flags
+>**Note:** No additional flags
 
 `reset` - Resets the connections list to a single local connection
 
-> **Note:** No additional flags
+>**Note:** No additional flags
 
 ## help
 

--- a/README.md
+++ b/README.md
@@ -169,34 +169,52 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 
 Subcommands:</br>
 
-`bind` - Bind a project to Codewind for building and running
+`create` - Downloads a project created from a template at the given URL
+
 > **Flags:**
-> --name,-n value               Project name
-> --language,-l value           Project language
-> --type,-t value               Project Type
-> --path,-p value               Project Path
-> --conid value                 Connection ID
+> --url,-u value URL of project to download
+> --path,-p value Path at which to create the new project
+
+`validate` - Return the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist
+
+> **Flags:**
+> --name,-n value Project name
+> --type,-t value Project Type
+> --path,-p value Project Path
+
+`bind` - Bind a project to Codewind for building and running
+
+> **Flags:**
+> --name,-n value Project name
+> --language,-l value Project language
+> --type,-t value Project Type
+> --path,-p value Project Path
+> --conid value Connection ID
 
 `sync` - Synchronize a bound project to its connection
+
 > **Flags:**
-> --path,-p value               Project Path
-> --id,-i value                 Project ID
-> --time,-t value               Time of last project sync
+> --path,-p value Project Path
+> --id,-i value Project ID
+> --time,-t value Time of last project sync
 
 `connection/con` - Manage the connection targets for a project
 
 `set,s` - Sets the connection for a projectID
+
 > **Flags:**
-> --id,i value                  Project ID
-> --conid value                 Connection ID
+> --id,i value Project ID
+> --conid value Connection ID
 
 `get,g` - Gets connections for a projectID
+
 > **Flags:**
-> --id,i value                  Project ID
+> --id,i value Project ID
 
 `remove,r` - Removes the connection from a projectID
+
 > **Flags:**
-> --id,i value                  Project ID
+> --id,i value Project ID
 
 ## install
 
@@ -206,19 +224,20 @@ Subcommands:</br>
 Subcommands:</br>
 
 `remote` - Install a remote deployment of Codewind
+
 > **Flags:**
-> --namespace,-n value          Kubernetes namespace to install into
-> --session,-ses value          Codewind session secret to encrypt session store
-> --ingress,-i value            Ingress Domain eg: 10.22.33.44.nip.io
-> --kadminuser,-au value        Keycloak admin user
-> --kadminpass,-ap value        Keycloak admin password
-> --kdevuser,-du value          Keycloak developer username
-> --kdevpass,-dp value          Keycloak developer username initial password
-> --krealm,-r value             Keycloak realm to setup
-> --kclient,-c value            Keycloak client to setup
-> --pvcsize,-p value            Codewind PVC size (integer between 1 and 999 Gigabytes)
-> --kurl value                  Don't deploy a new Keycloak pod, use an existing one at this URL
-> --konly                       Install a deployment of Keycloak only
+> --namespace,-n value Kubernetes namespace to install into
+> --session,-ses value Codewind session secret to encrypt session store
+> --ingress,-i value Ingress Domain eg: 10.22.33.44.nip.io
+> --kadminuser,-au value Keycloak admin user
+> --kadminpass,-ap value Keycloak admin password
+> --kdevuser,-du value Keycloak developer username
+> --kdevpass,-dp value Keycloak developer username initial password
+> --krealm,-r value Keycloak realm to setup
+> --kclient,-c value Keycloak client to setup
+> --pvcsize,-p value Codewind PVC size (integer between 1 and 999 Gigabytes)
+> --kurl value Don't deploy a new Keycloak pod, use an existing one at this URL
+> --konly Install a deployment of Keycloak only
 
 ### start
 
@@ -231,11 +250,11 @@ Subcommands:</br>
 
 ### stop
 
->**Note:** No additional flags
+> **Note:** No additional flags
 
 ### stop-all
 
->**Note:** No additional flags
+> **Note:** No additional flags
 
 ### remove
 
@@ -244,7 +263,7 @@ Subcommands:</br>
 
 ### templates
 
->**Note:** No additional flags
+> **Note:** No additional flags
 
 Subcommands:</br>
 
@@ -253,7 +272,7 @@ Subcommands:</br>
 ### version
 
 > **Flags:**
-> --conid value                 Connection ID (see the connections cmd)
+> --conid value Connection ID (see the connections cmd)
 
 ## sectoken
 
@@ -261,18 +280,18 @@ Subcommands:</br>
 
 `get/g` - Authenticate and obtain an access_token.
 
->**Note 1:**: The preferred way to authenticate is by supplying just the connection ID (conid) and username. In this mode the command will use the stored password from the platform keyring
->**Note 2:**: If you dont have a connection ID (conid) you must supply use the host, realm and client flags
->**Note 3:**: You can use a combination of both the connection ID (conid) and host/realm/client flags. In this mode, the host/realm/client flags take precedence override the connection defaults
->**Note 4:**: The password flag is optional when used with the connection ID (conid) flag and when a password already exists in the platform keyring. Including the password flag will update the keychain password after a successful login or add a password to the keychain if one does not exist
+> **Note 1:**: The preferred way to authenticate is by supplying just the connection ID (conid) and username. In this mode the command will use the stored password from the platform keyring
+> **Note 2:**: If you dont have a connection ID (conid) you must supply use the host, realm and client flags
+> **Note 3:**: You can use a combination of both the connection ID (conid) and host/realm/client flags. In this mode, the host/realm/client flags take precedence override the connection defaults
+> **Note 4:**: The password flag is optional when used with the connection ID (conid) flag and when a password already exists in the platform keyring. Including the password flag will update the keychain password after a successful login or add a password to the keychain if one does not exist
 
 > **Flags:**
-> --host value                  URL or ingress to Keycloak service
-> --realm value                 Application realm
-> --username value              Account Username
-> --password value              Account Password
-> --client value                Client
-> --conid  value                Connection ID (see the connections cmd)
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm
+> --username value Account Username
+> --password value Account Password
+> --client value Client
+> --conid value Connection ID (see the connections cmd)
 
 ## sectoken
 
@@ -283,7 +302,7 @@ Subcommands:</br>
 Refresh tokens are automatically stored in the platform keychain. This command will use the refresh token to obtain a new access token from the authentication service. The access_token can then be used by curl or socket connections when accessing Codewind.
 
 > **Flags:**
-> --conid  value                Connection ID (see the connections cmd)
+> --conid value Connection ID (see the connections cmd)
 
 ## secrealm
 
@@ -292,9 +311,9 @@ Subcommands:</br>
 `create/c` - Create a new realm (requires either admin_token or username/password)
 
 > **Flags:**
-> --host value                   URL or ingress to Keycloak service
-> --newrealm value               Application realm to be created
-> --accesstoken value            Admin access_token
+> --host value URL or ingress to Keycloak service
+> --newrealm value Application realm to be created
+> --accesstoken value Admin access_token
 
 ## secclient
 
@@ -302,29 +321,29 @@ Subcommands:</br>
 
 `create/c` - Create a new client in an existing Keycloak realm (requires either admin_token or username/password)
 
-> --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm where client should be created
-> --newclient value              New client ID to create
-> --redirect value               Allowed redirect callback URL eg: `http://127.0.0.1:9090/*`
-> --accesstoken value            Admin access_token
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm where client should be created
+> --newclient value New client ID to create
+> --redirect value Allowed redirect callback URL eg: `http://127.0.0.1:9090/*`
+> --accesstoken value Admin access_token
 
 `get/g` - Get client id (requires either admin_token or username/password)
 
-> --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
-> --clientid value               Client ID to retrieve
-> --accesstoken value            Admin access_token
-> --username value               Admin Username
-> --password value               Admin Password
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm
+> --clientid value Client ID to retrieve
+> --accesstoken value Admin access_token
+> --username value Admin Username
+> --password value Admin Password
 
 `secret/s` - Get client secret (requires either admin_token or username/password)
 
-> --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
-> --clientid value               Client ID to retrieve
-> --accesstoken value            Admin access_token
-> --username value               Admin Username
-> --password value               Admin Password
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm
+> --clientid value Client ID to retrieve
+> --accesstoken value Admin access_token
+> --username value Admin Username
+> --password value Admin Password
 
 ## seckeyring
 
@@ -332,14 +351,14 @@ Subcommands:</br>
 
 `update/u` - Add new or update existing Codewind credentials key in keyring
 
-> --conid  `<value>`              Connection ID (see the connections cmd)
-> --username `<value>`            Username
-> --password `<value>`            Password
+> --conid `<value>` Connection ID (see the connections cmd)
+> --username `<value>` Username
+> --password `<value>` Password
 
 `validate/v` - Checks if credentials key exist in the keyring
 
-> --conid  `<value>`              Connection ID (see the connections cmd)
-> --username `<value>`            Username
+> --conid `<value>` Connection ID (see the connections cmd)
+> --username `<value>` Username
 
 ## secuser
 
@@ -347,39 +366,39 @@ Subcommands:</br>
 
 `create/c` - Create a new user in an existing Keycloak realm (requires either admin_token or username/password)
 
-> --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
-> --accesstoken value            Admin access_token
-> --username value               Admin Username
-> --password value               Admin Password
-> --name value                   Username to add
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm
+> --accesstoken value Admin access_token
+> --username value Admin Username
+> --password value Admin Password
+> --name value Username to add
 
 `get/g` - Gets an existing Keycloak user from an existing realm (requires either admin_token or username/password)
 
-> --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
-> --accesstoken value            Admin access_token
-> --username value               Admin Username
-> --password value               Admin Password
-> --name value                   Username to query
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm
+> --accesstoken value Admin access_token
+> --username value Admin Username
+> --password value Admin Password
+> --name value Username to query
 
 `setpw/p` - Reset an existing users password (requires either admin_token or username/password)
 
-> --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
-> --accesstoken value            Admin access_token
-> --username value               Admin Username
-> --password value               Admin Password
-> --name value                   Username to query
-> --newpw value                  New replacement password
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm
+> --accesstoken value Admin access_token
+> --username value Admin Username
+> --password value Admin Password
+> --name value Username to query
+> --newpw value New replacement password
 
 `addrole/p` - Adds an existing role to a user (requires either admin_token or username/password)
 
-> --host value                   URL or ingress to Keycloak service
-> --realm value                  Application realm
-> --accesstoken value            Admin access_token
-> --name value                   Username to target
-> --role value                   Name of an existing role to add
+> --host value URL or ingress to Keycloak service
+> --realm value Application realm
+> --accesstoken value Admin access_token
+> --name value Username to target
+> --role value Name of an existing role to add
 
 ## connections
 
@@ -388,33 +407,33 @@ Subcommands:</br>
 `add/a` - Add a new connection to the list
 
 > **Flags:**
-> --label value     A displayable name
-> --url value       The ingress URL of the PFE instance
+> --label value A displayable name
+> --url value The ingress URL of the PFE instance
 
 `update/u` - Update an existing connection
 
 > **Flags:**
-> --conid value     The Connection ID to update
-> --label value     A displayable name
-> --url value       The ingress URL of the PFE instance
+> --conid value The Connection ID to update
+> --label value A displayable name
+> --url value The ingress URL of the PFE instance
 
 `get/g` - Get a connection using its ID
 
 > **Flags:**
-> --conid value     The Connection ID to retrieve
+> --conid value The Connection ID to retrieve
 
 `remove/rm` - Remove a connection from the list
 
 > **Flags:**
-> --conid value     A Connection ID
+> --conid value A Connection ID
 
 `list/ls` - List known connections
 
->**Note:** No additional flags
+> **Note:** No additional flags
 
 `reset` - Resets the connections list to a single local connection
 
->**Note:** No additional flags
+> **Note:** No additional flags
 
 ## help
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Subcommands:</br>
 > --url,-u value URL of project to download
 > --path,-p value Path at which to create the new project
 
-`validate` - Return the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist
+`validate` - Returns the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist
 
 > **Flags:**
 > --name,-n value Project name

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 
 Subcommands:</br>
 
-`create` - Downloads a project created from a template at the given URL
+`create` - Downloads a project created from a template, at the given URL
 
 > **Flags:**
 > --url,-u value URL of project to download
@@ -179,8 +179,8 @@ Subcommands:</br>
 
 > **Flags:**
 > --name,-n value Project name
-> --type,-t value Project Type
-> --path,-p value Project Path
+> --path,-p value Project path, on local disk
+> --type,-t value Project build type, if known (not required)
 
 `bind` - Bind a project to Codewind for building and running
 > **Flags:**

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -68,13 +68,24 @@ func Commands() {
 
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "url, u", Usage: "URL of project to download"},
-						cli.StringFlag{Name: "type, t", Usage: "Known type and subtype of project (`type:subtype`). Ignored when URL is given"},
+						cli.StringFlag{Name: "path, p", Usage: "The path at which to create the new project", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						ProjectCreate(c)
+						return nil
+					},
+				},
+				{
+					Name:    "validate",
+					Aliases: []string{""},
+					Usage:   "Returns the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist",
+
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "type, t", Usage: "Known build type of project", Required: false},
+						cli.StringFlag{Name: "path, p", Usage: "The path at which to create the new project", Required: true},
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id for the project", Required: false},
 					},
 					Action: func(c *cli.Context) error {
-						if c.String("u") != "" {
-							ProjectCreate(c)
-						}
 						ProjectValidate(c)
 						return nil
 					},

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -78,7 +78,7 @@ func Commands() {
 				{
 					Name:    "validate",
 					Aliases: []string{""},
-					Usage:   "Returns the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist",
+					Usage:   "Returns the predicted language and build type for a project, and writes a default .cw-settings if one does not already exist",
 
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "type, t", Usage: "Known build type of project", Required: false},

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -33,7 +33,9 @@ func ProjectValidate(c *cli.Context) {
 
 // ProjectCreate : Downloads template and creates a new project
 func ProjectCreate(c *cli.Context) {
-	err := project.DownloadTemplate(c)
+	destination := c.String("p")
+	url := c.String("u")
+	err := project.DownloadTemplate(destination, url)
 	if err != nil {
 		HandleProjectError(err)
 		os.Exit(1)

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -28,11 +28,7 @@ func ProjectValidate(c *cli.Context) {
 		fmt.Println(projectErr.Error())
 		os.Exit(1)
 	}
-	projectInfo, err := json.Marshal(response)
-	if err != nil {
-		HandleProjectError(err)
-		os.Exit(1)
-	}
+	projectInfo, _ := json.Marshal(response)
 	fmt.Println(string(projectInfo))
 	os.Exit(0)
 }

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -21,13 +21,19 @@ import (
 	"github.com/urfave/cli"
 )
 
-// ProjectValidate : Validate a project
+// ProjectValidate : Detects the project type, and adds .cw-settings if it does not already exist
 func ProjectValidate(c *cli.Context) {
-	err := project.ValidateProject(c)
+	response, projectErr := project.ValidateProject(c)
+	if projectErr != nil {
+		fmt.Println(projectErr.Error())
+		os.Exit(1)
+	}
+	projectInfo, err := json.Marshal(response)
 	if err != nil {
 		HandleProjectError(err)
 		os.Exit(1)
 	}
+	fmt.Println(string(projectInfo))
 	os.Exit(0)
 }
 

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -35,11 +35,18 @@ func ProjectValidate(c *cli.Context) {
 func ProjectCreate(c *cli.Context) {
 	destination := c.String("p")
 	url := c.String("u")
-	err := project.DownloadTemplate(destination, url)
+	result, err := project.DownloadTemplate(destination, url)
 	if err != nil {
 		HandleProjectError(err)
 		os.Exit(1)
 	}
+	if printAsJSON {
+		jsonResponse, _ := json.Marshal(result)
+		fmt.Println(string(jsonResponse))
+	} else {
+		fmt.Println("Project downloaded to " + destination)
+	}
+	os.Exit(0)
 }
 
 // ProjectSync : Does a project Sync

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -52,11 +52,8 @@ type (
 )
 
 // DownloadTemplate using the url/link provided
-func DownloadTemplate(c *cli.Context) *ProjectError {
-	destination := c.Args().Get(0)
-
+func DownloadTemplate(destination string, url string) *ProjectError {
 	checkProjectDirIsEmpty(destination)
-
 	projectDir := path.Base(destination)
 
 	// Remove invalid characters from the string we will use
@@ -67,12 +64,11 @@ func DownloadTemplate(c *cli.Context) *ProjectError {
 		projectName = "PROJ_NAME_PLACEHOLDER"
 	}
 
-	url := c.String("u")
-
 	err := utils.DownloadFromURLThenExtract(url, destination)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	err = utils.ReplaceInFiles(destination, "[PROJ_NAME_PLACEHOLDER]", projectName)
 	if err != nil {
 		log.Fatal(err)
@@ -105,7 +101,6 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 	for _, extension := range extensions {
 
 		var isMatch bool
-
 		if len(params) > 0 {
 			// check if extension project type matched the hinted type
 			isMatch = extension.ProjectType == params["$type"]
@@ -115,9 +110,7 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 		}
 
 		if isMatch {
-
 			var cmdErr error
-
 			// check if there are any commands to run
 			for _, command := range extension.Commands {
 				if command.Name == commandName {
@@ -136,7 +129,7 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 // ValidateProject returns the language and buildType for a project at given filesystem path,
 // and writes a default .cw-settings file to that project
 func ValidateProject(c *cli.Context) *ProjectError {
-	projectPath := c.Args().Get(0)
+	projectPath := c.String("path")
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	checkProjectPathExists(projectPath)
 	validationStatus := "success"

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -13,7 +13,6 @@ package project
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -130,7 +129,7 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 
 // ValidateProject returns the language and buildType for a project at given filesystem path,
 // and writes a default .cw-settings file to that project
-func ValidateProject(c *cli.Context) *ProjectError {
+func ValidateProject(c *cli.Context) (ValidationResponse, *ProjectError) {
 	projectPath := c.String("path")
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	checkProjectPathExists(projectPath)
@@ -160,15 +159,13 @@ func ValidateProject(c *cli.Context) *ProjectError {
 		Path:   projectPath,
 		Result: validationResult,
 	}
-	projectInfo, err := json.Marshal(response)
 
 	errors.CheckErr(err, 203, "")
 	// write settings file only for non-extension projects
 	if extensionType == "" {
 		writeCwSettingsIfNotInProject(conID, projectPath, buildType)
 	}
-	fmt.Println(string(projectInfo))
-	return nil
+	return response, nil
 }
 
 func writeCwSettingsIfNotInProject(conID string, projectPath string, BuildType string) {

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -52,7 +52,7 @@ type (
 )
 
 // DownloadTemplate using the url/link provided
-func DownloadTemplate(destination string, url string) *ProjectError {
+func DownloadTemplate(destination string, url string) (Result, *ProjectError) {
 	checkProjectDirIsEmpty(destination)
 	projectDir := path.Base(destination)
 
@@ -73,7 +73,9 @@ func DownloadTemplate(destination string, url string) *ProjectError {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return nil
+
+	response := Result{Status: "success", StatusMessage: "Project downloaded to" + destination}
+	return response, nil
 }
 
 // checkIsExtension checks if a project is an extension project and run associated commands as necessary

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -192,7 +192,7 @@ func checkProjectDirIsEmpty(projectPath string) {
 			log.Fatal(err)
 		}
 		if !dirIsEmpty {
-			log.Fatal("Non empty project at given path")
+			log.Fatal("Non empty directory provided")
 		}
 	}
 }


### PR DESCRIPTION
Resolves: https://github.com/eclipse/codewind/issues/1452

## Summary

Makes the `cwctl project create` command consistent with the other commands. 

- Splits out create and validate into their own subcommands, at the moment this is decided based on whether a URL is given.

- Uses `--path`, as opposed to the first non-flagged argument for path. 

- Adds documentation for the command in the README.md and commands file.

## Testing

- Commands run as expected. 

- Tests pass locally.