### PR TITLE
Make parsing error message friendly

### DIFF
--- a/pkg/gatekeeper/gatekeeper.go
+++ b/pkg/gatekeeper/gatekeeper.go
@@ -13,10 +13,12 @@ package gatekeeper
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/pkg/utils"
+	logr "github.com/sirupsen/logrus"
 )
 
 // GatekeeperEnvironment : Codewind Gatekeeper Environment
@@ -30,7 +32,8 @@ type GatekeeperEnvironment struct {
 func GetGatekeeperEnvironment(httpClient utils.HTTPClient, host string) (*GatekeeperEnvironment, error) {
 
 	// build REST request
-	url := host + "/api/v1/gatekeeper/environment"
+	routePath := "/api/v1/gatekeeper/environment"
+	url := host + routePath
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -53,7 +56,9 @@ func GetGatekeeperEnvironment(httpClient utils.HTTPClient, host string) (*Gateke
 	var environment GatekeeperEnvironment
 	err = json.Unmarshal(byteArray, &environment)
 	if err != nil {
-		return nil, err
+		logr.Trace("Unable to parse response from URL. Bad JSON received: ", err.Error())
+		badJSONErr := errors.New("Bad response received. The URL provided " + host + " should point to the Codewind Gatekeeper service. Check its route " + routePath + " returns valid JSON")
+		return nil, badJSONErr
 	}
 	return &environment, nil
 }

--- a/pkg/gatekeeper/gatekeeper_test.go
+++ b/pkg/gatekeeper/gatekeeper_test.go
@@ -59,3 +59,17 @@ func Test_GetGatekeeperEnvironment(t *testing.T) {
 		assert.Equal(t, "remoteClient", gatekeeperEnv.ClientID)
 	})
 }
+
+func Test_GetGatekeeperEnvironmentBadHost(t *testing.T) {
+	body := ioutil.NopCloser(bytes.NewReader([]byte("<HTML></HTML>")))
+	mockClient := &MockResponse{StatusCode: http.StatusOK, Body: body}
+
+	t.Run("Assert a bad response fails with error", func(t *testing.T) {
+		gatekeeperEnv, err := GetGatekeeperEnvironment(mockClient, "http://noserver.test.com")
+		if err == nil {
+			t.Fail()
+		}
+		assert.Nil(t, gatekeeperEnv)
+	})
+
+}


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

# Description of pull request
If creating a connection to an invalid Gatekeeper service cwctl should provide a friendly error with advice. 

Fixes # 1892

## Solution
Updated error message and troubleshooting steps when the remote service is not Gatekeeper or does not return valid JSON: 

Example : 

```
$ cwctl connections add \
--label somename \
--url https://www.eclipse.org \
--username developer 

ERRO[0001] Bad response received. The URL provided https://www.eclipse.org should point to the Codewind Gatekeeper service. Check its route /api/v1/gatekeeper/environment returns valid JSON 
```

with the --json flag : 

```json
{"error":"con_environment","error_description":"Bad response received. The URL provided https://www.eclipse.org should point to the Codewind Gatekeeper service. Check its route /api/v1/gatekeeper/environment returns valid JSON"}
```

with --loglevel trace an additional line with root cause from Go :

```
TRAC[0001] Unable to parse response from URL. Bad JSON received: invalid character '<' looking for beginning of value 
```

Existing tests pass,  added new test to check for bad non gatekeeper host : 

```
...
...
=== RUN   Test_GetGatekeeperEnvironmentBadHost/Assert_a_bad_response_fails_with_error
--- PASS: Test_GetGatekeeperEnvironmentBadHost (0.00s)
    --- PASS: Test_GetGatekeeperEnvironmentBadHost/Assert_a_bad_response_fails_with_error (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/pkg/gatekeeper    1.499s

```

