### PR TITLE
bump version to 0.8.0

### DIFF
--- a/pkg/appconstants/version.go
+++ b/pkg/appconstants/version.go
@@ -12,4 +12,4 @@
 package appconstants
 
 // VersionNum : CLI Version number
-const VersionNum = "x.x.dev"
+const VersionNum = "0.8.0"

--- a/pkg/remote/defaults.go
+++ b/pkg/remote/defaults.go
@@ -42,16 +42,16 @@ const (
 	GatekeeperImage = "eclipse/codewind-gatekeeper-amd64"
 
 	// PFEImageTag is the image tag associated with the docker image that's used for Codewind-PFE
-	PFEImageTag = "latest"
+	PFEImageTag = "0.8.0"
 
 	// PerformanceTag is the image tag associated with the docker image that's used for the Performance dashboard
-	PerformanceTag = "latest"
+	PerformanceTag = "0.8.0"
 
 	// KeycloakImageTag is the image tag associated with the docker image that's used for Codewind-Keycloak
-	KeycloakImageTag = "latest"
+	KeycloakImageTag = "0.8.0"
 
 	// GatekeeperImageTag is the image tag associated with the docker image that's used for Codewind-Gatekeeper
-	GatekeeperImageTag = "latest"
+	GatekeeperImageTag = "0.8.0"
 
 	// ImagePullPolicy is the pull policy used for all containers in Codewind, defaults to Always
 	ImagePullPolicy = corev1.PullAlways


### PR DESCRIPTION
change to use 0.8.0 images


Signed-off-by: Toby Corbin <corbint@uk.ibm.com>