### PR TITLE
Check the status code when downloading a file.

### DIFF
--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -52,7 +52,6 @@ type (
 
 // DownloadTemplate using the url/link provided
 func DownloadTemplate(destination string, url string) (*Result, *ProjectError) {
-	checkProjectDirIsEmpty(destination)
 
 	projErr := checkProjectDirIsEmpty(destination)
 	if projErr != nil {

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -35,9 +35,10 @@ func DownloadFromURLThenExtract(URL string, destination string) error {
 // DownloadFromTarGzURL downloads a tar.gz file from a URL
 // and extracts it to a destination
 func DownloadFromTarGzURL(URL string, destination string) error {
-	_ = os.MkdirAll(destination, 0755) // gives User rwx permission, everyone else rx
+	time := time.Now().Format(time.RFC3339)
+	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
+	pathToTempFile := path.Join(os.TempDir(), "_"+time+"temp.tar.gz")
 
-	pathToTempFile := path.Join(destination, "temp.tar.gz")
 	err := DownloadFile(URL, pathToTempFile)
 	if err != nil {
 		return err

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	goErr "errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -147,6 +148,10 @@ func DownloadFile(URL, destination string) error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return goErr.New(fmt.Sprintf("File download failed for %s, status code %d", URL, resp.StatusCode))
+	}
 
 	// Create the file
 	file, err := os.Create(destination)


### PR DESCRIPTION
Signed-off-by: Howard Hellyer <hhellyer@uk.ibm.com>

# Description of pull request

Fixes eclipse/codewind#1350 - the error message being returned was actually the result of trying to extract a file that was either empty or contained the error message returned with the 404 status code for the file that couldn't be found.

## Solution
We checked for errors from `http.Get` - however non-200 are still successful http requests.
This PR adds an additional check of the status code from the `http.Get` call we use to download the project template.

The PR also ensures that tar's file downloads use the same temporary file name format as zip file downloads to prevent the installer creating empty directories and removes an extra call to `checkProjectDirIsEmpty` directly before a second call that actually checks the return values from that function.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant information of your test configuration or test you have added to support this change -->

## Checklist

- [X] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [X] My changes do not generate any new warnings/linter errors
- [ ] If necessary, I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no typos in the code comments or this pull request
- [X] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
