### PR TITLE
Add IntelliJ metadata file and directory to the ignored files/directory lists

### DIFF
--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -373,6 +373,7 @@ func ignoreFileOrDirectory(name string, isDir bool, cwSettingsIgnoredPathsList [
 		".bluemix",
 		".build-ubuntu",
 		".yo-rc.json",
+		"*.iml",
 	}
 
 	// List of directories that will not be sent to PFE
@@ -390,6 +391,7 @@ func ignoreFileOrDirectory(name string, isDir bool, cwSettingsIgnoredPathsList [
 		".bluemix",
 		"terraform",
 		".build-ubuntu",
+		".idea",
 	}
 
 	ignoredList := ignoredFiles

--- a/pkg/project/sync_test.go
+++ b/pkg/project/sync_test.go
@@ -138,6 +138,18 @@ func TestIgnoreFileOrDirectory(t *testing.T) {
 			shouldBeIgnored:  true,
 			ignoredPathsList: []string{"noddy_modules"},
 		},
+		"success case: file called file.iml should be ignored (IntelliJ metadata file, *.iml)": {
+			name:             "file.iml",
+			isDir:            false,
+			shouldBeIgnored:  true,
+			ignoredPathsList: []string{},
+		},
+		"success case: path containing .idea should be ignored (IntelliJ metadata directory, .idea)": {
+			name:             ".idea",
+			isDir:            true,
+			shouldBeIgnored:  true,
+			ignoredPathsList: []string{},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

# Description of pull request
Updates the `ignoredFiles` to have `*.iml` to ignore metadata files.
Updates the `ignoredDirectories` to have `.idea` to ignore metadata directories.

Fix for https://github.com/eclipse/codewind/issues/1996 for CLI 

## Solution
<!-- Please include a summary of the change and how it addresses the issue -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant information of your test configuration or test you have added to support this change -->

## Checklist

- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
