### PR TITLE
display docker compose error if returned

### DIFF
--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -56,7 +56,11 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 		}
 	}
 
-	utils.DockerComposeRemove(dockerComposeFile, tag)
+	dockerErr := utils.DockerComposeRemove(dockerComposeFile, tag)
+	if dockerErr != nil {
+		HandleDockerError(dockerErr)
+		os.Exit(1)
+	}
 }
 
 // DoRemoteRemove : Delete a remote Codewind deployment

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -27,7 +27,11 @@ func StopAllCommand(c *cli.Context, dockerComposeFile string) {
 		HandleDockerError(err)
 		os.Exit(1)
 	}
-	utils.DockerComposeStop(tag, dockerComposeFile)
+	dockerErr := utils.DockerComposeStop(tag, dockerComposeFile)
+	if dockerErr != nil {
+		HandleDockerError(dockerErr)
+		os.Exit(1)
+	}
 
 	fmt.Println("Stopping Project containers")
 	containersToRemove := utils.GetContainersToRemove(containers)


### PR DESCRIPTION
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>

# Description of pull request
A docker-compose error will be returned if the functions `DockerComposeRemove`/ `DockerComposeStop` fail. This is good but it is not caught at the top of the call stack - It gives a "silent failure".

## Solution
1) check for the output request i.e JSON vs not JSON
2) print the error out
3) exit with error code 1 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
1) Bats output - `18 tests, 0 failures, 6 skipped`
2) `remove` failure output:
```
Please wait whilst images are removed...  
{"error":"IMAGE_REMOVE_ERROR","error_description":"exit status 1"}
``` 
3) `stop-all` failure output:
```
Please wait while containers shutdown...  
{"error":"DOCKER_COMPOSE_STOP_ERROR","error_description":"exit status 1"}
```

## Checklist

- [x] I have commented my code where needed
- [N/A] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [N/A] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
