### PR TITLE
Ignore local k8s deployments with the local status cmd

### DIFF
--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -136,7 +136,7 @@ func DockerCompose(dockerComposeFile string, tag string, loglevel string) *Docke
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil { // after 'Start' the program is continued and script is executing in background
-	    //print out docker-compose sysout & syserr for error diagnosis
+		//print out docker-compose sysout & syserr for error diagnosis
 		fmt.Printf(output.String())
 		DeleteTempFile(dockerComposeFile)
 		return &DockerError{errOpDockerComposeStart, err, err.Error()}
@@ -593,7 +593,7 @@ func DetermineDebugPortForPFE() (pfeDebugPort string) {
 
 // GetContainerTags of the Codewind version(s) currently running
 func GetContainerTags() ([]string, *DockerError) {
-	containerArr := baseImageNameArr
+	containerArr := containerImageNames
 	tagArr := []string{}
 
 	containers, err := GetContainerList()
@@ -603,13 +603,12 @@ func GetContainerTags() ([]string, *DockerError) {
 
 	for _, container := range containers {
 		for _, key := range containerArr {
-			if strings.HasPrefix(container.Image, key) {
+			if strings.HasPrefix(container.Names[0], "/"+key) {
 				tag := strings.Split(container.Image, ":")[1]
 				tagArr = append(tagArr, tag)
 			}
 		}
 	}
-
 	tagArr = RemoveDuplicateEntries(tagArr)
 	return tagArr, nil
 }

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -44,7 +44,7 @@ var baseImageNameArr = [2]string{
 const pfeContainerName = "codewind-pfe"
 const performanceContainerName = "codewind-performance"
 
-var containerImageNames = [...]string{
+var containerNames = [...]string{
 	pfeContainerName,
 	performanceContainerName,
 }
@@ -370,7 +370,7 @@ func GetContainersToRemove(containerList []types.Container) []types.Container {
 // CheckContainerStatus of Codewind running/stopped
 func CheckContainerStatus() (bool, *DockerError) {
 	var containerStatus = false
-	containerArr := containerImageNames
+	containerArr := containerNames
 	containers, err := GetContainerList()
 	if err != nil {
 		return false, err
@@ -593,7 +593,7 @@ func DetermineDebugPortForPFE() (pfeDebugPort string) {
 
 // GetContainerTags of the Codewind version(s) currently running
 func GetContainerTags() ([]string, *DockerError) {
-	containerArr := containerImageNames
+	containerArr := containerNames
 	tagArr := []string{}
 
 	containers, err := GetContainerList()


### PR DESCRIPTION
Signed-off-by: Liam Hampton <liam.hampton@ibm.com>

# Description of pull request
If Codewind is installed locally and also installed into docker minikube, the current container search criteria doesn't ignore `k8s` deployments. This gives an broken output when running the command `cwctl --json --insecure status` 
e.g 
```
{"status":"started","url":"http://127.0.0.1:10000","installed-versions":["latest","0.8.0"],"started":["eb7b0e1f45b74321e153cfd67bd91a2f21ee35a56356f917ac72423a04678d11","aeda98e7e2e9b863fb6b28684a18444530991beb2880deaf5ee6cc676310df62","0.8.0"]}
```
Fixes # https://github.com/eclipse/codewind/issues/1316

## Solution
By changing the logic of the search to use `container` names instead of `image` names, we can ignore all `k8s` deployed containers running in minikube.

With deployments running in `k8s` and local install running the local `status` command now outputs:

```
$ docker ps
CONTAINER ID        IMAGE                                                            COMMAND                  CREATED             STATUS              PORTS                       NAMES
d4145acd6f5f        eclipse/codewind-pfe-amd64:0.8.0                                 "sh -c ' /file-watch…"   15 seconds ago      Up 14 seconds       127.0.0.1:10000->9090/tcp   codewind-pfe
0e8fca2523ae        eclipse/codewind-performance-amd64:0.8.0                         "docker-entrypoint.s…"   15 seconds ago      Up 14 seconds       127.0.0.1:9095->9095/tcp    codewind-performance
aefa08b3ff86        eclipse/codewind-pfe-amd64                                       "sh -c ' /file-watch…"   24 hours ago        Up 24 hours                                     k8s_codewind-pfe_codewind-pfe-k5ze87al-64c459c4f-flr72_liamchampton_d1acf008-e0a4-47c4-8f12-f6d680ce2d16_0
b186b10665dc        eclipse/codewind-keycloak-amd64                                  "/opt/jboss/tools/do…"   24 hours ago        Up 24 hours                                     k8s_codewind-keycloak_codewind-keycloak-k5ze87al-5fc79d4d68-6ltdn_liamchampton_104b86f1-c699-4293-9c9c-361f78114985_0
a34a5a8bb07a        eclipse/codewind-gatekeeper-amd64                                "docker-entrypoint.s…"   24 hours ago        Up 24 hours                                     k8s_codewind-gatekeeper_codewind-gatekeeper-k5ze87al-6dc69cd769-f2h8s_liamchampton_ee5bcc00-206c-4cf3-83f6-2b2162ff5c54_0
24fb3e299237        eclipse/codewind-performance-amd64                               "docker-entrypoint.s…"   24 hours ago        Up 24 hours                                     k8s_codewind-performance_codewind-performance-k5ze87al-fd45746c-jp7sc_liamchampton_37952d1b-93fa-49d1-8211-d0181320d50a_0
9ff6ab78913f        quay.io/kubernetes-ingress-controller/nginx-ingress-controller   "/usr/bin/dumb-init …"   24 hours ago        Up 24 hours                                     k8s_nginx-ingress-controller_nginx-ingress-controller-5876d56d4c-2z2r2_ingress-nginx_d7de27a8-2463-4a36-bd8f-817e268107b1_0

$ cwctl --json --insecure status
{"status":"started","url":"http://127.0.0.1:10000","installed-versions":["0.8.0"],"started":["0.8.0"]}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
***Bats output***
```
18 tests, 0 failures, 6 skipped
```

## Checklist

- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [ ] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
