### PR TITLE
[0.8.0] Add deployments/finalizers role to Codewind

### DIFF
--- a/pkg/remote/deploy_pfe_rbac.go
+++ b/pkg/remote/deploy_pfe_rbac.go
@@ -66,7 +66,7 @@ func CreateCodewindRoles(deployOptions *DeployOptions) rbacv1.ClusterRole {
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{"apps", "extensions"},
-			Resources: []string{"deployments"},
+			Resources: []string{"deployments", "deployments/finalizers"},
 			Verbs:     []string{"watch", "get", "list", "create", "update", "delete", "patch"},
 		},
 		rbacv1.PolicyRule{


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR adds `deployments/finalizers` to the Codewind role that cwctl creates for Hybrid, allowing Codewind to set finalizers on deployments (i.e. tie resources to deployments).

This is necessary to enable the fix for https://github.com/eclipse/codewind/issues/2292 to be merged into master. 

## Which issue(s) does this PR fix
N/A

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/pull/2293

This is a backport of:
https://github.com/eclipse/codewind-installer/pull/381 as without this the changes for https://github.com/eclipse/codewind/pull/2293 block this level of cwctl from being able to install.
We do not plan to release this but it will be impossible to debug issues with 0.8.0 on Kubernetes without this fix as setting a deployment registry would be blocked and in turn that would block performing builds.

## Does this PR require a documentation change ?
N/A

## Any special notes for your reviewer ?
N/A