### PR TITLE
Add a 'loglevels' command to set and query the log level

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -816,6 +816,22 @@ func Commands() {
 			},
 		},
 		{
+			Name:    "loglevels",
+			Aliases: []string{"log"},
+			Usage:   "Get or set logging levels of remotely deployed Codewind containers",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "conid",
+					Usage: "ConnectionID to check",
+					Value: "local",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				LogLevels(c)
+				return nil
+			},
+		},
+		{
 			Name:    "version",
 			Aliases: []string{"v"},
 			Usage:   "Get versions of remotely deployed Codewind containers",

--- a/pkg/actions/logging.go
+++ b/pkg/actions/logging.go
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/urfave/cli"
+)
+
+// LogLevels : Optionally set then display the log level information
+// for a Codewind PFE container
+func LogLevels(c *cli.Context) {
+	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
+	newLogLevel := strings.TrimSpace(strings.ToLower(c.Args().Get(0)))
+
+	if newLogLevel != "" {
+		err := apiroutes.SetLogLevel(connectionID, http.DefaultClient, newLogLevel)
+		if err != nil {
+			fmt.Println(err.Error())
+			os.Exit(1)
+		}
+	}
+
+	loggingLevels, err := apiroutes.GetLogLevels(connectionID, http.DefaultClient)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	utils.PrettyPrintJSON(loggingLevels)
+}

--- a/pkg/apiroutes/logging.go
+++ b/pkg/apiroutes/logging.go
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+)
+
+type (
+	// LogLevels : The logging level information
+	LoggingResponse struct {
+		CurrentLevel string   `json:"currentLevel"`
+		DefaultLevel string   `json:"defaultLevel"`
+		AllLevels    []string `json:"allLevels"`
+	}
+
+	// LogParameter : The request structure to set the log level
+	LogParameter struct {
+		Level string `json:"level"`
+	}
+)
+
+// GetLogLevel : Get the current log level for the PFE container
+func GetLogLevels(conID string, httpClient utils.HTTPClient) (LoggingResponse, error) {
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return LoggingResponse{}, conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		return LoggingResponse{}, conErr.Err
+	}
+
+	req, err := http.NewRequest("GET", conURL+"/api/v1/logging", nil)
+	if err != nil {
+		return LoggingResponse{}, err
+	}
+
+	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
+	if httpSecError != nil {
+		return LoggingResponse{}, httpSecError
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return LoggingResponse{}, errors.New(http.StatusText(resp.StatusCode))
+	}
+
+	defer resp.Body.Close()
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return LoggingResponse{}, err
+	}
+
+	var loggingLevels LoggingResponse
+	err = json.Unmarshal(byteArray, &loggingLevels)
+	if err != nil {
+		return LoggingResponse{}, err
+	}
+
+	return loggingLevels, nil
+}
+
+// SetLogLevel : Set the current log level for the PFE container
+func SetLogLevel(conID string, httpClient utils.HTTPClient, newLogLevel string) error {
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		return conInfoErr.Err
+	}
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		return conErr.Err
+	}
+
+	// Send the new logging level.
+	logLevel := &LogParameter{Level: newLogLevel}
+	jsonPayload, _ := json.Marshal(logLevel)
+	req, err := http.NewRequest("PUT", conURL+"/api/v1/logging", bytes.NewBuffer(jsonPayload))
+	req.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		return err
+	}
+
+	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
+	if httpSecError != nil {
+		return httpSecError
+	}
+
+	if resp.StatusCode == 400 {
+		return errors.New("Invalid log level")
+	} else if resp.StatusCode == 500 {
+		return errors.New("Error setting log level")
+	} else if resp.StatusCode != http.StatusOK {
+		return errors.New(http.StatusText(resp.StatusCode))
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a 'loglevels' command to set and query the log levels for remote PFE containers.

This is for enhancement: https://github.com/eclipse/codewind/issues/729

