### PR TITLE
Use HandleProjectError and HandleConnectionError

### DIFF
--- a/pkg/actions/connection.go
+++ b/pkg/actions/connection.go
@@ -25,14 +25,9 @@ import (
 
 // ConnectionAddToList : Add new connection to the connections config file and returns the ID of the added entry
 func ConnectionAddToList(c *cli.Context) {
-	printAsJSON := c.GlobalBool("json")
 	connection, conErr := connections.AddConnectionToList(http.DefaultClient, c)
 	if conErr != nil {
-		if printAsJSON {
-			fmt.Println(conErr.Error())
-		} else {
-			logr.Println(conErr.Desc)
-		}
+		HandleConnectionError(conErr)
 		os.Exit(1)
 	}
 
@@ -54,14 +49,9 @@ func ConnectionAddToList(c *cli.Context) {
 
 // ConnectionUpdate : Update an existing connection
 func ConnectionUpdate(c *cli.Context) {
-	printAsJSON := c.GlobalBool("json")
 	connection, conErr := connections.UpdateExistingConnection(http.DefaultClient, c)
 	if conErr != nil {
-		if printAsJSON {
-			fmt.Println(conErr.Error())
-		} else {
-			logr.Println(conErr.Desc)
-		}
+		HandleConnectionError(conErr)
 		os.Exit(1)
 	}
 	type Result struct {
@@ -81,15 +71,10 @@ func ConnectionUpdate(c *cli.Context) {
 
 // ConnectionGetByID : Get connection by its id
 func ConnectionGetByID(c *cli.Context) {
-	printAsJSON := c.GlobalBool("json")
 	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	connection, conErr := connections.GetConnectionByID(connectionID)
 	if conErr != nil {
-		if printAsJSON {
-			fmt.Println(conErr.Error())
-		} else {
-			logr.Println(conErr.Desc)
-		}
+		HandleConnectionError(conErr)
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(connection)
@@ -99,14 +84,9 @@ func ConnectionGetByID(c *cli.Context) {
 
 // ConnectionRemoveFromList : Removes a connection from the connections config file
 func ConnectionRemoveFromList(c *cli.Context) {
-	printAsJSON := c.GlobalBool("json")
 	conErr := connections.RemoveConnectionFromList(c)
 	if conErr != nil {
-		if printAsJSON {
-			fmt.Println(conErr.Error())
-		} else {
-			logr.Println(conErr.Desc)
-		}
+		HandleConnectionError(conErr)
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(connections.Result{Status: "OK", StatusMessage: "Connection removed"})
@@ -120,14 +100,9 @@ func ConnectionRemoveFromList(c *cli.Context) {
 
 // ConnectionListAll : Fetch all connections
 func ConnectionListAll(c *cli.Context) {
-	printAsJSON := c.GlobalBool("json")
 	allConnections, conErr := connections.GetConnectionsConfig()
 	if conErr != nil {
-		if printAsJSON {
-			fmt.Println(conErr.Error())
-		} else {
-			logr.Println(conErr.Desc)
-		}
+		HandleConnectionError(conErr)
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(allConnections)
@@ -137,14 +112,9 @@ func ConnectionListAll(c *cli.Context) {
 
 // ConnectionResetList : Reset to a single default local connection
 func ConnectionResetList(c *cli.Context) {
-	printAsJSON := c.GlobalBool("json")
 	conErr := connections.ResetConnectionsFile()
 	if conErr != nil {
-		if printAsJSON {
-			fmt.Println(conErr.Error())
-		} else {
-			logr.Println(conErr.Desc)
-		}
+		HandleConnectionError(conErr)
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(connections.Result{Status: "OK", StatusMessage: "Connection list reset"})

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -25,7 +25,7 @@ import (
 func ProjectValidate(c *cli.Context) {
 	err := project.ValidateProject(c)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	}
 	os.Exit(0)
@@ -35,20 +35,19 @@ func ProjectValidate(c *cli.Context) {
 func ProjectCreate(c *cli.Context) {
 	err := project.DownloadTemplate(c)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	}
 }
 
 // ProjectSync : Does a project Sync
 func ProjectSync(c *cli.Context) {
-	PrintAsJSON := c.GlobalBool("json")
 	response, err := project.SyncProject(c)
 	if err != nil {
-		fmt.Println(err.Err)
+		HandleProjectError(err)
 		os.Exit(1)
 	} else {
-		if PrintAsJSON {
+		if printAsJSON {
 			jsonResponse, _ := json.Marshal(response)
 			fmt.Println(string(jsonResponse))
 		} else {
@@ -60,13 +59,12 @@ func ProjectSync(c *cli.Context) {
 
 // ProjectBind : Does a project bind
 func ProjectBind(c *cli.Context) {
-	PrintAsJSON := c.GlobalBool("json")
 	response, err := project.BindProject(c)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	} else {
-		if PrintAsJSON {
+		if printAsJSON {
 			jsonResponse, _ := json.Marshal(response)
 			fmt.Println(string(jsonResponse))
 		} else {
@@ -81,7 +79,7 @@ func ProjectBind(c *cli.Context) {
 func ProjectRemove(c *cli.Context) {
 	err := project.RemoveProject(c)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	}
 	os.Exit(0)
@@ -92,7 +90,7 @@ func UpgradeProjects(c *cli.Context) {
 	dir := strings.TrimSpace(c.String("workspace"))
 	response, err := project.UpgradeProjects(dir)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	}
 	PrettyPrintJSON(response)
@@ -105,7 +103,7 @@ func ProjectSetConnection(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	err := project.SetConnection(conID, projectID)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project target added successfully"})
@@ -118,7 +116,7 @@ func ProjectGetConnection(c *cli.Context) {
 	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
 	connectionTargets, err := project.GetConnectionID(projectID)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	}
 	fmt.Println(connectionTargets)
@@ -130,7 +128,7 @@ func ProjectRemoveConnection(c *cli.Context) {
 	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
 	err := project.ResetConnectionFile(projectID)
 	if err != nil {
-		fmt.Println(err.Error())
+		HandleProjectError(err)
 		os.Exit(1)
 	}
 	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project target removed successfully"})

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -14,11 +14,12 @@ package actions
 import (
 	"fmt"
 
+	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	logr "github.com/sirupsen/logrus"
 )
 
-// HandleDockerError prints a Docker error, in JSON format if the global flag is set, and as a string if not
+// HandleDockerError prints a Docker error, in JSON format if the global flag is set and as a string if not
 func HandleDockerError(err *utils.DockerError) {
 	// printAsJSON is a global variable, set in commands.go
 	if printAsJSON {
@@ -31,6 +32,15 @@ func HandleDockerError(err *utils.DockerError) {
 // HandleTemplateError prints a Template error, in JSON format if the global flag is set, and as a string if not
 func HandleTemplateError(err *TemplateError) {
 	// printAsJSON is a global variable, set in commands.go
+	if printAsJSON {
+		fmt.Println(err.Error())
+	} else {
+		logr.Error(err.Desc)
+	}
+}
+
+// HandleConnectionError prints a Connection error, in JSON format if the global flag is set and as a string if not
+func HandleConnectionError(err *connections.ConError) {
 	if printAsJSON {
 		fmt.Println(err.Error())
 	} else {

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/eclipse/codewind-installer/pkg/project"
 	logr "github.com/sirupsen/logrus"
 )
 
@@ -41,6 +42,15 @@ func HandleTemplateError(err *TemplateError) {
 
 // HandleConnectionError prints a Connection error, in JSON format if the global flag is set and as a string if not
 func HandleConnectionError(err *connections.ConError) {
+	if printAsJSON {
+		fmt.Println(err.Error())
+	} else {
+		logr.Error(err.Desc)
+	}
+}
+
+// HandleProjectError prints a Project error, in JSON format if the global flag is set and as a string if not
+func HandleProjectError(err *project.ProjectError) {
 	if printAsJSON {
 		fmt.Println(err.Error())
 	} else {


### PR DESCRIPTION
### Summary

Implements the same method as #303 for connections errors, removing duplicated code to a helper function. Also removes reading `--json` for each function, as this is not set globally (in commands.go).

### Testing

Tests pass locally, and commands run as expected. 


Signed-off-by: James Cockbain <james.cockbain@ibm.com>