### PR TITLE
Detect CHE before Docker

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,13 +41,13 @@ func PFEOriginFromConnection(connection *connections.Connection) (string, *Confi
 }
 
 func getLocalHostnameAndPort() (string, *ConfigError) {
+	val, ok := os.LookupEnv("CHE_API_EXTERNAL")
+	if ok && (val != "") {
+		return "https://localhost:9090", nil
+	}
 	hostname, port, err := utils.GetPFEHostAndPort()
 	if err != nil || hostname == "" || port == "" {
 		return "", &ConfigError{errOpConfPFEHostnamePortNotFound, nil, "Hostname or port for PFE not found"}
-	}
-	val, ok := os.LookupEnv("CHE_API_EXTERNAL")
-	if ok && (val != "") {
-		return "https://" + hostname + ":" + port, nil
 	}
 	return "http://" + hostname + ":" + port, nil
 }


### PR DESCRIPTION
## Problem

Unable to create a new project in CHE as logged in Issue http://github.com/eclipse/codewind/issues/1665 

## Solution

Flips the search order when obtaining the Host and Port of PFE. 

The CLI will now test if it is running in CHE first and always return the address of the local theia server rather than attempt to use Docker API to determine the endpoint. 

Manually tested a deployment into  : 

- [x] CHE
- [x] LOCAL
- [x] REMOTE

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>