### PR TITLE
add tests for project unbind

### DIFF
--- a/pkg/project/unbind_test.go
+++ b/pkg/project/unbind_test.go
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package project
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnbind(t *testing.T) {
+	mockConnection := connections.Connection{ID: "local"}
+
+	body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+	t.Run("Expect success - project unbinds", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		err := Unbind(mockClient, &mockConnection, "dummyurl", "mockID")
+		if err != nil {
+			t.Errorf("Unbind() failed with error %s", err)
+		}
+	})
+
+	t.Run("Expect failure - pfe returns non 200 status", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: body}
+		err := Unbind(mockClient, &mockConnection, "dummyurl", "mockID")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

# Description of pull request

Adds a success and failure unit test for project unbind, and refactor to handle errors with greater clarity.

Part of https://github.com/eclipse/codewind/issues/1896.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken

Tests all pass locally. 

Command runs as expected.

## Checklist

- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
