### PR TITLE
mock PFE calls in TestWriteNewCwSettings + add extra project unit tests 

### DIFF
--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -323,9 +323,9 @@ func renameLegacySettings(pathToLegacySettings string, pathToCwSettings string) 
 
 // writeNewCwSettings writes a default .cw-settings file to the given path,
 // dependant on the build type of the project
-func writeNewCwSettings(client utils.HTTPClient, connection *connections.Connection, conURL string, pathToCwSettings string, BuildType string) *ProjectError {
+func writeNewCwSettings(httpClient utils.HTTPClient, connection *connections.Connection, conURL string, pathToCwSettings string, BuildType string) *ProjectError {
 
-	defaultCwSettings, projErr := getDefaultCwSettings(client, connection, conURL, BuildType)
+	defaultCwSettings, projErr := getDefaultCwSettings(httpClient, connection, conURL, BuildType)
 	if projErr != nil {
 		return projErr
 	}
@@ -344,9 +344,9 @@ func writeNewCwSettings(client utils.HTTPClient, connection *connections.Connect
 	return nil
 }
 
-func getDefaultCwSettings(client utils.HTTPClient, connection *connections.Connection, conURL string, BuildType string) (CWSettings, *ProjectError) {
+func getDefaultCwSettings(httpClient utils.HTTPClient, connection *connections.Connection, conURL string, BuildType string) (CWSettings, *ProjectError) {
 
-	IgnoredPaths, err := apiroutes.GetIgnoredPaths(client, connection, BuildType, conURL)
+	IgnoredPaths, err := apiroutes.GetIgnoredPaths(httpClient, connection, BuildType, conURL)
 	if err != nil {
 		// If error getting the default ignoredPaths, set as empty slice
 		IgnoredPaths = []string{}

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -191,13 +191,23 @@ func writeCwSettingsIfNotInProject(conID string, projectPath string, BuildType s
 	pathToCwSettings := path.Join(projectPath, ".cw-settings")
 	pathToLegacySettings := path.Join(projectPath, ".mc-settings")
 
+	connection, conErr := connections.GetConnectionByID(conID)
+	if conErr != nil {
+		return &ProjectError{errOpCreateProject, conErr, conErr.Desc}
+	}
+
+	conURL, configErr := config.PFEOriginFromConnection(connection)
+	if configErr != nil {
+		return &ProjectError{errOpCreateProject, conErr, configErr.Desc}
+	}
+
 	if _, err := os.Stat(pathToLegacySettings); os.IsExist(err) {
 		projErr := renameLegacySettings(pathToLegacySettings, pathToCwSettings)
 		if projErr != nil {
 			return projErr
 		}
 	} else if _, err := os.Stat(pathToCwSettings); os.IsNotExist(err) {
-		projErr := writeNewCwSettings(conID, pathToCwSettings, BuildType)
+		projErr := writeNewCwSettings(&http.Client{}, connection, conURL, pathToCwSettings, BuildType)
 		if projErr != nil {
 			return projErr
 		}
@@ -313,39 +323,35 @@ func renameLegacySettings(pathToLegacySettings string, pathToCwSettings string) 
 
 // writeNewCwSettings writes a default .cw-settings file to the given path,
 // dependant on the build type of the project
-func writeNewCwSettings(conID string, pathToCwSettings string, BuildType string) *ProjectError {
-	defaultCwSettings, projErr := getDefaultCwSettings(conID, BuildType)
+func writeNewCwSettings(client utils.HTTPClient, connection *connections.Connection, conURL string, pathToCwSettings string, BuildType string) *ProjectError {
+
+	defaultCwSettings, projErr := getDefaultCwSettings(client, connection, conURL, BuildType)
 	if projErr != nil {
 		return projErr
 	}
+
 	cwSettings := addNonDefaultFieldsToCwSettings(defaultCwSettings, BuildType)
 	settings, err := json.MarshalIndent(cwSettings, "", "  ")
 	if err != nil {
 		return &ProjectError{errOpCreateProject, err, err.Error()}
 	}
+
 	// File permission 0644 grants read and write access to the owner
 	err = ioutil.WriteFile(pathToCwSettings, settings, 0644)
+	if err != nil {
+		return &ProjectError{errOpCreateProject, err, err.Error()}
+	}
 	return nil
 }
 
-func getDefaultCwSettings(conID string, BuildType string) (CWSettings, *ProjectError) {
-	client := &http.Client{}
-
-	connection, conErr := connections.GetConnectionByID(conID)
-	if conErr != nil {
-		return CWSettings{}, &ProjectError{errOpCreateProject, conErr, conErr.Desc}
-	}
-
-	conURL, configErr := config.PFEOriginFromConnection(connection)
-	if configErr != nil {
-		return CWSettings{}, &ProjectError{errOpCreateProject, conErr, configErr.Desc}
-	}
+func getDefaultCwSettings(client utils.HTTPClient, connection *connections.Connection, conURL string, BuildType string) (CWSettings, *ProjectError) {
 
 	IgnoredPaths, err := apiroutes.GetIgnoredPaths(client, connection, BuildType, conURL)
 	if err != nil {
 		// If error getting the default ignoredPaths, set as empty slice
 		IgnoredPaths = []string{}
 	}
+
 	return CWSettings{
 		ContextRoot:       "",
 		InternalPort:      "",

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -255,6 +256,29 @@ func TestCheckProjectDirIsEmpty(t *testing.T) {
 			assert.Equal(t, err, test.wantError)
 		})
 	}
+	os.RemoveAll(testFolder)
+}
+
+func TestRenameLegacySettings(t *testing.T) {
+	testFolder := "rename_legacy_settings_delete_me"
+	os.Mkdir(testFolder, 0777)
+	legacySettingsPath := path.Join(testFolder, ".mc-settings")
+	newSettingsPath := path.Join(testFolder, ".cw-settings")
+	ioutil.WriteFile(legacySettingsPath, []byte{}, 0644)
+
+	t.Run("error case - path to legacy settings does not exist", func(t *testing.T) {
+		err := renameLegacySettings("/not_a_path/.mc-settings", "/not_a_path/.cw-settings")
+		assert.Error(t, err)
+	})
+
+	t.Run("success case - renames legacy settings", func(t *testing.T) {
+		err := renameLegacySettings(legacySettingsPath, newSettingsPath)
+		assert.Nil(t, err)
+		newSettingsFileExists := utils.PathExists(newSettingsPath)
+		legacySettingsFileExists := utils.PathExists(legacySettingsPath)
+		assert.True(t, newSettingsFileExists)
+		assert.False(t, legacySettingsFileExists)
+	})
 	os.RemoveAll(testFolder)
 }
 

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -226,6 +226,38 @@ func TestProjectPathExists(t *testing.T) {
 	}
 }
 
+func TestCheckProjectDirIsEmpty(t *testing.T) {
+	errNoPath := errors.New(textNoProjectPath)
+	errProjectNonEmpty := errors.New(textProjectPathNonEmpty)
+
+	testFolder := "check_project_dir_empty_folder_delete_me"
+	os.Mkdir(testFolder, 0777)
+	tests := map[string]struct {
+		path      string
+		wantError *ProjectError
+	}{
+		"error case - empty path": {
+			path:      "",
+			wantError: &ProjectError{errOpCreateProject, errNoPath, errNoPath.Error()},
+		},
+		"error case - non empty path": {
+			path:      "../../resources/test/go-project",
+			wantError: &ProjectError{errOpCreateProject, errProjectNonEmpty, errProjectNonEmpty.Error()},
+		},
+		"success case - empty project at path": {
+			path:      testFolder,
+			wantError: nil,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := checkProjectDirIsEmpty(test.path)
+			assert.Equal(t, err, test.wantError)
+		})
+	}
+	os.RemoveAll(testFolder)
+}
+
 func readCwSettings(filepath string) CWSettings {
 	cwSettingsFile, err := ioutil.ReadFile(filepath)
 	if err != nil {

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -14,6 +14,7 @@ package project
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -193,6 +194,34 @@ func TestWriteNewCwSettings(t *testing.T) {
 				assert.Equal(t, cwSettings.MavenProperties, test.wantCwSettings.MavenProperties)
 			}
 			os.Remove(test.inProjectPath)
+		})
+	}
+}
+
+func TestProjectPathExists(t *testing.T) {
+	errNoPath := errors.New(textNoProjectPath)
+	errNoProject := errors.New(textProjectPathDoesNotExist)
+	tests := map[string]struct {
+		path      string
+		wantError *ProjectError
+	}{
+		"success case - path exists": {
+			path:      "../../resources/test/go-project",
+			wantError: nil,
+		},
+		"error case - empty path": {
+			path:      "",
+			wantError: &ProjectError{errOpCreateProject, errNoPath, errNoPath.Error()},
+		},
+		"error case - no project at path": {
+			path:      "not_a_path",
+			wantError: &ProjectError{errOpCreateProject, errNoProject, errNoProject.Error()},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := checkProjectPathExists(test.path)
+			assert.Equal(t, err, test.wantError)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

# Description of pull request

Mocks PFE when testing writeNewCwSettings, which allows the tests to run without a PFE running. 

Slight refactor of the local function to allow for the PFE client to be passed in.

This is the last piece of work to allow the project package tests to run in Jenkins.

Also adds new unit tests for functions in project/create.go.

Towards https://github.com/eclipse/codewind.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken

All new and old tests pass. 

Create and validate commands run successfully.

## Checklist

- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
