### PR TITLE
Add support for setting the loglevel to kube installs.

### DIFF
--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -116,6 +116,7 @@ func DoRemoteInstall(c *cli.Context) {
 		KeycloakTLSSecure:     true,
 		CodewindSessionSecret: session,
 		CodewindPVCSize:       strconv.Itoa(codewindPVCSize) + "Gi",
+		LogLevel:              c.GlobalString("loglevel"),
 	}
 
 	deploymentResult, remInstError := remote.DeployRemote(&deployOptions)

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -52,6 +52,7 @@ type DeployOptions struct {
 	CodewindSessionSecret string
 	ClientSecret          string
 	CodewindPVCSize       string
+	LogLevel              string
 }
 
 // DeploymentResult : Ingress root URLs

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -203,6 +203,10 @@ func setPFEEnvVars(codewind Codewind, deployOptions *DeployOptions) []corev1.Env
 			Name:  "CODEWIND_AUTH_HOST",
 			Value: authHost,
 		},
+		{
+			Name:  "LOG_LEVEL",
+			Value: deployOptions.LogLevel,
+		},
 	}
 }
 


### PR DESCRIPTION
This follows on from https://github.com/eclipse/codewind-installer/pull/335 by passing the logging level to PFE containers started in Kubernetes. That PR contains more details on the implementation.

This is also for https://github.com/eclipse/codewind/issues/729