### PR TITLE
Change cwctl remove to use sechhttp

### DIFF
--- a/pkg/project/getproject.go
+++ b/pkg/project/getproject.go
@@ -37,7 +37,7 @@ func GetProject(httpClient utils.HTTPClient, conID, projectID string) (*Project,
 	}
 
 	// send request
-	resp, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, req, conInfo)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}

--- a/pkg/project/getproject.go
+++ b/pkg/project/getproject.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
 
@@ -36,9 +37,9 @@ func GetProject(httpClient utils.HTTPClient, conID, projectID string) (*Project,
 	}
 
 	// send request
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
+	resp, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, req, conInfo)
+	if httpSecError != nil {
+		return nil, httpSecError
 	}
 	defer resp.Body.Close()
 

--- a/pkg/project/project_utils.go
+++ b/pkg/project/project_utils.go
@@ -33,6 +33,7 @@ const (
 	errOpFileLoad    = "proj_load"
 	errOpFileWrite   = "proj_write"
 	errOpFileDelete  = "proj_delete"
+	errOpUnbind      = "proj_unbind"
 	errOpGetProject  = "proj_get"
 	errOpConflict    = "proj_conflict"
 	errOpNotFound    = "proj_notfound"

--- a/pkg/project/remove.go
+++ b/pkg/project/remove.go
@@ -12,8 +12,6 @@
 package project
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -37,7 +35,6 @@ func RemoveProject(c *cli.Context) *ProjectError {
 	if deleteFiles {
 		project, projErr := GetProject(http.DefaultClient, conID, projectID)
 		if projErr != nil {
-			fmt.Println(projErr)
 			return &ProjectError{errOpGetProject, projErr, projErr.Error()}
 		}
 		projectPath = project.LocationOnDisk
@@ -46,8 +43,7 @@ func RemoveProject(c *cli.Context) *ProjectError {
 	// Unbind the project from codewind
 	err := Unbind(http.DefaultClient, conID, projectID)
 	if err != nil {
-		projError := errors.New("Project unbind failed")
-		return &ProjectError{errOpFileDelete, projError, projError.Error()}
+		return &ProjectError{errOpUnbind, err, err.Error()}
 	}
 
 	// Delete the associated connection file

--- a/pkg/project/unbind.go
+++ b/pkg/project/unbind.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
 
@@ -35,10 +36,11 @@ func Unbind(httpClient utils.HTTPClient, conID, projectID string) error {
 	}
 
 	// send request
-	res, err := httpClient.Do(req)
-	if err != nil {
-		return err
+	res, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, req, conInfo)
+	if httpSecError != nil {
+		return httpSecError
 	}
+
 	defer res.Body.Close()
 	return nil
 }

--- a/pkg/project/unbind.go
+++ b/pkg/project/unbind.go
@@ -36,7 +36,7 @@ func Unbind(httpClient utils.HTTPClient, conID, projectID string) error {
 	}
 
 	// send request
-	res, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, req, conInfo)
+	res, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
 	if httpSecError != nil {
 		return httpSecError
 	}


### PR DESCRIPTION
Fix for https://github.com/eclipse/codewind/issues/1660
### Summary
* Use `sechhttp` in `unbind.go` so that we can reach remote deployments.

### Testing
* Successfully ran `cwctl remove` on an OpenShift cluster (Mongrel).

Signed-off-by: James Wallis <james.wallis1@ibm.com>