### PR TITLE
cwctl version --all & cwctl version --conid local

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ Subcommands:</br>
 > --id,-i value Project ID
 > --time,-t value Time of last project sync
 
+`list` - List projects bound to a Codewind deployment
+> **Flags**
+> --conid value                 Connection ID
+
+`get` - Get a single project, requires either the project ID or name
+When using a project ID the CLI will automatically detect which connection it relates to
+> **Flags**
+> --id value                    Project ID
+> --name                        Project name
+> --conid                       Connection ID
+
 `connection/con` - Manage the connection targets for a project
 
 `set,s` - Sets the connection for a projectID

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | stop-all    |       | 'Stop all of the Codewind and project containers'                   |
 | remove      | `rm`  | 'Remove Codewind and Project docker images'                         |
 | templates   |       | 'Manage project templates'                                          |
-| version     |       | 'Print the versions of Codewind containers, for a given connection  |
+| version     |       | 'Print the versions of Codewind containers, for a given connection' |
 | sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |
 | secrole     | `sl`  | 'Manage realm based ACCESS roles'                                   |
 | secrealm    | `sr`  | 'Manage new or existing REALM configurations'                       |

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | stop-all    |       | 'Stop all of the Codewind and project containers'                   |
 | remove      | `rm`  | 'Remove Codewind and Project docker images'                         |
 | templates   |       | 'Manage project templates'                                          |
-| version     |       | 'Print the versions of Codewind containers, for a given container'  |
+| version     |       | 'Print the versions of Codewind containers, for a given connection  |
 | sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |
 | secrole     | `sl`  | 'Manage realm based ACCESS roles'                                   |
 | secrealm    | `sr`  | 'Manage new or existing REALM configurations'                       |
@@ -275,6 +275,7 @@ Subcommands:</br>
 
 > **Flags:**
 > --conid value Connection ID (see the connections cmd)
+> --all - Show Container versions for all Codewind connections
 
 ## sectoken
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -865,7 +865,8 @@ func Commands() {
 			Aliases: []string{"v"},
 			Usage:   "Get versions of remotely deployed Codewind containers",
 			Flags: []cli.Flag{
-				cli.StringFlag{Name: "conid", Usage: "The connection ID", Required: true},
+				cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection ID", Required: false},
+				cli.BoolFlag{Name: "all, a", Usage: "Get the codewind container versions for all connections", Required: false},
 			},
 			Action: func(c *cli.Context) error {
 				GetVersions(c)

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -863,7 +863,7 @@ func Commands() {
 		{
 			Name:    "version",
 			Aliases: []string{"v"},
-			Usage:   "Get versions of remotely deployed Codewind containers",
+			Usage:   "Get versions of deployed Codewind containers",
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection ID", Required: false},
 				cli.BoolFlag{Name: "all, a", Usage: "Get the codewind container versions for all connections", Required: false},

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -13,6 +13,8 @@ package actions
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
 
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
@@ -76,4 +78,15 @@ func HandleRemInstError(err *remote.RemInstError) {
 	} else {
 		logr.Error(err.Desc)
 	}
+}
+
+// PrintTable prints a formatted table into the terminal
+func PrintTable(content []string) {
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 0, 8, 2, '\t', 0)
+	for _, line := range content {
+		fmt.Fprintln(w, line)
+	}
+	fmt.Fprintln(w)
+	w.Flush()
 }

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -12,7 +12,6 @@
 package actions
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/utils"
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
 	"github.com/eclipse/codewind-installer/pkg/remote"
@@ -61,8 +61,7 @@ func GetSingleConnectionVersion(c *cli.Context) {
 	}
 
 	if printAsJSON {
-		json, _ := json.Marshal(containerVersions)
-		fmt.Println(string(json))
+		utils.PrettyPrintJSON(containerVersions)
 	} else {
 		var tableContent []string
 		tableContent = append(tableContent, "CWCTL VERSION: "+containerVersions.CwctlVersion+"\n")
@@ -88,8 +87,7 @@ func GetAllConnectionVersions() {
 	}
 
 	if printAsJSON {
-		json, _ := json.Marshal(containerVersionsList)
-		fmt.Println(string(json))
+		utils.PrettyPrintJSON(containerVersionsList)
 	} else {
 		var tableContent []string
 		tableContent = append(tableContent, "CWCTL VERSION: "+containerVersionsList.CwctlVersion+"\n")
@@ -97,15 +95,14 @@ func GetAllConnectionVersions() {
 		for conID, con := range containerVersionsList.Connections {
 			tableContent = append(tableContent, conID+"\t"+con.PFEVersion+"\t"+con.PerformanceVersion+"\t"+con.GatekeeperVersion)
 		}
-
-		if len(containerVersionsList.ConnectionErrors) > 0 {
+		numConErrs := len(containerVersionsList.ConnectionErrors)
+		if numConErrs > 0 {
 			tableContent = append(tableContent, "\nSOME ERRORS WHILE DETECTING CONNECTION VERSIONS")
 			tableContent = append(tableContent, "CONNECTION ID \tERROR")
 			for conID, conErr := range containerVersionsList.ConnectionErrors {
 				tableContent = append(tableContent, conID+"\t"+conErr.Error())
 			}
 		}
-
 		PrintTable(tableContent)
 	}
 }

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -37,6 +37,7 @@ func GetVersions(c *cli.Context) {
 	}
 }
 
+// GetSingleConnectionVersion : Gets the cwctl and container versions for a single connection
 func GetSingleConnectionVersion(c *cli.Context) {
 	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	containerVersions, err := apiroutes.GetContainerVersions(connectionID, appconstants.VersionNum, http.DefaultClient)
@@ -58,6 +59,7 @@ func GetSingleConnectionVersion(c *cli.Context) {
 	}
 }
 
+// GetAllConnectionVersions : Gets the cwctl and container versions for all connections
 func GetAllConnectionVersions() {
 	connections, getConnectionsErr := connections.GetAllConnectionIDs()
 	if getConnectionsErr != nil {

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -12,6 +12,7 @@
 package actions
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -21,18 +22,64 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
 	"github.com/eclipse/codewind-installer/pkg/remote"
 	"github.com/eclipse/codewind-installer/pkg/utils"
+
+	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	"github.com/urfave/cli"
 )
 
 // GetVersions : Gets versions of Codewind containers
 func GetVersions(c *cli.Context) {
+	if c.Bool("all") {
+		GetAllConnectionVersions()
+	} else {
+		GetSingleConnectionVersion(c)
+	}
+}
+
+func GetSingleConnectionVersion(c *cli.Context) {
 	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	containerVersions, err := apiroutes.GetContainerVersions(connectionID, http.DefaultClient)
+	containerVersions, err := apiroutes.GetContainerVersions(connectionID, appconstants.VersionNum, http.DefaultClient)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-	utils.PrettyPrintJSON(containerVersions)
+
+	if printAsJSON {
+		json, _ := json.Marshal(containerVersions)
+		fmt.Println(string(json))
+	} else {
+		w := new(tabwriter.Writer)
+		w.Init(os.Stdout, 0, 8, 2, '\t', 0)
+		fmt.Fprintln(w, "CWCTL VERSION: "+containerVersions.CwctlVersion+"\n")
+		fmt.Fprintln(w, "CONNECTION ID \tPFE VERSION\tPERFORMANCE VERSION\tGATEKEEPER VERSION")
+		fmt.Fprintln(w, containerVersions.CwctlVersion+"\t"+containerVersions.PFEVersion+"\t"+containerVersions.PerformanceVersion+"\t"+containerVersions.GatekeeperVersion)
+		fmt.Fprintln(w)
+		w.Flush()
+	}
+}
+
+func GetAllConnectionVersions() {
+	conns := []string{"local", "K5DWSFUO"}
+	ContainerVersionsList, err := apiroutes.GetAllContainerVersions(conns, appconstants.VersionNum, http.DefaultClient)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	if printAsJSON {
+		json, _ := json.Marshal(ContainerVersionsList)
+		fmt.Println(string(json))
+	} else {
+		w := new(tabwriter.Writer)
+		w.Init(os.Stdout, 0, 8, 2, '\t', 0)
+		fmt.Fprintln(w, "CWCTL VERSION: "+ContainerVersionsList.CwctlVersion+"\n")
+		fmt.Fprintln(w, "CONNECTION ID \tPFE VERSION\tPERFORMANCE VERSION\tGATEKEEPER VERSION")
+		for conID, con := range ContainerVersionsList.Connections {
+			fmt.Fprintln(w, conID+"\t"+con.PFEVersion+"\t"+con.PerformanceVersion+"\t"+con.GatekeeperVersion)
+		}
+		fmt.Fprintln(w)
+		w.Flush()
+	}
 }
 
 // RemoteListAll prints information for all remote installations in the given namespace

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -16,16 +16,13 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
-	"github.com/eclipse/codewind-installer/pkg/utils"
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
 	"github.com/eclipse/codewind-installer/pkg/remote"
-	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/urfave/cli"
 )
 
@@ -61,7 +58,7 @@ func GetSingleConnectionVersion(c *cli.Context) {
 	}
 
 	if printAsJSON {
-		utils.PrettyPrintJSON(containerVersions)
+		PrettyPrintJSON(containerVersions)
 	} else {
 		var tableContent []string
 		tableContent = append(tableContent, "CWCTL VERSION: "+containerVersions.CwctlVersion+"\n")
@@ -87,7 +84,7 @@ func GetAllConnectionVersions() {
 	}
 
 	if printAsJSON {
-		utils.PrettyPrintJSON(containerVersionsList)
+		PrettyPrintJSON(containerVersionsList)
 	} else {
 		var tableContent []string
 		tableContent = append(tableContent, "CWCTL VERSION: "+containerVersionsList.CwctlVersion+"\n")
@@ -116,16 +113,14 @@ func RemoteListAll(c *cli.Context) {
 		os.Exit(1)
 	}
 	if printAsJSON {
-		utils.PrettyPrintJSON(remoteInstalls)
+		PrettyPrintJSON(remoteInstalls)
 	} else {
-		w := new(tabwriter.Writer)
-		w.Init(os.Stdout, 0, 8, 2, '\t', 0)
-		fmt.Fprintln(w, "Workspace ID \tNamespace \tVersion \tInstall Date \tAuth Realm \tURL")
+		var tableContent []string
+		tableContent = append(tableContent, "Workspace ID \tNamespace \tVersion \tInstall Date \tAuth Realm \tURL")
 		for _, install := range remoteInstalls {
-			fmt.Fprintln(w, install.WorkspaceID+"\t"+install.Namespace+"\t"+install.Version+"\t"+install.InstallDate+"\t"+install.CodewindAuthRealm+"\t"+install.CodewindURL)
+			tableContent = append(tableContent, install.WorkspaceID+"\t"+install.Namespace+"\t"+install.Version+"\t"+install.InstallDate+"\t"+install.CodewindAuthRealm+"\t"+install.CodewindURL)
 		}
-		fmt.Fprintln(w)
-		w.Flush()
+		PrintTable(tableContent)
 	}
 	os.Exit(0)
 }

--- a/pkg/apiroutes/test_utils.go
+++ b/pkg/apiroutes/test_utils.go
@@ -12,7 +12,10 @@
 package apiroutes
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -22,10 +25,34 @@ type MockResponse struct {
 	Body       io.ReadCloser
 }
 
+// MockMultipleResponses takes a slice of MockResponses and iterates through them on each request
+// Used when a function makes multiple PFE API requests
+type MockMultipleResponses struct {
+	MockResponses []MockResponse
+	Counter       int
+}
+
 // Do makes a http request
 func (c *MockResponse) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: c.StatusCode,
 		Body:       c.Body,
 	}, nil
+}
+
+// Do makes a http request and increments the MockMultipleResponses counter
+func (c *MockMultipleResponses) Do(req *http.Request) (*http.Response, error) {
+	response := c.MockResponses[c.Counter]
+	c.Counter++
+	return &http.Response{
+		StatusCode: response.StatusCode,
+		Body:       response.Body,
+	}, nil
+}
+
+// CreateMockResponseBody is a helper function that creates a mock JSON response body
+func CreateMockResponseBody(mockResponse interface{}) io.ReadCloser {
+	jsonResponse, _ := json.Marshal(mockResponse)
+	body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+	return body
 }

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -16,19 +16,25 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/eclipse/codewind-installer/pkg/appconstants"
+	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
 
 type (
+	// ContainerVersionsList : sdf
+	ContainerVersionsList struct {
+		CwctlVersion string                       `json:"cwctlVersion"`
+		Connections  map[string]ContainerVersions `json:"connections"`
+	}
+
 	// ContainerVersions : The versions of the Codewind containers that are running
 	ContainerVersions struct {
-		CwctlVersion       string
-		PerformanceVersion string
-		GatekeeperVersion  string
-		PFEVersion         string
+		CwctlVersion       string `json:"cwctlVersion,omitempty"`
+		PerformanceVersion string `json:"performanceVersion"`
+		GatekeeperVersion  string `json:"gatekeeperVersion,omitempty"`
+		PFEVersion         string `json:"PFEVersion"`
 	}
 
 	// EnvResponse : The relevant response fields from the remote environment API
@@ -38,41 +44,70 @@ type (
 	}
 )
 
+// GetAllContainerVersions : Get the versions of each Codewind container for each given connection ID
+func GetAllContainerVersions(conIDList []string, cwctlVersion string, httpClient utils.HTTPClient) (ContainerVersionsList, error) {
+	var containerVersionsList ContainerVersionsList
+	containerVersionsList.CwctlVersion = cwctlVersion
+
+	var connectionVersions = make(map[string]ContainerVersions)
+	for _, conID := range conIDList {
+		containerVersion, containerVersionErr := GetContainerVersions(conID, "", httpClient)
+		if containerVersionErr != nil {
+			return ContainerVersionsList{}, containerVersionErr
+		}
+		connectionVersions[conID] = containerVersion
+	}
+	containerVersionsList.Connections = connectionVersions
+
+	return containerVersionsList, nil
+}
+
 // GetContainerVersions : Get the versions of each Codewind container, for a given connection ID
-func GetContainerVersions(conID string, httpClient utils.HTTPClient) (ContainerVersions, error) {
+func GetContainerVersions(conID, cwctlVersion string, httpClient utils.HTTPClient) (ContainerVersions, error) {
 	conInfo, conInfoErr := connections.GetConnectionByID(conID)
 	if conInfoErr != nil {
 		return ContainerVersions{}, conInfoErr.Err
 	}
 
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		return ContainerVersions{}, conErr.Err
+	}
+
 	var containerVersions ContainerVersions
-	PFEVersion, err := GetPFEVersionFromConnection(conInfo, http.DefaultClient)
+	PFEVersion, err := GetPFEVersionFromConnection(conInfo, conURL, http.DefaultClient)
 	if err != nil {
 		return ContainerVersions{}, err
 	}
 
-	GatekeeperVersion, err := GetGatekeeperVersionFromConnection(conInfo, http.DefaultClient)
+	PerformanceVersion, err := GetPerformanceVersionFromConnection(conInfo, conURL, http.DefaultClient)
 	if err != nil {
 		return ContainerVersions{}, err
 	}
 
-	PerformanceVersion, err := GetPerformanceVersionFromConnection(conInfo, http.DefaultClient)
-	if err != nil {
-		return ContainerVersions{}, err
+	// Add cwctlVersion if it is passed in
+	if cwctlVersion != "" {
+		containerVersions.CwctlVersion = cwctlVersion
 	}
 
-	// Get cwctl version from inside the code
-	containerVersions.CwctlVersion = appconstants.VersionNum
 	containerVersions.PFEVersion = PFEVersion
-	containerVersions.GatekeeperVersion = GatekeeperVersion
 	containerVersions.PerformanceVersion = PerformanceVersion
+
+	if conID != "local" {
+		GatekeeperVersion, err := GetGatekeeperVersionFromConnection(conInfo, http.DefaultClient)
+		if err != nil {
+			return ContainerVersions{}, err
+		}
+
+		containerVersions.GatekeeperVersion = GatekeeperVersion
+	}
 
 	return containerVersions, nil
 }
 
 // GetPFEVersionFromConnection : Get the version of the PFE container, deployed to the connection with the given ID
-func GetPFEVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
-	req, err := http.NewRequest("GET", connection.URL+"/api/v1/environment", nil)
+func GetPFEVersionFromConnection(connection *connections.Connection, url string, HTTPClient utils.HTTPClient) (string, error) {
+	req, err := http.NewRequest("GET", url+"/api/v1/environment", nil)
 	if err != nil {
 		return "", err
 	}
@@ -99,8 +134,8 @@ func GetGatekeeperVersionFromConnection(connection *connections.Connection, HTTP
 }
 
 // GetPerformanceVersionFromConnection : Get the version of the Performance container, deployed to the connection with the given ID
-func GetPerformanceVersionFromConnection(connection *connections.Connection, HTTPClient utils.HTTPClient) (string, error) {
-	req, err := http.NewRequest("GET", connection.URL+"/performance/api/v1/environment", nil)
+func GetPerformanceVersionFromConnection(connection *connections.Connection, url string, HTTPClient utils.HTTPClient) (string, error) {
+	req, err := http.NewRequest("GET", url+"/performance/api/v1/environment", nil)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -49,10 +49,10 @@ type (
 // GetAllContainerVersions : Get the versions of each Codewind container for each given connection ID
 func GetAllContainerVersions(connectionsList []connections.Connection, cwctlVersion string, httpClient utils.HTTPClient) (ContainerVersionsList, error) {
 	var containerVersionsList ContainerVersionsList
-	containerVersionsList.CwctlVersion = cwctlVersion
-
 	var connectionVersions = make(map[string]ContainerVersions)
 	var connectionVersionsErrors = make(map[string]error)
+
+	containerVersionsList.CwctlVersion = cwctlVersion
 
 	for _, connection := range connectionsList {
 		conID := connection.ID
@@ -101,7 +101,6 @@ func GetContainerVersions(conURL, cwctlVersion string, connection *connections.C
 		if GatekeeperVersionErr != nil {
 			return ContainerVersions{}, GatekeeperVersionErr
 		}
-
 		containerVersions.GatekeeperVersion = GatekeeperVersion
 	}
 
@@ -109,8 +108,8 @@ func GetContainerVersions(conURL, cwctlVersion string, connection *connections.C
 }
 
 // GetPFEVersionFromConnection : Get the version of the PFE container, deployed to the connection with the given ID
-func GetPFEVersionFromConnection(connection *connections.Connection, url string, HTTPClient utils.HTTPClient) (string, error) {
-	req, err := http.NewRequest("GET", url+"/api/v1/environment", nil)
+func GetPFEVersionFromConnection(connection *connections.Connection, conURL string, HTTPClient utils.HTTPClient) (string, error) {
+	req, err := http.NewRequest("GET", conURL+"/api/v1/environment", nil)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -25,8 +25,9 @@ import (
 type (
 	// ContainerVersionsList : sdf
 	ContainerVersionsList struct {
-		CwctlVersion string                       `json:"cwctlVersion"`
-		Connections  map[string]ContainerVersions `json:"connections"`
+		CwctlVersion     string                       `json:"cwctlVersion"`
+		Connections      map[string]ContainerVersions `json:"connections"`
+		ConnectionErrors map[string]string            `json:"errors"`
 	}
 
 	// ContainerVersions : The versions of the Codewind containers that are running
@@ -50,14 +51,18 @@ func GetAllContainerVersions(conIDList []string, cwctlVersion string, httpClient
 	containerVersionsList.CwctlVersion = cwctlVersion
 
 	var connectionVersions = make(map[string]ContainerVersions)
+	var connectionVersionsErrors = make(map[string]string)
+
 	for _, conID := range conIDList {
 		containerVersion, containerVersionErr := GetContainerVersions(conID, "", httpClient)
 		if containerVersionErr != nil {
-			return ContainerVersionsList{}, containerVersionErr
+			connectionVersionsErrors[conID] = containerVersionErr.Error()
+		} else {
+			connectionVersions[conID] = containerVersion
 		}
-		connectionVersions[conID] = containerVersion
 	}
 	containerVersionsList.Connections = connectionVersions
+	containerVersionsList.ConnectionErrors = connectionVersionsErrors
 
 	return containerVersionsList, nil
 }

--- a/pkg/apiroutes/version.go
+++ b/pkg/apiroutes/version.go
@@ -23,7 +23,8 @@ import (
 )
 
 type (
-	// ContainerVersionsList : sdf
+	// ContainerVersionsList : The versions of the Codewind containers that are running on all connections
+	// Adds errors into the struct in order to report as many correct versions as possible
 	ContainerVersionsList struct {
 		CwctlVersion     string                       `json:"cwctlVersion"`
 		Connections      map[string]ContainerVersions `json:"connections"`

--- a/pkg/apiroutes/version_test.go
+++ b/pkg/apiroutes/version_test.go
@@ -22,9 +22,9 @@ import (
 
 func Test_GetAllContainerVersions(t *testing.T) {
 	t.Run("Asserts PFE ready", func(t *testing.T) {
-		pfeBody1 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "pfeversion"})
-		performanceBody1 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "performanceversion"})
-		pfeBody2 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "pfeversion2"})
+		pfeBody1 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "1"})
+		performanceBody1 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "2"})
+		pfeBody2 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "3"})
 		performanceBody2 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "nil"})
 
 		mockClient := MockMultipleResponses{
@@ -45,8 +45,8 @@ func Test_GetAllContainerVersions(t *testing.T) {
 		versions, err := GetAllContainerVersions(mockConnections, "latest", &mockClient)
 
 		expectedLocalVersion := ContainerVersions{
-			PFEVersion:         "x.x.dev-pfeversion",
-			PerformanceVersion: "x.x.dev-performanceversion",
+			PFEVersion:         "x.x.dev-1",
+			PerformanceVersion: "x.x.dev-2",
 		}
 
 		assert.Nil(t, err)
@@ -62,8 +62,8 @@ func Test_GetAllContainerVersions(t *testing.T) {
 
 func Test_GetContainerVersions(t *testing.T) {
 	t.Run("Gets the version of cwctl and the PFE, Performance containers when the connection ID = local (no Gatekeeper)", func(t *testing.T) {
-		pfeBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "pfeversion"})
-		performanceBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "performanceversion"})
+		pfeBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "1"})
+		performanceBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "2"})
 
 		mockClient := MockMultipleResponses{
 			Counter: 0,
@@ -79,8 +79,8 @@ func Test_GetContainerVersions(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, "latest", versions.CwctlVersion)
-		assert.Equal(t, "x.x.dev-pfeversion", versions.PFEVersion)
-		assert.Equal(t, "x.x.dev-performanceversion", versions.PerformanceVersion)
+		assert.Equal(t, "x.x.dev-1", versions.PFEVersion)
+		assert.Equal(t, "x.x.dev-2", versions.PerformanceVersion)
 		assert.Empty(t, versions.GatekeeperVersion)
 		// Ensure all mock responses have been used
 		assert.Equal(t, mockClient.Counter, len(mockClient.MockResponses))

--- a/pkg/apiroutes/version_test.go
+++ b/pkg/apiroutes/version_test.go
@@ -85,33 +85,6 @@ func Test_GetContainerVersions(t *testing.T) {
 		// Ensure all mock responses have been used
 		assert.Equal(t, mockClient.Counter, len(mockClient.MockResponses))
 	})
-
-	// t.Run("Gets the version of cwctl and the PFE, Performance and Gatekeeper containers", func(t *testing.T) {
-	// 	pfeBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "20200129-142743"})
-	// 	performanceBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "performanceversion"})
-	// 	gatekeeperBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "gatekeeperversion"})
-
-	// 	mockClient := MockMultipleResponses{
-	// 		Counter: 0,
-	// 		MockResponses: []MockResponse{
-	// 			{StatusCode: http.StatusOK, Body: pfeBody},
-	// 			{StatusCode: http.StatusOK, Body: performanceBody},
-	// 			{StatusCode: http.StatusOK, Body: gatekeeperBody},
-	// 		},
-	// 	}
-
-	// 	mockConnection := connections.Connection{
-	// 		ID: "123",
-	// 	}
-
-	// 	versions, err := GetContainerVersions("www.pfe.com/", "latest", &mockConnection, &mockClient)
-
-	// 	assert.Nil(t, err)
-	// 	assert.Equal(t, "latest", versions.CwctlVersion)
-	// 	assert.Equal(t, "x.x.dev-pfeversion", versions.PFEVersion)
-	// 	assert.Equal(t, "x.x.dev-performanceversion", versions.PerformanceVersion)
-	// 	assert.Equal(t, "x.x.dev-gatekeeperversion", versions.GatekeeperVersion)
-	// })
 }
 
 func Test_GetPFEVersionFromConnection(t *testing.T) {

--- a/pkg/apiroutes/version_test.go
+++ b/pkg/apiroutes/version_test.go
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package apiroutes
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetAllContainerVersions(t *testing.T) {
+	t.Run("Asserts PFE ready", func(t *testing.T) {
+		pfeBody1 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "pfeversion"})
+		performanceBody1 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "performanceversion"})
+		pfeBody2 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "pfeversion2"})
+		performanceBody2 := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "nil"})
+
+		mockClient := MockMultipleResponses{
+			Counter: 0,
+			MockResponses: []MockResponse{
+				{StatusCode: http.StatusOK, Body: pfeBody1},
+				{StatusCode: http.StatusOK, Body: performanceBody1},
+				{StatusCode: http.StatusOK, Body: pfeBody2},
+				{StatusCode: http.StatusOK, Body: performanceBody2},
+			},
+		}
+
+		mockConnections := []connections.Connection{
+			connections.Connection{ID: "local"},
+			connections.Connection{ID: "notlocal"},
+		}
+
+		versions, err := GetAllContainerVersions(mockConnections, "latest", &mockClient)
+
+		expectedLocalVersion := ContainerVersions{
+			PFEVersion:         "x.x.dev-pfeversion",
+			PerformanceVersion: "x.x.dev-performanceversion",
+		}
+
+		assert.Nil(t, err)
+		assert.Equal(t, "latest", versions.CwctlVersion)
+		// Check that local had its version information returned correctly
+		assert.Equal(t, expectedLocalVersion, versions.Connections["local"])
+		assert.Empty(t, versions.Connections["notlocal"])
+		// Check that local didn't error and that notlocal did
+		assert.Nil(t, versions.ConnectionErrors["local"])
+		assert.Error(t, versions.ConnectionErrors["notlocal"])
+	})
+}
+
+func Test_GetContainerVersions(t *testing.T) {
+	t.Run("Gets the version of cwctl and the PFE, Performance containers when the connection ID = local (no Gatekeeper)", func(t *testing.T) {
+		pfeBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "pfeversion"})
+		performanceBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "performanceversion"})
+
+		mockClient := MockMultipleResponses{
+			Counter: 0,
+			MockResponses: []MockResponse{
+				{StatusCode: http.StatusOK, Body: pfeBody},
+				{StatusCode: http.StatusOK, Body: performanceBody},
+			},
+		}
+
+		mockConnection := connections.Connection{ID: "local"}
+
+		versions, err := GetContainerVersions("www.pfe.com/", "latest", &mockConnection, &mockClient)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "latest", versions.CwctlVersion)
+		assert.Equal(t, "x.x.dev-pfeversion", versions.PFEVersion)
+		assert.Equal(t, "x.x.dev-performanceversion", versions.PerformanceVersion)
+		assert.Empty(t, versions.GatekeeperVersion)
+		// Ensure all mock responses have been used
+		assert.Equal(t, mockClient.Counter, len(mockClient.MockResponses))
+	})
+
+	// t.Run("Gets the version of cwctl and the PFE, Performance and Gatekeeper containers", func(t *testing.T) {
+	// 	pfeBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "20200129-142743"})
+	// 	performanceBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "performanceversion"})
+	// 	gatekeeperBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "gatekeeperversion"})
+
+	// 	mockClient := MockMultipleResponses{
+	// 		Counter: 0,
+	// 		MockResponses: []MockResponse{
+	// 			{StatusCode: http.StatusOK, Body: pfeBody},
+	// 			{StatusCode: http.StatusOK, Body: performanceBody},
+	// 			{StatusCode: http.StatusOK, Body: gatekeeperBody},
+	// 		},
+	// 	}
+
+	// 	mockConnection := connections.Connection{
+	// 		ID: "123",
+	// 	}
+
+	// 	versions, err := GetContainerVersions("www.pfe.com/", "latest", &mockConnection, &mockClient)
+
+	// 	assert.Nil(t, err)
+	// 	assert.Equal(t, "latest", versions.CwctlVersion)
+	// 	assert.Equal(t, "x.x.dev-pfeversion", versions.PFEVersion)
+	// 	assert.Equal(t, "x.x.dev-performanceversion", versions.PerformanceVersion)
+	// 	assert.Equal(t, "x.x.dev-gatekeeperversion", versions.GatekeeperVersion)
+	// })
+}
+
+func Test_GetPFEVersionFromConnection(t *testing.T) {
+	t.Run("Gets the version of the PFE container with a mocked httpClient", func(t *testing.T) {
+		mockBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "20200129-142743"})
+		mockClient := MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{ID: "local"}
+
+		version, err := GetPFEVersionFromConnection(&mockConnection, "www.pfe.com/", &mockClient)
+		assert.Nil(t, err)
+		assert.Equal(t, "x.x.dev-20200129-142743", version)
+	})
+
+	t.Run("Errors as the response body is not JSON", func(t *testing.T) {
+		mockBody := ioutil.NopCloser(strings.NewReader("bad res }}}"))
+		mockClient := MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{ID: "local"}
+
+		version, err := GetPFEVersionFromConnection(&mockConnection, "www.pfe.com/performance", &mockClient)
+		assert.Error(t, err)
+		assert.Empty(t, version)
+	})
+}
+
+func Test_GetGatekeeperVersionFromConnection(t *testing.T) {
+	t.Run("Gets the version of the Gatekeeper container with a mocked httpClient", func(t *testing.T) {
+		mockBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "20200129-142743"})
+		mockClient := MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{ID: "local"}
+
+		version, err := GetGatekeeperVersionFromConnection(&mockConnection, "www.pfe.com/gatekeeper", &mockClient)
+		assert.Nil(t, err)
+		assert.Equal(t, "x.x.dev-20200129-142743", version)
+	})
+
+	t.Run("Errors as the response body is not JSON", func(t *testing.T) {
+		mockBody := ioutil.NopCloser(strings.NewReader("bad res }}}"))
+		mockClient := MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{ID: "local"}
+
+		version, err := GetGatekeeperVersionFromConnection(&mockConnection, "www.pfe.com/performance", &mockClient)
+		assert.Error(t, err)
+		assert.Empty(t, version)
+	})
+}
+
+func Test_GetPerformanceVersionFromConnection(t *testing.T) {
+	t.Run("Gets the version of the Performance container with a mocked httpClient", func(t *testing.T) {
+		mockBody := CreateMockResponseBody(EnvResponse{Version: "x.x.dev", ImageBuildTime: "20200129-142743"})
+		mockClient := MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{ID: "local"}
+
+		version, err := GetPerformanceVersionFromConnection(&mockConnection, "www.pfe.com/performance", &mockClient)
+		assert.Nil(t, err)
+		assert.Equal(t, "x.x.dev-20200129-142743", version)
+	})
+
+	t.Run("Errors as the response body is not JSON", func(t *testing.T) {
+		mockBody := ioutil.NopCloser(strings.NewReader("bad res }}}"))
+		mockClient := MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{ID: "local"}
+
+		version, err := GetPerformanceVersionFromConnection(&mockConnection, "www.pfe.com/performance", &mockClient)
+		assert.Error(t, err)
+		assert.Empty(t, version)
+	})
+}

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -269,6 +269,20 @@ func GetAllConnections() ([]Connection, *ConError) {
 	return nil, &ConError{errOpNotFound, err, err.Error()}
 }
 
+// GetAllConnectionIDs : Retrieve all saved connections and return their IDs
+func GetAllConnectionIDs() ([]string, *ConError) {
+	var connectionIDs []string
+	connections, getConErr := GetAllConnections()
+	if getConErr != nil {
+		return nil, getConErr
+	}
+
+	for _, con := range connections {
+		connectionIDs = append(connectionIDs, con.ID)
+	}
+	return connectionIDs, nil
+}
+
 // loadConnectionsConfigFile : Load the connections configuration file from disk
 // and returns the contents of the file or an error
 func loadConnectionsConfigFile() (*ConnectionConfig, *ConError) {

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -269,20 +269,6 @@ func GetAllConnections() ([]Connection, *ConError) {
 	return nil, &ConError{errOpNotFound, err, err.Error()}
 }
 
-// GetAllConnectionIDs : Retrieve all saved connections and return their IDs
-func GetAllConnectionIDs() ([]string, *ConError) {
-	var connectionIDs []string
-	connections, getConErr := GetAllConnections()
-	if getConErr != nil {
-		return nil, getConErr
-	}
-
-	for _, con := range connections {
-		connectionIDs = append(connectionIDs, con.ID)
-	}
-	return connectionIDs, nil
-}
-
 // loadConnectionsConfigFile : Load the connections configuration file from disk
 // and returns the contents of the file or an error
 func loadConnectionsConfigFile() (*ConnectionConfig, *ConError) {

--- a/pkg/connections/connection_test.go
+++ b/pkg/connections/connection_test.go
@@ -65,6 +65,18 @@ func Test_GetConnectionsConfig(t *testing.T) {
 	})
 }
 
+func Test_GetAllConnections(t *testing.T) {
+	t.Run("Asserts there is only one connection and ensures it has an ID", func(t *testing.T) {
+		ResetConnectionsFile()
+		result, err := GetAllConnections()
+		if err != nil {
+			t.Fail()
+		}
+		assert.Len(t, result, 1)
+		assert.Equal(t, result[0].ID, "local")
+	})
+}
+
 // Test_CreateNewConnection :  Adds a new connection to the list called remoteserver
 func Test_CreateNewConnection(t *testing.T) {
 	set := flag.NewFlagSet("tests", 0)


### PR DESCRIPTION
# Description of pull request

Fixes # (https://github.com/eclipse/codewind/issues/1848)
Added a `--all` command to the `cwctl version` and changed its behaviour so it will work for `local` deployments.

## Solution
<!-- Please include a summary of the change and how it addresses the issue -->

**cwctl version**
Previously `cwctl version` took a mandatory `--conid` for a remote deployment of Codewind and would not work if the `--conid local` was past in. I have changed the behaviour so that just running `cwctl version` will output the version of the local Codewind deployment and the user can add the optional `--conid` flag to specify the Codewind deployment.

**cwctl version --all**
Added a `--all` optional parameter to output all the versions for all connections.

**JSON & human readable output (tables)**
I've also changed the output of the `cwctl version` command so that it will give JSON output only on the `--json` flag.

If the `--json` flag isn't given then the output will now be in a human readable table.

`cwctl version` output:
```
CWCTL VERSION: x.x.dev

CONNECTION ID 	PFE VERSION		PERFORMANCE VERSION		GATEKEEPER VERSION
local		latest-20200129-142721	x.x.dev-20200129-142743
```

`cwctl version --all` output:
```
CWCTL VERSION: x.x.dev

CONNECTION ID 	PFE VERSION			PERFORMANCE VERSION		GATEKEEPER VERSION
local		latest-20200129-142721		x.x.dev-20200129-142743
K5DWSFUO	x.x.dev-20200109-205144		x.x.dev-20200109-205413		x.x.dev-20200109-205659
K60JPX9A	x.x.dev-20200108-171055		x.x.dev-20200110-162816		x.x.dev-20200108-171623
```

**Error handling**
Haven't changed the error handling for `cwctl version` so it just outputs as:
```
{"error":"tx_auth","error_description":"Post https://codewind-keycloak-k580uluz.apps.exact-mongrel-icp-mst.9.20.195.90.nip.io/auth/realms/codewind/protocol/openid-connect/token: x509: certificate signed by unknown authority"}
```

For `cwctl version -a` I have implemented it so that if one call to a connection fails the function will keep running and report as many versions as possible. This is because the self-signed certificate is a common error when communicating with remote deployments.
```
CWCTL VERSION: x.x.dev

CONNECTION ID 	PFE VERSION		PERFORMANCE VERSION		GATEKEEPER VERSION
local		latest-20200129-142721	x.x.dev-20200129-142743

SOME ERRORS WHILE DETECTING CONNECTION VERSIONS
CONNECTION ID 	ERROR
K5DWSFUO	{"error":"tx_auth","error_description":"Post https://codewind-keycloak-k580uluz.apps.exact-mongrel-icp-mst.9.20.195.90.nip.io/auth/realms/codewind/protocol/openid-connect/token: x509: certificate signed by unknown authority"}
K60JPX9A	{"error":"tx_auth","error_description":"Post https://codewind-keycloak-k56r5wiq.apps.exact-mongrel-icp-mst.9.20.195.90.nip.io/auth/realms/codewind/protocol/openid-connect/token: x509: certificate signed by unknown authority"}
```
and for `--json`
```
{"cwctlVersion":"x.x.dev","connections":{"local":{"performanceVersion":"x.x.dev-20200129-142743","PFEVersion":"latest-20200129-142721"}},"errors":{"K5DWSFUO":"{\"error\":\"tx_auth\",\"error_description\":\"Post https://codewind-keycloak-k580uluz.apps.exact-mongrel-icp-mst.9.20.195.90.nip.io/auth/realms/codewind/protocol/openid-connect/token: x509: certificate signed by unknown authority\"}","K60JPX9A":"{\"error\":\"tx_auth\",\"error_description\":\"Post https://codewind-keycloak-k56r5wiq.apps.exact-mongrel-icp-mst.9.20.195.90.nip.io/auth/realms/codewind/protocol/openid-connect/token: x509: certificate signed by unknown authority\"}"}}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update - design docs

## Testing undertaken
<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant information of your test configuration or test you have added to support this change -->

## Checklist

- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
