### PR TITLE
Add IKS annotations for HTTPs services

### DIFF
--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -168,12 +168,12 @@ func generateIngressGatekeeper(codewind Codewind) extensionsv1.Ingress {
 
 	annotations := map[string]string{
 		"nginx.ingress.kubernetes.io/rewrite-target":     "/",
+		"ingress.bluemix.net/redirect-to-https":          "True",
+		"ingress.bluemix.net/ssl-services":               "ssl-service=" + GatekeeperPrefix + "-" + codewind.WorkspaceID,
 		"nginx.ingress.kubernetes.io/backend-protocol":   "HTTPS",
 		"kubernetes.io/ingress.class":                    "nginx",
 		"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
 	}
-	// blockOwnerDeletion := true
-	// controller := true
 
 	return extensionsv1.Ingress{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/remote/deploy_keycloak.go
+++ b/pkg/remote/deploy_keycloak.go
@@ -153,9 +153,6 @@ func generateIngressKeycloak(codewind Codewind) extensionsv1.Ingress {
 		"kubernetes.io/ingress.class":                    "nginx",
 	}
 
-	// blockOwnerDeletion := true
-	// controller := true
-
 	return extensionsv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "extensions/v1beta1",


### PR DESCRIPTION
## Problem 

Codewind Gatekeeper is not accessible in IKS but works ok on Openshift in IBM Cloud. 

This happens because by default, Ingresses in IKS are expecting the destination service (Gatekeeper) to be using HTTP.   Gatekeeper in IKS uses HTTPs and is thus not accessible returning a 502 gateway error as reported in issue #1900

## Solution

The Ingresses created by CWCTL are missing two required annotations for IBM Cloud.  This PR adds the two missing annotations. 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>
