### PR TITLE
change project validation to return javascript as language

### DIFF
--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -222,7 +222,7 @@ func determineProjectInfo(projectPath string) (string, string) {
 		language = "java"
 		buildType = determineJavaBuildType(projectPath)
 	} else if utils.PathExists(path.Join(projectPath, "package.json")) {
-		language = "nodejs"
+		language = "javascript"
 		buildType = "nodejs"
 	} else if utils.PathExists(path.Join(projectPath, "Package.swift")) {
 		language = "swift"

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -41,7 +41,7 @@ func TestDetermineProjectInfo(t *testing.T) {
 		},
 		"success case: node.js project": {
 			in:            path.Join("../..", "resources", "test", "node-project"),
-			wantLanguage:  "nodejs",
+			wantLanguage:  "javascript",
 			wantBuildType: "nodejs",
 		},
 		"success case: swift project": {

--- a/resources/workspaces/valid-projects/.projects/valid-project.inf
+++ b/resources/workspaces/valid-projects/.projects/valid-project.inf
@@ -1,5 +1,5 @@
 {
   "name": "valid-project",
-  "language": "nodejs",
+  "language": "javascript",
   "projectType": "nodejs"
 }


### PR DESCRIPTION
Resolves https://github.com/eclipse/codewind/issues/784. 

## Summary

Return `language=javascript` rather than `language=nodejs` when validating a users project. 

Changes are being proposed for PFE to ensure we can handle both `language=javascript` and `language=nodejs.

## Testing

Tests pass. 

Commands (`cwctl project create` with url and without), work as expected. 

cwctl binary copied into both eclipse and vscode plugins and projects are created and built successfully.


Signed-off-by: James Cockbain <james.cockbain@ibm.com>