### PR TITLE
Fix ignored path tests

### DIFF
--- a/pkg/apiroutes/ignored-paths.go
+++ b/pkg/apiroutes/ignored-paths.go
@@ -17,7 +17,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
@@ -27,15 +26,8 @@ import (
 type IgnoredPaths []string
 
 // GetIgnoredPaths calls pfe to get the default ignoredPaths for that projectType
-func GetIgnoredPaths(conID, projectType string, httpClient utils.HTTPClient) (IgnoredPaths, error) {
-	conInfo, conInfoErr := connections.GetConnectionByID(conID)
-	if conInfoErr != nil {
-		return nil, conInfoErr.Err
-	}
-	conURL, conErr := config.PFEOriginFromConnection(conInfo)
-	if conErr != nil {
-		return nil, conErr.Err
-	}
+func GetIgnoredPaths(httpClient utils.HTTPClient, connection *connections.Connection, projectType string, conURL string) (IgnoredPaths, error) {
+
 	req, err := http.NewRequest("GET", conURL+"/api/v1/ignoredPaths", nil)
 	if err != nil {
 		return nil, err
@@ -44,8 +36,8 @@ func GetIgnoredPaths(conID, projectType string, httpClient utils.HTTPClient) (Ig
 	q := req.URL.Query()
 	q.Add("projectType", projectType)
 	req.URL.RawQuery = q.Encode()
-	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
+
+	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, connection)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}

--- a/pkg/apiroutes/ignored-paths_test.go
+++ b/pkg/apiroutes/ignored-paths_test.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/security"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,16 +31,18 @@ func Test_IgnoredPaths(t *testing.T) {
 			t.Fail()
 		}
 		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
-		mockClientTrue := &MockResponse{StatusCode: http.StatusOK, Body: body}
-		gotIgnoredPaths, err := GetIgnoredPaths("local", "nodejs", mockClientTrue)
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		mockConnection := connections.Connection{ID: "local"}
+		gotIgnoredPaths, err := GetIgnoredPaths(mockClient, &mockConnection, "nodejs", "dummyurl")
 		if err != nil {
 			t.Fail()
 		}
 		assert.Equal(t, testIgnoredPaths, gotIgnoredPaths)
 	})
 	t.Run("Asserts 400 response from PFE returns an error", func(t *testing.T) {
-		mockClientFalse := &MockResponse{StatusCode: http.StatusNotFound, Body: nil}
-		_, err := GetIgnoredPaths("local", "nodejs", mockClientFalse)
+		mockConnection := connections.Connection{ID: "local"}
+		mockClientFalse := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: nil}
+		_, err := GetIgnoredPaths(mockClientFalse, &mockConnection, "nodejs", "dummyurl")
 		if err == nil {
 			t.Fail()
 		}

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -153,6 +153,10 @@ func ValidateProject(c *cli.Context) (*ValidationResponse, *ProjectError) {
 	}
 
 	extensionType, err := checkIsExtension(conID, projectPath, c)
+	if err != nil {
+		return nil, &ProjectError{errOpCreateProject, err, err.Error()}
+	}
+
 	if extensionType != "" {
 		if err == nil {
 			validationResult = ProjectType{
@@ -169,10 +173,6 @@ func ValidateProject(c *cli.Context) (*ValidationResponse, *ProjectError) {
 		Status: validationStatus,
 		Path:   projectPath,
 		Result: validationResult,
-	}
-
-	if err != nil {
-		return nil, &ProjectError{errOpCreateProject, err, err.Error()}
 	}
 
 	// write settings file only for non-extension projects

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -23,6 +23,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/eclipse/codewind-installer/pkg/connections"
+
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/urfave/cli"
@@ -325,7 +327,23 @@ func writeNewCwSettings(conID string, pathToCwSettings string, BuildType string)
 
 func getDefaultCwSettings(conID string, BuildType string) CWSettings {
 	client := &http.Client{}
-	IgnoredPaths, err := apiroutes.GetIgnoredPaths(conID, BuildType, client)
+
+	// return errors in here
+	connection, conErr := connections.GetConnectionByID(conID)
+	if conErr != nil {
+		fmt.Println(conErr)
+		os.Exit(1)
+	}
+
+	fmt.Println(connection)
+
+	conURL, conErr2 := config.PFEOriginFromConnection(connection)
+	if conErr2 != nil {
+		fmt.Println(conErr2)
+		os.Exit(1)
+	}
+
+	IgnoredPaths, err := apiroutes.GetIgnoredPaths(client, connection, BuildType, conURL)
 	if err != nil {
 		// If error getting the default ignoredPaths, set as empty slice
 		IgnoredPaths = []string{}


### PR DESCRIPTION
# Description of pull request

Fixes broken ignoredPaths tests, which have been so since the move to `sechttp` requests with remote. 

## Solution

Refactors the function to accept a client as a parameter, and passing in a mock-client in the tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant information of your test configuration or test you have added to support this change -->
Relevant tests pass locally. 

Relevant commands (`project validate` and `project create`) function as expected.

## Checklist

- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines