### PR TITLE
Prevent CheckContainerStatus() picking up images not started by docker-compose.

### DIFF
--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -44,7 +44,7 @@ var baseImageNameArr = [2]string{
 const pfeContainerName = "codewind-pfe"
 const performanceContainerName = "codewind-performance"
 
-var containerImageNames = []string{
+var containerImageNames = [...]string{
 	pfeContainerName,
 	performanceContainerName,
 }

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -41,11 +41,19 @@ var baseImageNameArr = [2]string{
 	performanceImageName,
 }
 
+const pfeContainerName = "codewind-pfe"
+const performanceContainerName = "codewind-performance"
+
+var containerImageNames = []string{
+	pfeContainerName,
+	performanceContainerName,
+}
+
 // codewind-docker-compose.yaml data
 var data = `
 version: 2
 services:
- codewind-pfe:
+ ` + pfeContainerName + `:
   image: ${PFE_IMAGE_NAME}${PLATFORM}:${TAG}
   container_name: codewind-pfe
   user: root
@@ -62,7 +70,7 @@ services:
   ports: ["127.0.0.1:${PFE_EXTERNAL_PORT}:9090"]
   volumes: ["/var/run/docker.sock:/var/run/docker.sock","cw-workspace:/codewind-workspace","${WORKSPACE_DIRECTORY}:/mounted-workspace"]
   networks: [network]
- codewind-performance:
+ ` + performanceContainerName + `:
   image: ${PERFORMANCE_IMAGE_NAME}${PLATFORM}:${TAG}
   ports: ["127.0.0.1:9095:9095"]
   container_name: codewind-performance
@@ -350,7 +358,7 @@ func GetContainersToRemove(containerList []types.Container) []types.Container {
 // CheckContainerStatus of Codewind running/stopped
 func CheckContainerStatus() (bool, *DockerError) {
 	var containerStatus = false
-	containerArr := baseImageNameArr
+	containerArr := containerImageNames
 	containers, err := GetContainerList()
 	if err != nil {
 		return false, err
@@ -359,7 +367,11 @@ func CheckContainerStatus() (bool, *DockerError) {
 	containerCount := 0
 	for _, container := range containers {
 		for _, key := range containerArr {
-			if strings.HasPrefix(container.Image, key) {
+			if len(container.Names) != 1 {
+				continue
+			}
+			// The container names returned by docker are prefixed with "/"
+			if strings.HasPrefix(container.Names[0], "/"+key) {
 				containerCount++
 			}
 		}


### PR DESCRIPTION
# Description of pull request

We are unable to run codewind locally in docker and docker's local kubernetes cluster. The containers do not clash but we check if codewind is running by looking at the image names, which are being used in the docker containers created by kubernetes not the container names which do not match what we use in our docker-compose.yaml

## Solution

This updates the `CheckContainerStatus()` function to look at the container names, which are unique to local codewind, not the image names which are shared.
Previously it was possible to run both versions at the same time, provided you started codewind in kube after you'd started it in docker. You then couldn't restart codewind in docker as it would find the containers running our images in local kubernetes which was a problem for development.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
I've started and stopped codewind locally while also running codewind installed into dockers local kubernetes cluster.
I've connected to both at the same time.

## Checklist

- [X] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [X] My changes do not generate any new warnings/linter errors
- [] If necessary, I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes
- [ ] There are no typos in the code comments or this pull request
- [X] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
