### PR TITLE
fix upgrade test

### DIFF
--- a/pkg/project/upgrade.go
+++ b/pkg/project/upgrade.go
@@ -48,6 +48,13 @@ func UpgradeProjects(oldDir string) (*map[string]interface{}, *ProjectError) {
 			if err != nil {
 				return nil
 			}
+
+			// only read .inf files
+			extension := filepath.Ext(path)
+			if extension != ".inf" {
+				return nil
+			}
+
 			var result map[string]string
 			json.Unmarshal([]byte(file), &result)
 

--- a/pkg/project/upgrade_test.go
+++ b/pkg/project/upgrade_test.go
@@ -74,7 +74,7 @@ func Test_UpgradeProjects(t *testing.T) {
 					expectedOutput: &validOuput,
 				},
 		*/
-		"success case: reports failed upgrade when project inf is mnissing information": {
+		"success case: reports failed upgrade when project inf is missing information": {
 			workspaceDir:   "/error-projects/missing-project-info",
 			expectsErr:     false,
 			expectedOutput: &missingInfoOutput,

--- a/resources/workspaces/empty/.projects/.emptydir
+++ b/resources/workspaces/empty/.projects/.emptydir
@@ -1,0 +1,3 @@
+# Ignore everything in this directory
+
+# We need a file to add to git


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

# Description of pull request

Fixes an upgrade test, which was broken as the empty directory it relied upon  was not added to git `resources/workspaces/empty/.projects/.emptydir`).

Fixes https://github.com/eclipse/codewind/issues/1886 (issue)

## Solution
<!-- Please include a summary of the change and how it addresses the issue -->

Adds an ignored file in this resources dir, so that it can be added into the git repo. `.

Update: Adds check for whether projects are `.inf` type, and doesn't attempt migration if not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant information of your test configuration or test you have added to support this change -->

## Checklist

- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
