### PR TITLE
2079/Bugfix/add remove (local) subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,23 @@ Subcommands:</br>
 ### remove
 
 `--tag/-t <value>` - Dockerhub image tag.</br>
-**Note:** Failing to specify a `--tag`, will remove all Codewind images on the host machine.
+> **Note:** Failing to specify a `--tag`, will result in an attempt to remove the default `latest` tagged Codewind images on the host machine.
+
+Subcommands:</br>
+
+`local/l` - Removes and deletes a Codewind local deployment
+> **Flags:**
+> --tag - Docker hub image tag
+
+`remote/r` - Removes and deletes a Codewind remote deployment from Kubernetes
+> **Flags:**
+> --namespace - Kubernetes namespace
+> --workspace - Codewind workspace ID
+
+`keycloak/k` - Removes and deletes a Keycloak deployment from Kubernetes
+> **Flags:**
+> --namespace - Kubernetes namespace
+> --workspace - Keycloak workspace ID
 
 ### templates
 

--- a/integration.bats
+++ b/integration.bats
@@ -36,7 +36,7 @@
 
 @test "invoke remove command - remove all dockerhub images" {
   cd cmd/cli/
-  run go run main.go remove
+  run go run main.go remove local
   echo "status = ${status}"
   echo "output trace = ${output}"
   [ "$status" -eq 0 ]

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -302,6 +302,7 @@ func Commands() {
 			Aliases: []string{"rm"},
 			Usage:   "Remove an instance of Codewind",
 			Action: func(c *cli.Context) error {
+				cli.ShowCommandHelp(c, "")
 				return nil
 			},
 			Subcommands: []cli.Command{

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -307,19 +307,6 @@ func Commands() {
 			},
 			Subcommands: []cli.Command{
 				{
-					Name:    "remote",
-					Aliases: []string{"r"},
-					Usage:   "Removes and deletes a Codewind remote deployment from Kubernetes",
-					Flags: []cli.Flag{
-						cli.StringFlag{Name: "namespace,n", Usage: "Kubernetes namespace", Required: true},
-						cli.StringFlag{Name: "workspace,w", Usage: "Codewind workspace ID", Required: true},
-					},
-					Action: func(c *cli.Context) error {
-						DoRemoteRemove(c)
-						return nil
-					},
-				},
-				{
 					Name:    "local",
 					Aliases: []string{"l"},
 					Usage:   "Removes and deletes a Codewind local deployment",
@@ -329,6 +316,19 @@ func Commands() {
 
 					Action: func(c *cli.Context) error {
 						RemoveCommand(c, dockerComposeFile)
+						return nil
+					},
+				},
+				{
+					Name:    "remote",
+					Aliases: []string{"r"},
+					Usage:   "Removes and deletes a Codewind remote deployment from Kubernetes",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "namespace,n", Usage: "Kubernetes namespace", Required: true},
+						cli.StringFlag{Name: "workspace,w", Usage: "Codewind workspace ID", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						DoRemoteRemove(c)
 						return nil
 					},
 				},

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -13,7 +13,6 @@ package actions
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -301,19 +300,8 @@ func Commands() {
 		{
 			Name:    "remove",
 			Aliases: []string{"rm"},
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "tag, t",
-					Usage: "dockerhub image tag",
-				},
-			},
-			Usage: "Remove Codewind and Project docker images",
+			Usage:   "Remove an instance of Codewind",
 			Action: func(c *cli.Context) error {
-				if len(c.Args()) > 0 {
-					fmt.Println("error")
-					return nil
-				}
-				RemoveCommand(c, dockerComposeFile)
 				return nil
 			},
 			Subcommands: []cli.Command{
@@ -327,6 +315,19 @@ func Commands() {
 					},
 					Action: func(c *cli.Context) error {
 						DoRemoteRemove(c)
+						return nil
+					},
+				},
+				{
+					Name:    "local",
+					Aliases: []string{"l"},
+					Usage:   "Removes and deletes a Codewind local deployment",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "tag, t", Usage: "dockerhub image tag"},
+					},
+
+					Action: func(c *cli.Context) error {
+						RemoveCommand(c, dockerComposeFile)
 						return nil
 					},
 				},

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -13,6 +13,7 @@ package actions
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -308,6 +309,10 @@ func Commands() {
 			},
 			Usage: "Remove Codewind and Project docker images",
 			Action: func(c *cli.Context) error {
+				if len(c.Args()) > 0 {
+					fmt.Println("error")
+					return nil
+				}
 				RemoveCommand(c, dockerComposeFile)
 				return nil
 			},


### PR DESCRIPTION
# Description of pull request
🚨 🚨  Needs a plugin change 🚨 🚨 
The CLI `remove` command currently has two behaviours. 1) Parent command to remove local deployments 2) Subcommand to remove a remote deployment. Since this is the case both should be a a subcommand. Reason for this is that if a subcommand is called with a typo, then the typo is treated as an argument for the parent command and not as a subcommand and the default behaviour of the parent command is activated. Thus meaning if you have two installs (local & remote) and you intend to remove remote but make a typo e.g`cwctl remove remte..` this will default to `cwctl remove` and attempt to remove the local instance instad.
 
Fixes # (issue)
https://github.com/eclipse/codewind/issues/2079

## Solution
1) Make the command behaviour consistent and use subcommands to remove deployments
2) If the parent command is called or the command contains a typo then the output will default to the command help
***Example***
```
./cwctl remove foo
NAME:
   cwctl remove - Remove an instance of Codewind

USAGE:
   cwctl remove command [command options] [arguments...]

COMMANDS:
   local, l     Removes and deletes a Codewind local deployment
   remote, r    Removes and deletes a Codewind remote deployment from Kubernetes
   keycloak, k  Removes and deletes a Keycloak deployment from Kubernetes

OPTIONS:
   --help, -h  show help
   
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] 🚨 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected) 🚨 🚨 
- [ ] This change requires a documentation update

## Testing undertaken
- Unit tests ran
- Bats test output: ***18 tests, 0 failures, 6 skipped***

## Checklist

- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings/linter errors
- [x] If necessary, I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] There are no typos in the code comments or this pull request
- [x] I have signed my commits and conformed with the Eclipse commit record guidelines

## Extra
<!-- Please add anything extra you feel is worth mentioning regarding this pull request -->
Eclipse commit record guidelines followed <https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#The_Commit_Record>
