### PR TITLE
Add loglevels command to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 | seckeyring  | `sk`  | 'Manage Codewind keys in the desktop keyring'                       |
 | secuser     | `su`  | 'Manage new or existing USER access configurations'                 |
 | connections | `con` | 'Manage connections configuration list'                             |
+| loglevels   | `log` | 'Get or set logging levels for Codewind containers'                 |
 | help        | `h`   | 'Shows a list of commands or help for one command'                  |
 
 ### Command Options:
@@ -429,6 +430,14 @@ Subcommands:</br>
 `reset` - Resets the connections list to a single local connection
 
 >**Note:** No additional flags
+
+## loglevels
+
+> **Flags:**
+> --conid value     The Connection ID of the remote Codewind installation. Defaults to `local`.
+
+> **Arguments:**
+> The log level to set, one of `error`, `warn`, `info`, `debug`, `trace`
 
 ## help
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -830,7 +830,7 @@ func Commands() {
 		{
 			Name:    "loglevels",
 			Aliases: []string{"log"},
-			Usage:   "Get or set logging levels of remotely deployed Codewind containers",
+			Usage:   "Get or set logging levels for Codewind containers",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "conid",


### PR DESCRIPTION
Signed-off-by: Howard Hellyer <hhellyer@uk.ibm.com>

# Description of pull request

When the `loglevels` command was added the `README.md` was not updated to include the new command.

## Solution

This adds the usage of the `loglevels` command to `README.md`.

## Type of change

- [X] This change requires a documentation update

## Testing undertaken


## Checklist

- [X] I have made corresponding changes to the documentation
- [X] There are no typos in the code comments or this pull request
- [X] I have signed my commits and conformed with the Eclipse commit record guidelines