### PR TITLE
Handle watch for pod startup timing out and retry.

### DIFF
--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -217,7 +217,10 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 			os.Exit(1)
 		}
 		podSearch := "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + KeycloakPrefix
-		WaitForPodReady(clientset, codewindInstance, podSearch, KeycloakPrefix+"-"+codewindInstance.WorkspaceID)
+		ready := false
+		for !ready {
+			ready = WaitForPodReady(clientset, codewindInstance, podSearch, KeycloakPrefix+"-"+codewindInstance.WorkspaceID)
+		}
 	}
 
 	err = SetupKeycloak(codewindInstance, remoteDeployOptions)
@@ -240,7 +243,10 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 	}
 
 	podSearch := "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + PFEPrefix
-	WaitForPodReady(clientset, codewindInstance, podSearch, PFEPrefix+"-"+codewindInstance.WorkspaceID)
+	ready := false
+	for !ready {
+		ready = WaitForPodReady(clientset, codewindInstance, podSearch, PFEPrefix+"-"+codewindInstance.WorkspaceID)
+	}
 
 	err = DeployPerformance(clientset, codewindInstance, remoteDeployOptions)
 	if err != nil {
@@ -249,7 +255,10 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 	}
 
 	podSearch = "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + PerformancePrefix
-	WaitForPodReady(clientset, codewindInstance, podSearch, PerformancePrefix+"-"+codewindInstance.WorkspaceID)
+	ready = false
+	for !ready {
+		ready = WaitForPodReady(clientset, codewindInstance, podSearch, PerformancePrefix+"-"+codewindInstance.WorkspaceID)
+	}
 
 	err = DeployGatekeeper(config, clientset, codewindInstance, remoteDeployOptions)
 	if err != nil {
@@ -258,7 +267,10 @@ func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemIn
 	}
 
 	podSearch = "codewindWorkspace=" + codewindInstance.WorkspaceID + ",app=" + GatekeeperPrefix
-	WaitForPodReady(clientset, codewindInstance, podSearch, GatekeeperPrefix+"-"+codewindInstance.WorkspaceID)
+	ready = false
+	for !ready {
+		ready = WaitForPodReady(clientset, codewindInstance, podSearch, GatekeeperPrefix+"-"+codewindInstance.WorkspaceID)
+	}
 
 	if remoteDeployOptions.GateKeeperTLSSecure {
 		gatekeeperURL = "https://" + gatekeeperURL


### PR DESCRIPTION
This PR handles the channel created by the `Pods.Watch` being closed when the watch times out. It uses the status value returned by the channel to determine that the channel has been closed.
When detected we warn the user but then keep watching.
To ensure the user get's regular feedback it explicitly sets the timeout to 30 seconds and prints a warning via the logger.

This is for issue https://github.com/eclipse/codewind/issues/1373