### PR TITLE
fix apiroutes template tests

### DIFF
--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -84,7 +84,7 @@ func TestGetTemplates(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := GetTemplates("local", test.inProjectStyle, test.inShowEnabledOnly)
 			assert.IsType(t, test.wantedType, got)
-			assert.Equal(t, test.wantedLength, len(got))
+			assert.True(t, len(got) >= test.wantedLength)
 			assert.Nil(t, err)
 		})
 	}
@@ -125,7 +125,7 @@ func TestGetTemplateRepos(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := GetTemplateRepos("local")
 			assert.IsType(t, test.wantedType, got)
-			assert.Equal(t, test.wantedLength, len(got))
+			assert.True(t, len(got) >= test.wantedLength)
 			assert.Equal(t, test.wantedErr, err)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

# Description of pull request

Fixes https://github.com/eclipse/codewind/issues/1887 (issue)

The tests were broken, as the assertion was against the expected number of filtered templates, based on the original defaults. 

## Solution
<!-- Please include a summary of the change and how it addresses the issue -->

This changes that to check if the returned number is greater than this value. Similar to the change that was made in the PFE tests.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant information of your test configuration or test you have added to support this change -->

## Checklist

- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
