### PR TITLE
add testing for filesystem.go

### DIFF
--- a/pkg/utils/filesystem_test.go
+++ b/pkg/utils/filesystem_test.go
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO : Move these 2 helpers somewhere central, for sharing between packages
+
+// CreateTempTestFile : creates a temp test file and returns that file and a clean-up function
+func CreateTempTestFile(t *testing.T, initialData string) (*os.File, func()) {
+	t.Helper()
+	tmpfile, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatalf("could not create temp file %v", err)
+	}
+
+	tmpfile.Write([]byte(initialData))
+
+	removeFile := func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name())
+	}
+	return tmpfile, removeFile
+}
+
+// CreateTempTestDir : creates a temp test dir and returns that dir and a clean-up function
+func CreateTempTestDir(t *testing.T) (string, func()) {
+	t.Helper()
+	tmpDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatalf("could not create temp file %v", err)
+	}
+
+	removeDir := func() {
+		os.RemoveAll(tmpDir)
+	}
+	return tmpDir, removeDir
+}
+
+func TestCreateTempFile(t *testing.T) {
+	testPath := "create_temp_file_test_delete_me"
+	t.Run("success case - creates temporary file", func(*testing.T) {
+		_ = CreateTempFile(testPath)
+		_, err := os.Stat(testPath)
+		assert.Nil(t, err)
+		assert.Equal(t, PathExists(testPath), true)
+		os.Remove(testPath)
+	})
+	t.Run("doesn't change an existing file", func(t *testing.T) {
+		file, removeFile := CreateTempTestFile(t, "Hello World")
+		defer removeFile()
+		created := CreateTempFile(file.Name())
+		assert.False(t, created)
+
+		writeFileContent := []byte("Hello World")
+		fileContent, _ := ioutil.ReadFile(file.Name())
+		assert.Equal(t, writeFileContent, fileContent)
+	})
+}
+
+func TestPathExists(t *testing.T) {
+	t.Run("returns true when path exists", func(t *testing.T) {
+		file, removeFile := CreateTempTestFile(t, "")
+		defer removeFile()
+		got := PathExists(file.Name())
+		assert.True(t, got)
+	})
+	t.Run("returns false when path does not exist", func(t *testing.T) {
+		testFile := "create_test_file_delete_me_2"
+		got := PathExists(testFile)
+		assert.False(t, got)
+		os.Remove(testFile)
+	})
+}
+
+func TestDirIsEmpty(t *testing.T) {
+	t.Run("returns true when dir is empty", func(t *testing.T) {
+		testDir, removeDir := CreateTempTestDir(t)
+		defer removeDir()
+		got, err := DirIsEmpty(testDir)
+
+		assert.True(t, got)
+		assert.Nil(t, err)
+	})
+	t.Run("returns false when dir is non-empty", func(t *testing.T) {
+		testDir, removeDir := CreateTempTestDir(t)
+		defer removeDir()
+		ioutil.WriteFile(path.Join(testDir, "test"), []byte{}, 0777)
+		got, err := DirIsEmpty(testDir)
+
+		assert.False(t, got)
+		assert.Nil(t, err)
+	})
+	t.Run("returns error when dir doesn't exist", func(t *testing.T) {
+		got, err := DirIsEmpty("not-created")
+
+		assert.False(t, got)
+		assert.NotNil(t, err)
+		os.Remove(testDir)
+	})
+}
+
+func TestWriteToComposeFile(t *testing.T) {
+	t.Run("docker compose should be written to the filepath", func(t *testing.T) {
+		testFile := "TestFile.yaml"
+		os.Create(testFile)
+		_ = WriteToComposeFile("TestFile.yaml", false)
+
+		pathExists := PathExists(testFile)
+		assert.True(t, pathExists)
+		os.Remove(testFile)
+	})
+
+	t.Run("docker compose should be written to the filepath", func(t *testing.T) {
+		testFile := "TestFile.yaml"
+		os.Create(testFile)
+		composeWritten := WriteToComposeFile("TestFile.yaml", false)
+
+		pathExists := PathExists(testFile)
+		assert.True(t, pathExists)
+		assert.True(t, composeWritten)
+		os.Remove(testFile)
+	})
+	t.Run("empty path returns nil", func(t *testing.T) {
+		composeWritten := WriteToComposeFile("", false)
+		assert.False(t, composeWritten)
+	})
+}
+
+func TestReplaceInFiles(t *testing.T) {
+	t.Run("replaces placeholder in file", func(t *testing.T) {
+		testFile, removeFile := CreateTempTestFile(t, "[PROJ_NAME_PLACEHOLDER] test")
+		defer removeFile()
+		err := ReplaceInFiles(testFile.Name(), "[PROJ_NAME_PLACEHOLDER]", "project")
+		assert.Nil(t, err)
+
+		fileContent, _ := ioutil.ReadFile(testFile.Name())
+		wantFileContent := []byte("project test")
+		assert.Equal(t, wantFileContent, fileContent)
+	})
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -84,36 +84,6 @@ func TestPullDockerImage(t *testing.T) {
 	}
 }
 
-func TestCreateTempFile(t *testing.T) {
-	file := CreateTempFile("TestFile.yaml")
-	assert.Equal(t, file, true, "should return true: should create a temp file")
-	os.Remove("./TestFile.yaml")
-}
-
-func TestWriteToComposeFile(t *testing.T) {
-	os.Create("TestFile.yaml")
-	got := WriteToComposeFile("TestFile.yaml", false)
-	assert.Equal(t, got, true, "should return true: should write data to a temp file")
-	os.Remove("TestFile.yaml")
-}
-
-func TestWriteToComposeFileFail(t *testing.T) {
-	writeToFile := WriteToComposeFile("", false)
-	assert.Equal(t, writeToFile, false, "should return false: should fail to write data")
-}
-
-func TestDeleteTempFile(t *testing.T) {
-	os.Create("TestFile.yaml")
-	removeFile, _ := DeleteTempFile("TestFile.yaml")
-	assert.Equal(t, removeFile, true, "should return true: should delete the temp file")
-}
-
-func TestDeleteTempFileFail(t *testing.T) {
-	errString := "stat TestFile.yaml: no such file or directory"
-	_, err := DeleteTempFile("TestFile.yaml")
-	assert.EqualError(t, err, errString)
-}
-
 func TestRemoveDuplicateEntries(t *testing.T) {
 	dupArr := []string{"test", "test", "test"}
 	result := RemoveDuplicateEntries(dupArr)


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

# Description of pull request

Increases the test coverage of the utils package from 36.5% to 40.6%. 

Moves existing tests from utils_tests to a new filesystem_test file, adds additional asserts to increase the coverage they provide.

Adds additional tests for the functions of filesystem.go, alongside 2 helper functions for creating temporary files and dirs for testing. 

These helpers would useful to apply to the other tests which perform these operations, as has been highlighted in the TODO. This would be simpler to change once the other testing PRs have been reviewed and merged however.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
All tests pass, this change only affects test code. 

## Checklist

- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
