### PR TITLE
Run validate after create project to generate a .cw-settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,14 @@ Subcommands:</br>
 > **Flags:**
 > --url,-u value URL of project to download
 > --path,-p value Path at which to create the new project
+> --conid value Connection ID of PFE that will be used to validate the project (optional)
 
 `validate` - Returns the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist
 
 > **Flags:**
-> --name,-n value Project name
 > --path,-p value Project path, on local disk
 > --type,-t value Project build type, if known (not required)
+> --conid value Connection ID of PFE that will be used to validate the project (optional)
 
 `bind` - Bind a project to Codewind for building and running
 > **Flags:**

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -66,7 +66,7 @@ func Commands() {
 					Usage: "Create a project on disk",
 
 					Flags: []cli.Flag{
-						cli.StringFlag{Name: "url, u", Usage: "URL of project to download", Required: false},
+						cli.StringFlag{Name: "url, u", Usage: "URL of project to download", Required: true},
 						cli.StringFlag{Name: "path, p", Usage: "The path at which to create the new project", Required: true},
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id of PFE which will be used to validate the project", Required: false},
 					},

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -66,8 +66,9 @@ func Commands() {
 					Usage: "Create a project on disk",
 
 					Flags: []cli.Flag{
-						cli.StringFlag{Name: "url, u", Usage: "URL of project to download"},
+						cli.StringFlag{Name: "url, u", Usage: "URL of project to download", Required: false},
 						cli.StringFlag{Name: "path, p", Usage: "The path at which to create the new project", Required: true},
+						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id of PFE which will be used to validate the project", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						ProjectCreate(c)

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -38,10 +38,10 @@ func ProjectValidate(c *cli.Context) {
 	os.Exit(0)
 }
 
-// ProjectCreate : Downloads template and creates a new project
+// ProjectCreate : Downloads template, create a new project then validate it
 func ProjectCreate(c *cli.Context) {
-	destination := c.String("p")
-	url := c.String("u")
+	destination := c.String("path")
+	url := c.String("url")
 	result, err := project.DownloadTemplate(destination, url)
 	if err != nil {
 		HandleProjectError(err)
@@ -49,11 +49,11 @@ func ProjectCreate(c *cli.Context) {
 	}
 	if printAsJSON {
 		jsonResponse, _ := json.Marshal(result)
-		fmt.Println(string(jsonResponse))
+		logr.Tracef(string(jsonResponse))
 	} else {
-		fmt.Println("Project downloaded to " + destination)
+		logr.Tracef("Project downloaded to %v", destination)
 	}
-	os.Exit(0)
+	ProjectValidate(c)
 }
 
 // ProjectSync : Does a project Sync

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/eclipse/codewind-installer/pkg/errors"
 	"github.com/google/go-github/github"
+	logr "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -157,7 +158,7 @@ func DownloadFile(URL, destination string) error {
 
 	// Write body to file
 	_, err = io.Copy(file, resp.Body)
-	log.Printf("Downloaded file from '%s' to '%s'\n", URL, destination)
+	logr.Tracef("Downloaded file from '%s' to '%s'\n", URL, destination)
 
 	return err
 }
@@ -204,7 +205,7 @@ func UnZip(filePath, destination string) error {
 			errors.CheckErr(err, 404, "")
 		}
 	}
-	log.Printf("Extracted file from '%s' to '%s'\n", filePath, destination)
+	logr.Tracef("Extracted file from '%s' to '%s'\n", filePath, destination)
 	return nil
 }
 


### PR DESCRIPTION
# Problem 
 .cw-settings is missing from newly created projects as seen in #1829

## Solution
Run project validate after project bind

## Extras
Mute unnecessary logging output by moving it to trace only
Added --conid option to project create since this will allow the project validator to use a remote PFE rather than local only

## Output

```
cwctl project create --path /Users/mark/Desktop/mc-node-app95 -u https://github.com/microclimate-dev2ops/nodeExpressTemplate 
{"status":"success","projectPath":"/Users/mark/Desktop/mc-node-app95","result":{"language":"javascript","projectType":"nodejs"}}
```

with remote using (conid) and verbose trace

```
cwctl --insecure --loglevel trace project create --path /Users/gb025216/Desktop/mc-node-app97 -u https://github.com/microclimate-dev2ops/nodeExpressTemplate --conid K5QJ455U
TRAC[0001] Downloaded file from 'https://codeload.github.com/microclimate-dev2ops/nodeExpressTemplate/legacy.zip/master' to '/var/folders/1z/xj1r_g7x3rsbfb8xkph31d1m0000gn/T/_2020-01-23T09-25-11Z.zip' 
TRAC[0001] Extracted file from '/var/folders/1z/xj1r_g7x3rsbfb8xkph31d1m0000gn/T/_2020-01-23T09-25-11Z.zip' to '/Users/mark/Desktop/mc-node-app97' 
TRAC[0001] Project downloaded to /Users/mark/Desktop/mc-node-app97 
TRAC[0001] Request URL: GET https://codewind-gatekeeper-k5mkppep.apps.mycluster.1.2.3.4.nip.io/api/v1/extensions 
TRAC[0001] Getting Connection: K5QJ455U                 
TRAC[0001] Retrieving an access token from the keychain 
TRAC[0001] Access token found in keychain, trying request 
TRAC[0001] Received HTTP Status code: 200               
TRAC[0001] Request URL: GET https://codewind-gatekeeper-k5mkppep.apps.mycluster.1.2.3.4.nip.io/api/v1/ignoredPaths?projectType=nodejs 
TRAC[0001] Getting Connection: K5QJ455U                 
TRAC[0001] Retrieving an access token from the keychain 
TRAC[0001] Access token found in keychain, trying request 
TRAC[0002] Received HTTP Status code: 200               
{"status":"success","projectPath":"/Users/mark/Desktop/mc-node-app97","result":{"language":"javascript","projectType":"nodejs"}}
```



## All existing tests pass: 

```
=== RUN   TestDetermineProjectInfo
=== RUN   TestDetermineProjectInfo/success_case:_python_project
=== RUN   TestDetermineProjectInfo/success_case:_go_project
=== RUN   TestDetermineProjectInfo/success_case:_liberty_project
=== RUN   TestDetermineProjectInfo/success_case:_spring_project
=== RUN   TestDetermineProjectInfo/success_case:_node.js_project
=== RUN   TestDetermineProjectInfo/success_case:_swift_project
--- PASS: TestDetermineProjectInfo (0.00s)
    --- PASS: TestDetermineProjectInfo/success_case:_python_project (0.00s)
    --- PASS: TestDetermineProjectInfo/success_case:_go_project (0.00s)
    --- PASS: TestDetermineProjectInfo/success_case:_liberty_project (0.00s)
    --- PASS: TestDetermineProjectInfo/success_case:_spring_project (0.00s)
    --- PASS: TestDetermineProjectInfo/success_case:_node.js_project (0.00s)
    --- PASS: TestDetermineProjectInfo/success_case:_swift_project (0.00s)
=== RUN   TestWriteNewCwSettings
=== RUN   TestWriteNewCwSettings/success_case:_liberty_project
=== RUN   TestWriteNewCwSettings/success_case:_spring_project
=== RUN   TestWriteNewCwSettings/success_case:_swift_project
=== RUN   TestWriteNewCwSettings/success_case:_python_project
=== RUN   TestWriteNewCwSettings/success_case:_go_project
=== RUN   TestWriteNewCwSettings/success_case:_node_project
--- PASS: TestWriteNewCwSettings (0.09s)
    --- PASS: TestWriteNewCwSettings/success_case:_liberty_project (0.02s)
    --- PASS: TestWriteNewCwSettings/success_case:_spring_project (0.02s)
    --- PASS: TestWriteNewCwSettings/success_case:_swift_project (0.01s)
    --- PASS: TestWriteNewCwSettings/success_case:_python_project (0.01s)
    --- PASS: TestWriteNewCwSettings/success_case:_go_project (0.01s)
    --- PASS: TestWriteNewCwSettings/success_case:_node_project (0.01s)
=== RUN   TestGetAll
=== RUN   TestGetAll/Expect_success_-_complete_project_list_should_be_returned
--- PASS: TestGetAll (0.00s)
    --- PASS: TestGetAll/Expect_success_-_complete_project_list_should_be_returned (0.00s)
=== RUN   TestGetProjectFromID
=== RUN   TestGetProjectFromID/Expect_success_-_project_should_be_returned
--- PASS: TestGetProjectFromID (0.00s)
    --- PASS: TestGetProjectFromID/Expect_success_-_project_should_be_returned (0.00s)
=== RUN   TestGetProjectIDFromName
=== RUN   TestGetProjectIDFromName/Expect_success_-_the_correct_ID_should_be_returned
--- PASS: TestGetProjectIDFromName (0.00s)
    --- PASS: TestGetProjectIDFromName/Expect_success_-_the_correct_ID_should_be_returned (0.00s)
=== RUN   Test_ProjectConnection
=== RUN   Test_ProjectConnection/Asserts_project_connection_file_doesn't_exist
=== RUN   Test_ProjectConnection/Asserts_setting_a_default_connection_file_doesn't_fail
=== RUN   Test_ProjectConnection/Asserts_project_connection_file_exists
=== RUN   Test_ProjectConnection/Asserts_project_defaults_to_local_connection
=== RUN   Test_ProjectConnection/Asserts_a_new_connectionID_can_be_set
=== RUN   Test_ProjectConnection/Asserts_the_correct_connection_has_been_added
=== RUN   Test_ProjectConnection/Asserts_resetting_the_connection_is_successful
=== RUN   Test_ProjectConnection/Asserts_connection_is_reset_to_local
=== RUN   Test_ProjectConnection/Asserts_attempting_to_set_an_invalid_project_ID_fails
=== RUN   Test_ProjectConnection/Asserts_the_connection_file_can_be_removed
=== RUN   Test_ProjectConnection/Asserts_the_connection_file_has_been_removed
--- PASS: Test_ProjectConnection (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_project_connection_file_doesn't_exist (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_setting_a_default_connection_file_doesn't_fail (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_project_connection_file_exists (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_project_defaults_to_local_connection (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_a_new_connectionID_can_be_set (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_the_correct_connection_has_been_added (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_resetting_the_connection_is_successful (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_connection_is_reset_to_local (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_attempting_to_set_an_invalid_project_ID_fails (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_the_connection_file_can_be_removed (0.00s)
    --- PASS: Test_ProjectConnection/Asserts_the_connection_file_has_been_removed (0.00s)
=== RUN   TestIgnoreFileOrDirectory
=== RUN   TestIgnoreFileOrDirectory/success_case:_directory_called_node_modules_should_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_directory_called_load-test-23498729_should_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_directory_called_not-a-load-test-23498729_should_not_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_file_called_.DS_Store_should_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_file_called_node_modules_should_not_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_directory_called_noddy_modules_should_not_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_file_called_something.swp_should_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_file_called_something.swpnot_should_not_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_directory_called_.DS_Store_should_not_be_ignored
=== RUN   TestIgnoreFileOrDirectory/success_case:_path_containing_noddy_modules_should_be_ignored_as_it_is_in_.cw-settings
--- PASS: TestIgnoreFileOrDirectory (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_directory_called_node_modules_should_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_directory_called_load-test-23498729_should_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_directory_called_not-a-load-test-23498729_should_not_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_file_called_.DS_Store_should_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_file_called_node_modules_should_not_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_directory_called_noddy_modules_should_not_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_file_called_something.swp_should_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_file_called_something.swpnot_should_not_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_directory_called_.DS_Store_should_not_be_ignored (0.00s)
    --- PASS: TestIgnoreFileOrDirectory/success_case:_path_containing_noddy_modules_should_be_ignored_as_it_is_in_.cw-settings (0.00s)
=== RUN   TestRetrieveIgnoredPathsList
=== RUN   TestRetrieveIgnoredPathsList/success_case:_calling_on_a_path_that_doesn't_exist_should_return_nil_with_a_length_0
=== RUN   TestRetrieveIgnoredPathsList/success_case:_calling_on_a_path_that_does_exist_but_isn't_valid_JSON
=== RUN   TestRetrieveIgnoredPathsList/success_case:_the_returned_ignoredPaths_list_should_contain_testfile_and_anothertestfile
=== RUN   TestRetrieveIgnoredPathsList/success_case:_the_returned_ignoredPaths_list_should_be_empty
=== RUN   TestRetrieveIgnoredPathsList/success_case:_calling_on_a_path_that_does_exist_and_is_valid_JSON_but_doesn't_contain_ignoredPaths
--- PASS: TestRetrieveIgnoredPathsList (0.00s)
    --- PASS: TestRetrieveIgnoredPathsList/success_case:_calling_on_a_path_that_doesn't_exist_should_return_nil_with_a_length_0 (0.00s)
    --- PASS: TestRetrieveIgnoredPathsList/success_case:_calling_on_a_path_that_does_exist_but_isn't_valid_JSON (0.00s)
    --- PASS: TestRetrieveIgnoredPathsList/success_case:_the_returned_ignoredPaths_list_should_contain_testfile_and_anothertestfile (0.00s)
    --- PASS: TestRetrieveIgnoredPathsList/success_case:_the_returned_ignoredPaths_list_should_be_empty (0.00s)
    --- PASS: TestRetrieveIgnoredPathsList/success_case:_calling_on_a_path_that_does_exist_and_is_valid_JSON_but_doesn't_contain_ignoredPaths (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/pkg/project       0.319s
```

Validated plugin in VSCode is still able to create a project and confirmed the .cw-settings file exists after creation:


![image](https://user-images.githubusercontent.com/28102564/72970660-02e81200-3dc0-11ea-913d-cf6d31914bbc.png)
 

