### PR TITLE
(0.8.0) remove the conversion of payload to json

### DIFF
--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -154,7 +154,7 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 			// Has this file been modified since last sync
 			if modifiedmillis > synctime {
 				fileContent, err := ioutil.ReadFile(path)
-				jsonContent, err := json.Marshal(string(fileContent))
+				//jsonContent, err := json.Marshal(string(fileContent))
 				// Skip this file if there is an error reading it.
 				if err != nil {
 					return nil
@@ -164,7 +164,7 @@ func syncFiles(projectPath string, projectID string, conURL string, synctime int
 
 				var buffer bytes.Buffer
 				zWriter := zlib.NewWriter(&buffer)
-				zWriter.Write([]byte(jsonContent))
+				zWriter.Write([]byte(fileContent))
 
 				zWriter.Close()
 				encoded := base64.StdEncoding.EncodeToString(buffer.Bytes())


### PR DESCRIPTION
https://github.com/eclipse/codewind/issues/1749

Binary files were being corrupted on upload due to the packaging of them into JSON.  I've removed this step (and also the step in portal) and this has fixed the problem

Signed-off-by: Toby Corbin <corbint@uk.ibm.com>