### PR TITLE
Fix auth hostname during install of remote

### DIFF
--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -91,6 +92,16 @@ func DoRemoteInstall(c *cli.Context) {
 		codewindPVCSize = 1
 	}
 
+	keycloakHost := c.String("kurl")
+	if keycloakHost != "" {
+		u, err := url.Parse(keycloakHost)
+		if err != nil {
+			logr.Error("Supplied Keycloak URL is invalid")
+			os.Exit(1)
+		}
+		keycloakHost = u.Hostname()
+	}
+
 	deployOptions := remote.DeployOptions{
 		Namespace:             c.String("namespace"),
 		IngressDomain:         c.String("ingress"),
@@ -102,6 +113,7 @@ func DoRemoteInstall(c *cli.Context) {
 		KeycloakClient:        c.String("kclient"),
 		KeycloakURL:           c.String("kurl"),
 		KeycloakOnly:          c.Bool("konly"),
+		KeycloakHost:          keycloakHost,
 		GateKeeperTLSSecure:   true,
 		KeycloakTLSSecure:     true,
 		CodewindSessionSecret: session,

--- a/pkg/remote/configure-keycloak.go
+++ b/pkg/remote/configure-keycloak.go
@@ -76,15 +76,15 @@ func SetupKeycloak(codewindInstance Codewind, deployOptions *DeployOptions) erro
 		return secErr.Err
 	}
 
+	// No additional Keycloak config required for a Keycloak only deployment
+	if deployOptions.KeycloakOnly {
+		return nil
+	}
+
 	secErr = configureKeycloakRealm(deployOptions, authURL, tokens)
 	if secErr != nil {
 		utils.PrettyPrintJSON(secErr)
 		return secErr.Err
-	}
-
-	// No additional Keycloak config required for a Keycloak only deployment
-	if deployOptions.KeycloakOnly {
-		return nil
 	}
 
 	secErr = configureKeycloakClient(deployOptions, authURL, tokens, gatekeeperPublicURL)

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -46,6 +46,7 @@ type DeployOptions struct {
 	KeycloakSecure        bool
 	KeycloakTLSSecure     bool
 	KeycloakURL           string
+	KeycloakHost          string
 	KeycloakOnly          bool
 	GateKeeperTLSSecure   bool
 	CodewindSessionSecret string

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -116,6 +116,12 @@ func generatePFEService(codewind Codewind) corev1.Service {
 }
 
 func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.EnvVar {
+
+	authHost := deployOptions.KeycloakHost
+	if authHost == "" {
+		authHost = KeycloakPrefix + codewind.Ingress
+	}
+
 	return []corev1.EnvVar{
 		{
 			Name:  "TEKTON_PIPELINE",
@@ -195,7 +201,7 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 		},
 		{
 			Name:  "CODEWIND_AUTH_HOST",
-			Value: KeycloakPrefix + codewind.Ingress,
+			Value: authHost,
 		},
 	}
 }


### PR DESCRIPTION
## Problem

When installing a new Codewind Remote deployment with the `--kurl` flag (to target an existing Keycloak service rather than to deploy a new Keycloak service), the IDEs are unable to authenticate.

Failure occurs because the Socket.IO authentication handler in PFE is unable to locate the registered public key needed to validate the signature on a supplied access_token.  per issue #1640 

## Solution 

This PR sets the correct Keycloak hostname in PFE when the `install remote` command uses the `--kurl` flag.  When PFE has the correct hostname it is subsequently able to connect to the authentication service and retrieve the clients public key. 

## Results

Multiple Remote deployments all using the same single Keycloak service : 

<img width="447" alt="Screenshot 2020-01-07 at 21 27 37" src="https://user-images.githubusercontent.com/28102564/71930942-913f7f80-3194-11ea-819e-644016534094.png">

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>