### PR TITLE
Extend timeout to 120 mins in deploy 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,7 @@ spec:
             }
 
             options {
-                timeout(time: 20, unit: 'MINUTES') 
+                timeout(time: 120, unit: 'MINUTES') 
                 retry(3) 
             }
 


### PR DESCRIPTION
Timeout with 20 minutes is not enough and it fails intermittently.  