### PR TITLE
Only use global --json flag, remove print for image check

### DIFF
--- a/integration.bats
+++ b/integration.bats
@@ -1,16 +1,16 @@
 #!/usr/bin/env bats
 
-@test "invoke install command - install latest with --json" {
+@test "invoke install command - install latest with --json global flag set" {
   cd cmd/cli/
-  run go run main.go install --json
+  run go run main.go --json install
   echo "status = ${status}"
   echo "output trace = ${output}"
     [ "$status" -eq 0 ]
 }
 
-@test "invoke status -j command - output = '{"status":"stopped","installed-versions":["latest"]}'" {
+@test "invoke status command with --json global flag set - output = '{"status":"stopped","installed-versions":["latest"]}'" {
   cd cmd/cli/
-  run go run main.go status -j
+  run go run main.go --json status
   echo "status = ${status}"
   echo "output trace = ${output}"
   [ "$output" = '{"status":"stopped","installed-versions":["latest"]}' ]

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -155,7 +155,6 @@ func Commands() {
 							Name:    "remove",
 							Aliases: []string{"r"},
 							Usage:   "Remove connection from a project",
-
 							Flags: []cli.Flag{
 								cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
 							},
@@ -178,10 +177,6 @@ func Commands() {
 					Name:  "tag, t",
 					Value: "latest",
 					Usage: "dockerhub image tag",
-				},
-				cli.BoolFlag{
-					Name:  "json, j",
-					Usage: "output as JSON",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -240,10 +235,6 @@ func Commands() {
 			Name:  "status",
 			Usage: "Print the installation status of Codewind",
 			Flags: []cli.Flag{
-				cli.BoolFlag{
-					Name:  "json, j",
-					Usage: "output as JSON",
-				},
 				cli.StringFlag{
 					Name:  "conid",
 					Usage: "ConnectionID to check",

--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -31,15 +31,13 @@ import (
 //InstallCommand to pull images from dockerhub
 func InstallCommand(c *cli.Context) {
 	tag := c.String("tag")
-	jsonOutput := c.Bool("json") || c.GlobalBool("json")
 
 	imageArr := [2]string{
 		"docker.io/eclipse/codewind-pfe-amd64:" + tag,
 		"docker.io/eclipse/codewind-performance-amd64:" + tag,
 	}
-
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(imageArr[i], jsonOutput)
+		utils.PullImage(imageArr[i], printAsJSON)
 		imageID, dockerError := utils.ValidateImageDigest(imageArr[i])
 
 		if dockerError != nil {
@@ -48,13 +46,13 @@ func InstallCommand(c *cli.Context) {
 			utils.RemoveImage(imageID)
 
 			// pull image again
-			utils.PullImage(imageArr[i], jsonOutput)
+			utils.PullImage(imageArr[i], printAsJSON)
 
 			// validate the new image
 			_, dockerError = utils.ValidateImageDigest(imageArr[i])
 
 			if dockerError != nil {
-				if jsonOutput {
+				if printAsJSON {
 					fmt.Println(dockerError)
 				} else {
 					logr.Errorf("Validation of image '%v' checksum failed - Removing image", imageArr[i])

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -524,7 +524,7 @@ func GetImageTags() ([]string, *DockerError) {
 					tag = strings.Split(tag, ":")[1]
 					tagArr = append(tagArr, tag)
 				} else {
-					log.Println("No tag available. Defaulting to ''")
+					logr.Debug("No tag available for '" + imageRepo + "'. Defaulting to ''")
 					tagArr = append(tagArr, "")
 				}
 			}


### PR DESCRIPTION
### Summary
* Change `install` and `status` command to use the global `--json` flag rather than a scoped one. Previously they accepted both to allow the IDE's time to update.
    * `status` had its scoped `--json` flag removed in: https://github.com/eclipse/codewind-installer/pull/303 this PR just updates the tests for it.
* Change a `log` in `Docker.go` to be a `logr.Debug` so that it isn't outputted to the terminal - fixes it being outputted when the `--json` flag is given.
   * Previously outputted: 
```
❯ cwctl --json status
195-90-nip-io:7443/my-rhel-icp-admin/jamesw0001
2020/01/13 11:16:04 No tag available. Defaulting to ''
2020/01/13 11:16:04 No tag available. Defaulting to ''
{"status":"stopped","installed-versions":[]}
```

### Testing
Ran (and fixed) that `bats` tests.

### Note
I have checked the Eclipse and VSCode plugins and they should use the global `--json` option but @eharris369 and @tetchel could you confirm that this PR won't break the status or install commands?

Signed-off-by: James Wallis <james.wallis1@ibm.com>