### PR TITLE
add unit tests for project bind

### DIFF
--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -113,7 +113,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 	_, _, _, uploadedFilesList, syncErr := syncFiles(projectPath, projectID, conURL, 0, conInfo)
 
 	// Call bind/end to complete
-	completeStatus, completeStatusCode := completeBind(projectID, conURL, conInfo)
+	completeStatus, completeStatusCode := completeBind(client, projectID, conURL, conInfo)
 	response := BindResponse{
 		ProjectID:     projectID,
 		UploadedFiles: uploadedFilesList,
@@ -165,7 +165,7 @@ func bindToPFE(client utils.HTTPClient, bindRequest BindRequest, conInfo *connec
 	return projectInfo, nil
 }
 
-func completeBind(projectID string, conURL string, connection *connections.Connection) (string, int) {
+func completeBind(client utils.HTTPClient, projectID string, conURL string, connection *connections.Connection) (string, int) {
 	bindEndURL := conURL + "/api/v1/projects/" + projectID + "/bind/end"
 
 	payload := &BindEndRequest{ProjectID: projectID}
@@ -174,7 +174,7 @@ func completeBind(projectID string, conURL string, connection *connections.Conne
 	// Make the request to end the sync process.
 	request, err := http.NewRequest("POST", bindEndURL, bytes.NewBuffer(jsonPayload))
 	request.Header.Set("Content-Type", "application/json")
-	resp, httpSecError := sechttp.DispatchHTTPRequest(http.DefaultClient, request, connection)
+	resp, httpSecError := sechttp.DispatchHTTPRequest(client, request, connection)
 
 	if httpSecError != nil {
 		logr.Errorln(err)

--- a/pkg/project/bind_test.go
+++ b/pkg/project/bind_test.go
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package project
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/security"
+)
+
+func TestBindToPFE(t *testing.T) {
+	creationTime := time.Now().UnixNano() / 100000
+
+	exampleBindRequest := BindRequest{
+		Language:    "javascript",
+		Name:        "test",
+		ProjectType: "nodejs",
+		Path:        "examplePath",
+		Time:        creationTime,
+	}
+
+	exampleBindResponse := BindResponse{
+		ProjectID:     "abcd",
+		UploadedFiles: []UploadedFile{},
+		Status:        "success",
+		StatusCode:    http.StatusOK,
+	}
+
+	successTests := map[string]struct {
+		bindRequest  BindRequest
+		bindResponse BindResponse
+	}{
+		"Expect success - project should be bound": {
+			bindRequest:  exampleBindRequest,
+			bindResponse: exampleBindResponse,
+		},
+	}
+	for name, test := range successTests {
+		t.Run(name, func(t *testing.T) {
+			jsonResponse, _ := json.Marshal(test.bindResponse)
+			body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+			mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+			mockConnection := connections.Connection{ID: "local"}
+			got, projErr := bindToPFE(mockClient, test.bindRequest, &mockConnection, "dummyurl")
+			if projErr != nil {
+				t.Errorf("bindToPFE() returned the following error: %s", projErr.Desc)
+			}
+			assert.Equal(t, got, &test.bindResponse)
+		})
+	}
+
+	failureTests := map[string]struct {
+		bindRequest      BindRequest
+		bindResponse     BindResponse
+		mockResponseCode int
+		wantedError      ProjectError
+	}{
+		"Expect failure - API not found": {
+			bindRequest:      exampleBindRequest,
+			mockResponseCode: http.StatusNotFound,
+			wantedError:      ProjectError{errOpResponse, errors.New(textAPINotFound), textAPINotFound},
+		},
+		"Expect failure - bad request": {
+			bindRequest:      exampleBindRequest,
+			mockResponseCode: http.StatusBadRequest,
+			wantedError:      ProjectError{errOpResponse, errors.New(textInvalidType), textInvalidType},
+		},
+		"Expect failure - duplicate name": {
+			bindRequest:      exampleBindRequest,
+			mockResponseCode: http.StatusConflict,
+			wantedError:      ProjectError{errOpResponse, errors.New(textDupName), textDupName},
+		},
+	}
+
+	for name, test := range failureTests {
+		t.Run(name, func(t *testing.T) {
+			mockClient := &security.ClientMockAuthenticate{StatusCode: test.mockResponseCode, Body: nil}
+			mockConnection := connections.Connection{ID: "local"}
+			_, projErr := bindToPFE(mockClient, test.bindRequest, &mockConnection, "dummyurl")
+			if projErr == nil {
+				t.Fail()
+			}
+			assert.Equal(t, test.wantedError, *projErr)
+		})
+	}
+}

--- a/pkg/project/bind_test.go
+++ b/pkg/project/bind_test.go
@@ -102,3 +102,10 @@ func TestBindToPFE(t *testing.T) {
 		})
 	}
 }
+
+func TestCompleteBind(t *testing.T) {
+	mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: nil}
+	mockConnection := connections.Connection{ID: "local"}
+	_, gotStatusCode := completeBind(mockClient, "testID", "dummyURL", &mockConnection)
+	assert.Equal(t, gotStatusCode, http.StatusOK)
+}

--- a/pkg/project/project_utils.go
+++ b/pkg/project/project_utils.go
@@ -28,6 +28,7 @@ type (
 const (
 	errBadPath           = "proj_path" // Invalid path provided
 	errBadType           = "proj_type" // Invalid type provided
+	errOpBind            = "proj_bind"
 	errOpRequest         = "proj_request"
 	errOpResponse        = "proj_response" // Bad response to http
 	errOpFileParse       = "proj_parse"


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

# Description of pull request
 
Part of https://github.com/eclipse/codewind/issues/1896.

## Solution

Adds unit tests for projectBind, mocking PFE API calls to test each relevant return code. 

Refactors the private functions to allow for this injection.

Increases project package test coverage from ~34% to ~40%. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant information of your test configuration or test you have added to support this change -->

Tests all pass. 

Ran bind on local projects, with refactored code. The projects are bound to Codewind.

## Checklist

- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
