### PR TITLE
Pass the logging level to the PFE container.

### DIFF
--- a/pkg/actions/start.go
+++ b/pkg/actions/start.go
@@ -32,12 +32,13 @@ func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint strin
 	} else {
 		tag := c.String("tag")
 		debug := c.Bool("debug")
+		loglevel := c.GlobalString("loglevel")
 		fmt.Println("Debug:", debug)
 
 		utils.CreateTempFile(dockerComposeFile)
 		utils.WriteToComposeFile(dockerComposeFile, debug)
 
-		err := utils.DockerCompose(dockerComposeFile, tag)
+		err := utils.DockerCompose(dockerComposeFile, tag, loglevel)
 		if err != nil {
 			HandleDockerError(err)
 			os.Exit(1)


### PR DESCRIPTION
This PR enables logging from startup by setting the log level environment variable when the PFE docker container is started. This is needed to get full logging information for initialisation from PFE as otherwise the log level can only be adjusted once the container has started and the REST API is available.

As there was already a `loglevel` flag for `cwctl` that took the same log levels this change just passes through that same level to PFE rather than have multiple flags. (If we are getting someone to trace startup it probably makes sense to get the logging for `cwctl` and the PFE container as they are closely integrated.)