### PR TITLE
add tests for set and get loglevels

### DIFF
--- a/pkg/actions/logging.go
+++ b/pkg/actions/logging.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/urfave/cli"
 )
@@ -28,15 +30,27 @@ func LogLevels(c *cli.Context) {
 	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	newLogLevel := strings.TrimSpace(strings.ToLower(c.Args().Get(0)))
 
+	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
+	if conInfoErr != nil {
+		fmt.Println(conInfoErr.Err)
+		os.Exit(1)
+	}
+
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		fmt.Println(conErr.Err)
+		os.Exit(1)
+	}
+
 	if newLogLevel != "" {
-		err := apiroutes.SetLogLevel(connectionID, http.DefaultClient, newLogLevel)
+		err := apiroutes.SetLogLevel(conInfo, conURL, http.DefaultClient, newLogLevel)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
 		}
 	}
 
-	loggingLevels, err := apiroutes.GetLogLevels(connectionID, http.DefaultClient)
+	loggingLevels, err := apiroutes.GetLogLevel(conInfo, conURL, http.DefaultClient)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/pkg/apiroutes/logging.go
+++ b/pkg/apiroutes/logging.go
@@ -18,14 +18,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
 
 type (
-	// LogLevels : The logging level information
+	// LoggingResponse : The logging level information
 	LoggingResponse struct {
 		CurrentLevel string   `json:"currentLevel"`
 		DefaultLevel string   `json:"defaultLevel"`
@@ -39,16 +38,7 @@ type (
 )
 
 // GetLogLevel : Get the current log level for the PFE container
-func GetLogLevels(conID string, httpClient utils.HTTPClient) (LoggingResponse, error) {
-	conInfo, conInfoErr := connections.GetConnectionByID(conID)
-	if conInfoErr != nil {
-		return LoggingResponse{}, conInfoErr.Err
-	}
-	conURL, conErr := config.PFEOriginFromConnection(conInfo)
-	if conErr != nil {
-		return LoggingResponse{}, conErr.Err
-	}
-
+func GetLogLevel(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient) (LoggingResponse, error) {
 	req, err := http.NewRequest("GET", conURL+"/api/v1/logging", nil)
 	if err != nil {
 		return LoggingResponse{}, err
@@ -79,16 +69,7 @@ func GetLogLevels(conID string, httpClient utils.HTTPClient) (LoggingResponse, e
 }
 
 // SetLogLevel : Set the current log level for the PFE container
-func SetLogLevel(conID string, httpClient utils.HTTPClient, newLogLevel string) error {
-	conInfo, conInfoErr := connections.GetConnectionByID(conID)
-	if conInfoErr != nil {
-		return conInfoErr.Err
-	}
-	conURL, conErr := config.PFEOriginFromConnection(conInfo)
-	if conErr != nil {
-		return conErr.Err
-	}
-
+func SetLogLevel(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, newLogLevel string) error {
 	// Send the new logging level.
 	logLevel := &LogParameter{Level: newLogLevel}
 	jsonPayload, _ := json.Marshal(logLevel)

--- a/pkg/apiroutes/logging_test.go
+++ b/pkg/apiroutes/logging_test.go
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetLogLevels(t *testing.T) {
+	allLevels := []string{"error", "warn", "info", "debug", "trace"}
+	loggingResponse := LoggingResponse{
+		CurrentLevel: "debug",
+		DefaultLevel: "info",
+		AllLevels:    allLevels,
+	}
+	mockConnection := connections.Connection{ID: "local"}
+	t.Run("success case - correct logging levels are returned", func(t *testing.T) {
+		jsonResponse, err := json.Marshal(loggingResponse)
+		if err != nil {
+			t.Fail()
+		}
+		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		gotLoggingLevels, err := GetLogLevel(&mockConnection, "mockURL", mockClient)
+		if err != nil {
+			t.Fail()
+		}
+		assert.Equal(t, gotLoggingLevels, loggingResponse)
+	})
+	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
+		mockClientFalse := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: nil}
+		_, err := GetIgnoredPaths(mockClientFalse, &mockConnection, "nodejs", "dummyurl")
+		assert.Error(t, err)
+	})
+}
+
+func Test_SetLogLevels(t *testing.T) {
+	t.Run("success case - returns nil error when PFE status code 200", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: nil}
+		mockConnection := connections.Connection{ID: "local"}
+		err := SetLogLevel(&mockConnection, "mockURL", mockClient, "trace")
+		assert.Nil(t, err)
+	})
+	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
+		mockConnection := connections.Connection{ID: "local"}
+		mockClientFalse := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: nil}
+		_, err := GetIgnoredPaths(mockClientFalse, &mockConnection, "nodejs", "dummyurl")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

# Description of pull request

Adds a success and failure unit test for loglevels set and get. 

Part of https://github.com/eclipse/codewind/issues/1978.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken

Tests all pass locally. 

Commands run as expected.

## Checklist

- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
