### PR TITLE
Output docker-compose streams on error; homogenise env structure log …

### DIFF
--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -170,10 +170,14 @@ func DockerComposeStop(tag, dockerComposeFile string) *DockerError {
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
+		//print out docker-compose sysout & syserr for error diagnosis
+		fmt.Printf(output.String())
 		return &DockerError{errOpDockerComposeStop, err, err.Error()}
 	}
 	fmt.Printf("Please wait while containers shutdown... %s \n", output.String())
 	if err := cmd.Wait(); err != nil {
+		//print out docker-compose sysout & syserr for error diagnosis
+		fmt.Printf(output.String())
 		return &DockerError{errOpDockerComposeStop, err, err.Error()}
 	}
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
@@ -194,11 +198,15 @@ func DockerComposeRemove(dockerComposeFile, tag string) *DockerError {
 	// after 'Start' the program is continued and script is executing in background
 	err := cmd.Start()
 	if err != nil {
+		//print out docker-compose sysout & syserr for error diagnosis
+		fmt.Printf(output.String())
 		return &DockerError{errOpDockerComposeRemove, err, err.Error()}
 	}
 	fmt.Printf("Please wait whilst images are removed... %s \n", output.String())
 	err = cmd.Wait()
 	if err != nil {
+		//print out docker-compose sysout & syserr for error diagnosis
+		fmt.Printf(output.String())
 		return &DockerError{errOpImageRemove, err, err.Error()}
 	}
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -136,11 +136,15 @@ func DockerCompose(dockerComposeFile string, tag string, loglevel string) *Docke
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
+	    //print out docker-compose sysout & syserr for error diagnosis
+		fmt.Printf(output.String())
 		DeleteTempFile(dockerComposeFile)
 		return &DockerError{errOpDockerComposeStart, err, err.Error()}
 	}
 	fmt.Printf("Please wait while containers initialize... %s \n", output.String())
 	if err := cmd.Wait(); err != nil {
+		//print out docker-compose sysout & syserr for error diagnosis
+		fmt.Printf(output.String())
 		DeleteTempFile(dockerComposeFile)
 		return &DockerError{errOpDockerComposeStart, err, err.Error()}
 	}

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -73,7 +73,7 @@ func WriteToComposeFile(dockerComposeFile string, debug bool) bool {
 	if debug == true {
 		fmt.Printf("==> %s structure is: \n%s\n\n", dockerComposeFile, string(marshalledData))
 	} else {
-		fmt.Println("==> environment structure written to " + dockerComposeFile)
+		fmt.Println("==> environment structure written to " + filepath.ToSlash(dockerComposeFile))
 	}
 
 	err = ioutil.WriteFile(dockerComposeFile, marshalledData, 0644)


### PR DESCRIPTION
…path

Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

# Description of pull request

Fixes https://github.com/eclipse/codewind/issues/1747

## Solution
If errors occur when running `docker-compose`, print those errors out to the console log rather than assume it will be shown in the Go error object

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
Ran an error scenario, noted that `docker-compose` output is now present

## Checklist

- [X] I have commented my code where needed
- [ N/A ] I have made corresponding changes to the documentation
- [X] My changes do not generate any new warnings/linter errors
- [X] If necessary, I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes
- [X] There are no typos in the code comments or this pull request
- [X] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
