### PR TITLE
Update Tekton cluster roles

### DIFF
--- a/pkg/remote/defaults.go
+++ b/pkg/remote/defaults.go
@@ -74,10 +74,10 @@ const (
 	// CodewindRoleBindingNamePrefix will include the workspaceID when deployed
 	CodewindRoleBindingNamePrefix = "codewind-rolebinding"
 
-	// CodewindTektonClusterRoleBindingName 
-	CodewindTektonClusterRoleBindingName = "codewind-tektonrolebinding"
+	// CodewindTektonClusterRoleBindingName : Tekton, cluster role binding
+	CodewindTektonClusterRoleBindingName = "codewind-tekton-rolebinding"
 
-	// CodewindTektonClusterRoleBindingName
+	// CodewindTektonClusterRolesName : Tekton, cluster role
 	CodewindTektonClusterRolesName = "codewind-tekton"
 
 	// ROKSStorageClass references the storage class to use on ROKS (OpenShift on IKS)

--- a/pkg/remote/deploy_pfe.go
+++ b/pkg/remote/deploy_pfe.go
@@ -31,9 +31,7 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 	codewindRoles := CreateCodewindRoles(deployOptions)
 	codewindRoleBindings := CreateCodewindRoleBindings(codewindInstance, deployOptions, codewindRoleBindingName)
 
-	codewindTektonClusterRoleBindingName := CodewindTektonClusterRoleBindingName
-	codewindTektonClusterRolesName := CodewindTektonClusterRolesName
-
+	codewindTektonClusterRoleBindingName := CodewindTektonClusterRoleBindingName + "-" + codewindInstance.WorkspaceID
 	codewindTektonRoles := CreateCodewindTektonClusterRoles(deployOptions)
 	codewindTektonRoleBindings := CreateCodewindTektonClusterRoleBindings(codewindInstance, deployOptions, codewindTektonClusterRoleBindingName)
 
@@ -59,25 +57,6 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 		}
 	}
 
-	logr.Infof("Checking if '%v' tekton cluster access roles are installed\n", codewindTektonClusterRolesName)
-	tektonclusterRole, err := clientset.RbacV1().ClusterRoles().Get(codewindTektonClusterRolesName, metav1.GetOptions{})
-	if tektonclusterRole != nil && err == nil {
-		logr.Infof("Cluster roles '%v' already installed - updating\n", codewindTektonClusterRolesName)
-		_, err = clientset.RbacV1().ClusterRoles().Update(&codewindTektonRoles)
-		if err != nil {
-			logr.Errorf("Unable to update `%v` tekton cluster access roles: %v\n", codewindTektonClusterRolesName, err)
-			return err
-		}
-		logr.Infof("Cluster roles '%v' updated complete\n", codewindTektonClusterRolesName)
-	} else {
-		logr.Infof("Adding new '%v' cluster access roles\n", codewindTektonClusterRolesName)
-		_, err = clientset.RbacV1().ClusterRoles().Create(&codewindTektonRoles)
-		if err != nil {
-			logr.Errorf("Unable to add %v tekton cluster access roles: %v\n", codewindTektonClusterRolesName, err)
-			return err
-		}
-	}
-
 	logr.Infof("Checking if '%v' role bindings exist\n", codewindRoleBindingName)
 	rolebindings, err := clientset.RbacV1().RoleBindings(codewindInstance.Namespace).Get(codewindRoleBindingName, metav1.GetOptions{})
 	if rolebindings != nil && err == nil {
@@ -91,19 +70,37 @@ func DeployPFE(config *restclient.Config, clientset *kubernetes.Clientset, codew
 		}
 	}
 
-	logr.Infof("Checking if '%v' cluster role bindings exist\n", codewindTektonClusterRoleBindingName)
+	logr.Infof("Checking if '%v' Tekton cluster access roles are installed\n", CodewindTektonClusterRolesName)
+	tektonclusterRole, err := clientset.RbacV1().ClusterRoles().Get(CodewindTektonClusterRolesName, metav1.GetOptions{})
+	if tektonclusterRole != nil && err == nil {
+		logr.Infof("Cluster roles '%v' already installed - updating\n", CodewindTektonClusterRolesName)
+		_, err = clientset.RbacV1().ClusterRoles().Update(&codewindTektonRoles)
+		if err != nil {
+			logr.Errorf("Unable to update `%v` Tekton cluster access roles: %v\n", CodewindTektonClusterRolesName, err)
+			return err
+		}
+		logr.Infof("Cluster roles '%v' updated complete\n", CodewindTektonClusterRolesName)
+	} else {
+		logr.Infof("Adding new '%v' cluster access roles\n", CodewindTektonClusterRolesName)
+		_, err = clientset.RbacV1().ClusterRoles().Create(&codewindTektonRoles)
+		if err != nil {
+			logr.Errorf("Unable to add %v Tekton cluster access roles: %v\n", CodewindTektonClusterRolesName, err)
+			return err
+		}
+	}
+
+	logr.Infof("Checking if '%v' role bindings exist\n", codewindTektonClusterRoleBindingName)
 	clusterrolebindings, err := clientset.RbacV1().ClusterRoleBindings().Get(codewindTektonClusterRoleBindingName, metav1.GetOptions{})
 	if clusterrolebindings != nil && err == nil {
 		logr.Warnf("Cluster Role binding '%v' already exist.\n", codewindTektonClusterRoleBindingName)
 	} else {
-		logr.Infof("Adding '%v' cluster role binding\n", codewindTektonClusterRoleBindingName)
+		logr.Infof("Adding '%v' role binding\n", codewindTektonClusterRoleBindingName)
 		_, err = clientset.RbacV1().ClusterRoleBindings().Create(&codewindTektonRoleBindings)
 		if err != nil {
 			logr.Errorf("Unable to add '%v' access roles: %v\n", codewindTektonClusterRoleBindingName, err)
 			return err
 		}
 	}
-
 
 	// Determine if we're running on OpenShift on IKS (and thus need to use the ibm-file-bronze storage class)
 	storageClass := ""

--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -32,8 +32,7 @@ func CreateCodewindTektonClusterRoles(deployOptions *DeployOptions) rbacv1.Clust
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: deployOptions.Namespace,
-			Name:      CodewindTektonClusterRoleBindingName,
+			Name: CodewindTektonClusterRolesName,
 		},
 		Rules: ourRoles,
 	}
@@ -156,8 +155,9 @@ func CreateCodewindRoleBindings(codewindInstance Codewind, deployOptions *Deploy
 }
 
 //CreateCodewindTektonClusterRoleBindings : create Codewind tekton cluster role bindings
-func CreateCodewindTektonClusterRoleBindings(codewindInstance Codewind, deployOptions *DeployOptions, codewindRoleBindingName string) rbacv1.ClusterRoleBinding {
+func CreateCodewindTektonClusterRoleBindings(codewindInstance Codewind, deployOptions *DeployOptions, roleBindingName string) rbacv1.ClusterRoleBinding {
 	labels := map[string]string{
+		"app":               CodewindTektonClusterRoleBindingName,
 		"codewindWorkspace": codewindInstance.WorkspaceID,
 	}
 	return rbacv1.ClusterRoleBinding{
@@ -166,7 +166,7 @@ func CreateCodewindTektonClusterRoleBindings(codewindInstance Codewind, deployOp
 			Kind:       "ClusterRoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   CodewindTektonClusterRoleBindingName,
+			Name:   roleBindingName,
 			Labels: labels,
 		},
 		Subjects: []rbacv1.Subject{


### PR DESCRIPTION
# Description of pull request

Unable to install more than one remote Codewind installation into the same namespace in Kubernetes. 

Fixes https://github.com/eclipse/codewind/issues/2007

## Solution

* Use unique labels and name for the Tekton binding
* Changed the install order so that Codewind bindings and Tekton Bindings are in sequence. 
* Updated remove code to delete the binding.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing undertaken
Performed dual deployments on Openshift 3.11, Kubernetes in Docker MAC and ROKS

```
INFO[0028] Checking if 'codewind-rolebinding-k6c2whfc' role bindings exist 
INFO[0028] Adding 'codewind-rolebinding-k6c2whfc' role binding 
INFO[0028] Checking if 'codewind-tekton' Tekton cluster access roles are installed 
INFO[0028] Cluster roles 'codewind-tekton' already installed - updating 
INFO[0028] Cluster roles 'codewind-tekton' updated complete 
INFO[0028] Checking if 'codewind-tekton-rolebinding-k6c2whfc' role bindings exist     <-- name is unique
INFO[0028] Adding 'codewind-tekton-rolebinding-k6c2whfc' role binding 
INFO[0028] Creating and setting Codewind PVC codewind-pfe-pvc-k6c2whfc to 1Gi  
INFO[0028] Deploying Codewind Service                   
```
 
second install in same namespace: 

```
INFO[0027] Cluster roles 'codewind-tekton' already installed - updating 
INFO[0027] Cluster roles 'codewind-tekton' updated complete 
INFO[0027] Checking if 'codewind-tekton-rolebinding-k6c2v6jq' role bindings exist    <-- name is unique
INFO[0027] Adding 'codewind-tekton-rolebinding-k6c2v6jq' role binding 
INFO[0027] Creating and setting Codewind PVC codewind-pfe-pvc-k6c2v6jq to 1Gi  
INFO[0027] Deploying Codewind Service                   
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>