### PR TITLE
return projectErrors from create.go

### DIFF
--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -136,9 +136,8 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 // ValidateProject returns the language and buildType for a project at given filesystem path,
 // and writes a default .cw-settings file to that project
 func ValidateProject(c *cli.Context) (*ValidationResponse, *ProjectError) {
-	projectPath := c.Args().Get(0)
+	projectPath := c.String("path")
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-
 	projErr := checkProjectPathExists(projectPath)
 	if projErr != nil {
 		return nil, projErr

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -13,6 +13,7 @@ package project
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -23,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
-	"github.com/eclipse/codewind-installer/pkg/errors"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/urfave/cli"
 )
@@ -53,6 +53,12 @@ type (
 // DownloadTemplate using the url/link provided
 func DownloadTemplate(destination string, url string) (Result, *ProjectError) {
 	checkProjectDirIsEmpty(destination)
+
+	projErr := checkProjectDirIsEmpty(destination)
+	if projErr != nil {
+		return nil, projErr
+	}
+
 	projectDir := path.Base(destination)
 
 	// Remove invalid characters from the string we will use
@@ -65,12 +71,12 @@ func DownloadTemplate(destination string, url string) (Result, *ProjectError) {
 
 	err := utils.DownloadFromURLThenExtract(url, destination)
 	if err != nil {
-		log.Fatal(err)
+		return nil, &ProjectError{errOpCreateProject, err, err.Error()}
 	}
 
 	err = utils.ReplaceInFiles(destination, "[PROJ_NAME_PLACEHOLDER]", projectName)
 	if err != nil {
-		log.Fatal(err)
+		return nil, &ProjectError{errOpCreateProject, err, err.Error()}
 	}
 
 	response := Result{Status: "success", StatusMessage: "Project downloaded to" + destination}
@@ -132,7 +138,12 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 func ValidateProject(c *cli.Context) (ValidationResponse, *ProjectError) {
 	projectPath := c.String("path")
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	checkProjectPathExists(projectPath)
+
+	projErr := checkProjectPathExists(projectPath)
+	if projErr != nil {
+		return projErr
+	}
+
 	validationStatus := "success"
 	// result could be ProjectType or string, so define as an interface
 	var validationResult interface{}
@@ -160,7 +171,10 @@ func ValidateProject(c *cli.Context) (ValidationResponse, *ProjectError) {
 		Result: validationResult,
 	}
 
-	errors.CheckErr(err, 203, "")
+	if err != nil {
+		return &ProjectError{errOpCreateProject, err, err.Error()}
+	}
+
 	// write settings file only for non-extension projects
 	if extensionType == "" {
 		writeCwSettingsIfNotInProject(conID, projectPath, buildType)
@@ -179,32 +193,38 @@ func writeCwSettingsIfNotInProject(conID string, projectPath string, BuildType s
 	}
 }
 
-// checkProjectDirIsEmpty stops the process if the given local filepath already exists, or is an empty string
-func checkProjectDirIsEmpty(projectPath string) {
+// checkProjectDirIsEmpty return an error if the given local filepath already exists, or is an empty string
+func checkProjectDirIsEmpty(projectPath string) *ProjectError {
 	if projectPath == "" {
-		log.Fatal("destination not set")
+		err := errors.New(textNoProjectPath)
+		return &ProjectError{errOpCreateProject, err, err.Error()}
 	}
 
 	// if the project dir already exists, continue if empty and exit if not
 	if utils.PathExists(projectPath) {
 		dirIsEmpty, err := utils.DirIsEmpty(projectPath)
 		if err != nil {
-			log.Fatal(err)
+			return &ProjectError{errOpCreateProject, err, err.Error()}
 		}
 		if !dirIsEmpty {
-			log.Fatal("Non empty directory provided")
+			projErr := errors.New(textProjectPathNonEmpty)
+			return &ProjectError{errOpCreateProject, projErr, projErr.Error()}
 		}
 	}
+	return nil
 }
 
-// checkProjectPathExists stops the process if the given local filepath does not exist, or is an empty string
-func checkProjectPathExists(projectPath string) {
+// checkProjectPathExists returns an error if the given local filepath does not exist, or is an empty string
+func checkProjectPathExists(projectPath string) *ProjectError {
 	if projectPath == "" {
-		log.Fatal("Project path not given")
+		err := errors.New(textNoProjectPath)
+		return &ProjectError{errOpCreateProject, err, err.Error()}
 	}
 	if !utils.PathExists(projectPath) {
-		log.Fatal("Project not found at given path")
+		err := errors.New(textProjectPathDoesNotExist)
+		return &ProjectError{errOpCreateProject, err, err.Error()}
 	}
+	return nil
 }
 
 // determineProjectInfo returns the language and build-type of a project
@@ -220,7 +240,11 @@ func determineProjectInfo(projectPath string) (string, string) {
 		language = "swift"
 		buildType = "swift"
 	} else {
-		language = determineProjectLanguage(projectPath)
+		determinedLanguage, err := determineProjectLanguage(projectPath)
+		if err != nil {
+			language = "unknown"
+		}
+		language = determinedLanguage
 		buildType = "docker"
 	}
 	return language, buildType
@@ -246,41 +270,47 @@ func determineJavaBuildType(projectPath string) string {
 	return "docker"
 }
 
-func determineProjectLanguage(projectPath string) string {
+func determineProjectLanguage(projectPath string) (string, error) {
 	projectFiles, err := ioutil.ReadDir(projectPath)
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 	for _, file := range projectFiles {
 		if !file.IsDir() {
 			switch filepath.Ext(file.Name()) {
 			case ".py":
-				return "python"
+				return "python", nil
 			case ".go":
-				return "go"
+				return "go", nil
 			default:
 				continue
 			}
 		}
 	}
-	return "unknown"
+	return "unknown", nil
 }
 
 // RenameLegacySettings renames a .mc-settings file to .cw-settings
-func renameLegacySettings(pathToLegacySettings string, pathToCwSettings string) {
+func renameLegacySettings(pathToLegacySettings string, pathToCwSettings string) error {
 	err := os.Rename(pathToLegacySettings, pathToCwSettings)
-	errors.CheckErr(err, 205, "")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // writeNewCwSettings writes a default .cw-settings file to the given path,
 // dependant on the build type of the project
-func writeNewCwSettings(conID string, pathToCwSettings string, BuildType string) {
+func writeNewCwSettings(conID string, pathToCwSettings string, BuildType string) error {
 	defaultCwSettings := getDefaultCwSettings(conID, BuildType)
 	cwSettings := addNonDefaultFieldsToCwSettings(defaultCwSettings, BuildType)
 	settings, err := json.MarshalIndent(cwSettings, "", "  ")
-	errors.CheckErr(err, 203, "")
+	if err != nil {
+		return err
+	}
 	// File permission 0644 grants read and write access to the owner
 	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)
+	return nil
 }
 
 func getDefaultCwSettings(conID string, BuildType string) CWSettings {

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -51,7 +51,7 @@ type (
 )
 
 // DownloadTemplate using the url/link provided
-func DownloadTemplate(destination string, url string) (Result, *ProjectError) {
+func DownloadTemplate(destination string, url string) (*Result, *ProjectError) {
 	checkProjectDirIsEmpty(destination)
 
 	projErr := checkProjectDirIsEmpty(destination)
@@ -80,7 +80,7 @@ func DownloadTemplate(destination string, url string) (Result, *ProjectError) {
 	}
 
 	response := Result{Status: "success", StatusMessage: "Project downloaded to" + destination}
-	return response, nil
+	return &response, nil
 }
 
 // checkIsExtension checks if a project is an extension project and run associated commands as necessary
@@ -135,13 +135,13 @@ func checkIsExtension(conID, projectPath string, c *cli.Context) (string, error)
 
 // ValidateProject returns the language and buildType for a project at given filesystem path,
 // and writes a default .cw-settings file to that project
-func ValidateProject(c *cli.Context) (ValidationResponse, *ProjectError) {
-	projectPath := c.String("path")
+func ValidateProject(c *cli.Context) (*ValidationResponse, *ProjectError) {
+	projectPath := c.Args().Get(0)
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 
 	projErr := checkProjectPathExists(projectPath)
 	if projErr != nil {
-		return projErr
+		return nil, projErr
 	}
 
 	validationStatus := "success"
@@ -172,14 +172,14 @@ func ValidateProject(c *cli.Context) (ValidationResponse, *ProjectError) {
 	}
 
 	if err != nil {
-		return &ProjectError{errOpCreateProject, err, err.Error()}
+		return nil, &ProjectError{errOpCreateProject, err, err.Error()}
 	}
 
 	// write settings file only for non-extension projects
 	if extensionType == "" {
 		writeCwSettingsIfNotInProject(conID, projectPath, buildType)
 	}
-	return response, nil
+	return &response, nil
 }
 
 func writeCwSettingsIfNotInProject(conID string, projectPath string, BuildType string) {

--- a/pkg/project/getproject_test.go
+++ b/pkg/project/getproject_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetProject(t *testing.T) {
+func TestGetProjectFromID(t *testing.T) {
 	t.Run("Expect success - project should be returned", func(t *testing.T) {
 		// construct mock response body and status code
 		projectID := "1234"
@@ -36,7 +36,7 @@ func TestGetProject(t *testing.T) {
 
 		mockConnection := connections.Connection{ID: "local"}
 
-		response, getAllError := GetProject(mockClient, &mockConnection, "dummyurl", projectID)
+		response, getAllError := GetProjectFromID(mockClient, &mockConnection, "dummyurl", projectID)
 		if getAllError != nil {
 			t.Fail()
 		}

--- a/pkg/project/project_utils.go
+++ b/pkg/project/project_utils.go
@@ -36,6 +36,7 @@ const (
 	errOpFileDelete     = "proj_delete"
 	errOpUnbind         = "proj_unbind"
 	errOpGetProject     = "proj_get"
+	errOpCreateProject  = "project create"
 	errOpConflict       = "proj_conflict"
 	errOpNotFound       = "proj_notfound"
 	errOpConNotFound    = "connection_notfound"
@@ -46,15 +47,18 @@ const (
 )
 
 const (
-	textDupName          = "project name is already in use"
-	textInvalidType      = "project type is invalid"
-	textInvalidProjectID = "project ID is invalid"
-	textConnectionExists = "project already added to this connection"
-	textConMissing       = "project connection not found"
-	textNoCodewind       = "unable to connect to Codewind server"
-	textAPINotFound      = "unable to find requested resource on Codewind server"
-	textNoProjects       = "unable to find any codewind projects"
-	textUpgradeError     = "error occurred upgrading projects"
+	textDupName                 = "project name is already in use"
+	textInvalidType             = "project type is invalid"
+	textInvalidProjectID        = "project ID is invalid"
+	textConnectionExists        = "project already added to this connection"
+	textConMissing              = "project connection not found"
+	textNoCodewind              = "unable to connect to Codewind server"
+	textAPINotFound             = "unable to find requested resource on Codewind server"
+	textNoProjects              = "unable to find any codewind projects"
+	textUpgradeError            = "error occurred upgrading projects"
+	textNoProjectPath           = "project path not given"
+	textProjectPathDoesNotExist = "given project path does not exist"
+	textProjectPathNonEmpty     = "Non empty directory provided"
 )
 
 // ProjectError : Error formatted in JSON containing an errorOp and a description from

--- a/pkg/project/project_utils.go
+++ b/pkg/project/project_utils.go
@@ -26,24 +26,25 @@ type (
 )
 
 const (
-	errBadPath          = "proj_path" // Invalid path provided
-	errBadType          = "proj_type" // Invalid type provided
-	errOpRequest        = "proj_request"
-	errOpResponse       = "proj_response" // Bad response to http
-	errOpFileParse      = "proj_parse"
-	errOpFileLoad       = "proj_load"
-	errOpFileWrite      = "proj_write"
-	errOpFileDelete     = "proj_delete"
-	errOpUnbind         = "proj_unbind"
-	errOpGetProject     = "proj_get"
-	errOpCreateProject  = "project create"
-	errOpConflict       = "proj_conflict"
-	errOpNotFound       = "proj_notfound"
-	errOpConNotFound    = "connection_notfound"
-	errOpInvalidID      = "proj_id_invalid"
-	errOpInvalidOptions = "proj_options_invalid"
-	errOpSync           = "proj_sync"
-	errOpSyncRef        = "proj_sync_ref"
+	errBadPath           = "proj_path" // Invalid path provided
+	errBadType           = "proj_type" // Invalid type provided
+	errOpRequest         = "proj_request"
+	errOpResponse        = "proj_response" // Bad response to http
+	errOpFileParse       = "proj_parse"
+	errOpFileLoad        = "proj_load"
+	errOpFileWrite       = "proj_write"
+	errOpFileDelete      = "proj_delete"
+	errOpUnbind          = "proj_unbind"
+	errOpGetProject      = "proj_get"
+	errOpCreateProject   = "project create"
+	errOpConflict        = "proj_conflict"
+	errOpNotFound        = "proj_notfound"
+	errOpConNotFound     = "connection_notfound"
+	errOpInvalidID       = "proj_id_invalid"
+	errOpInvalidOptions  = "proj_options_invalid"
+	errOpSync            = "proj_sync"
+	errOpSyncRef         = "proj_sync_ref"
+	errOpWriteCwSettings = "proj_write_cw_settings"
 )
 
 const (


### PR DESCRIPTION
## Summary

Currently, `project/create.go` handles errors using log.Fatal and errors.checkError(). These changes align the functions with the majority of the rest of the codebase, returning errors from the packages which are then handled and printed in actions. The PR also:

- Ensures we follow whether --json is set, returning a projectError struct whenever it is, and an error description if not. 

- Fixes a test (getproject_test.go), which was invoking a function that has had its name changed (getProject -> getProjectFromID).

## Testing

- Ran both the commands that invoke the files functions (create with and without --url). This was with both the golden path and various error cases to confirm correct output. 

- No tests failing, apart from the ones already failing in master.

