### PR TITLE
Feature/better kubeconfig resolving

### DIFF
--- a/pkg/remote/deploy_get.go
+++ b/pkg/remote/deploy_get.go
@@ -12,12 +12,11 @@
 package remote
 
 import (
-	"path/filepath"
 	"time"
 
+	logr "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // ExistingDeployment describes a remote installation of Codewind
@@ -37,9 +36,9 @@ type K8sAPI struct {
 
 // GetExistingDeployments returns information about the remote installations of codewind, across all namespaces by default
 func GetExistingDeployments(namespace string) ([]ExistingDeployment, *RemInstError) {
-	kubeconfig := filepath.Join(getHomeDir(), ".kube", "config")
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err := getKubeConfig()
 	if err != nil {
+		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}
 	}
 

--- a/pkg/remote/remove.go
+++ b/pkg/remote/remove.go
@@ -12,15 +12,12 @@
 package remote
 
 import (
-	"path/filepath"
-
 	"github.com/eclipse/codewind-installer/pkg/remote/kube"
 	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	logr "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // RemoveDeploymentOptions : Deployment removal options
@@ -87,10 +84,8 @@ type RemovalResult struct {
 
 // RemoveRemote : Remove remote install from Kube
 func RemoveRemote(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
-
-	kubeconfig := filepath.Join(getHomeDir(), ".kube", "config")
 	namespace := remoteRemovalOptions.Namespace
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err := getKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}
@@ -203,10 +198,8 @@ func RemoveRemote(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult
 
 // RemoveRemoteKeycloak : Remove remote keycloak install from Kube
 func RemoveRemoteKeycloak(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
-
-	kubeconfig := filepath.Join(getHomeDir(), ".kube", "config")
 	namespace := remoteRemovalOptions.Namespace
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err := getKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -76,6 +76,7 @@ func getKubeConfig() (*rest.Config, error) {
 	// Use KUBECONFIG environment variable if set
 	kubeconfig, ok := os.LookupEnv("KUBECONFIG")
 	if ok {
+	if ok {
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	logr "github.com/sirupsen/logrus"
@@ -75,7 +76,9 @@ func getKubeConfig() (*rest.Config, error) {
 
 	// Use KUBECONFIG environment variable if set
 	kubeconfig, ok := os.LookupEnv("KUBECONFIG")
-	if ok {
+	if ok && kubeconfig != "" {
+		// If multiple files provided choose first.
+		kubeconfig = strings.SplitN(kubeconfig, ":", -1)[0]
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -74,7 +74,8 @@ func getKubeConfig() (*rest.Config, error) {
 	var err error
 
 	// Use KUBECONFIG environment variable if set
-	if kubeconfig, ok := os.LookupEnv("KUBECONFIG"); ok {
+	kubeconfig, ok := os.LookupEnv("KUBECONFIG")
+	if ok {
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -20,11 +20,14 @@ import (
 	"encoding/pem"
 	"math/big"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
 	logr "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -63,6 +66,37 @@ func GetImages() (string, string, string, string) {
 		gatekeeperTag = GatekeeperImageTag
 	}
 	return pfeImage + ":" + pfeTag, performanceImage + ":" + performanceTag, keycloakImage + ":" + keycloakTag, gatekeeperImage + ":" + gatekeeperTag
+}
+
+// Get kubeconfig
+func getKubeConfig() (*rest.Config, error) {
+	var config *rest.Config
+	var err error
+
+	// Use KUBECONFIG environment variable if set
+	if kubeconfig, ok := os.LookupEnv("KUBECONFIG"); ok {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
+			return nil, &RemInstError{errOpNotFound, err, err.Error()}
+		}
+		return config, nil
+	}
+
+	homeDir := getHomeDir()
+
+	kubeconfig := filepath.Join(homeDir, ".kube", "config")
+	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		inClusterConfig, inClusterConfigErr := rest.InClusterConfig()
+		if inClusterConfigErr != nil {
+			logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
+			return nil, &RemInstError{errOpNotFound, err, err.Error()}
+		}
+		return inClusterConfig, nil
+	}
+
+	return config, nil
 }
 
 // Get home directory
@@ -258,7 +292,7 @@ func WaitForPodReady(clientset *kubernetes.Clientset, codewindInstance Codewind,
 	var waitTime int64 = 30
 
 	watcher, err := clientset.CoreV1().Pods(codewindInstance.Namespace).Watch(metav1.ListOptions{
-		LabelSelector: labelSelector,
+		LabelSelector:  labelSelector,
 		TimeoutSeconds: &waitTime,
 	})
 	if err != nil {
@@ -269,10 +303,10 @@ func WaitForPodReady(clientset *kubernetes.Clientset, codewindInstance Codewind,
 	lastReason := ""
 	changeEvent := watcher.ResultChan()
 	for {
-		event, channelOk := <- changeEvent
+		event, channelOk := <-changeEvent
 		if !channelOk {
 			// Channel closed, no event value. (Watch probably timed out.)
-			logr.Warnf("Watch for Pod %v ended. Timeout or connection error.", podName);
+			logr.Warnf("Watch for Pod %v ended. Timeout or connection error.", podName)
 			return false
 		}
 		foundPod, castOk := event.Object.(*corev1.Pod)

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -76,7 +76,6 @@ func getKubeConfig() (*rest.Config, error) {
 	// Use KUBECONFIG environment variable if set
 	kubeconfig, ok := os.LookupEnv("KUBECONFIG")
 	if ok {
-	if ok {
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -86,7 +86,7 @@ func getKubeConfig() (*rest.Config, error) {
 
 	homeDir := getHomeDir()
 
-	kubeconfig := filepath.Join(homeDir, ".kube", "config")
+	kubeconfig = filepath.Join(homeDir, ".kube", "config")
 	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		inClusterConfig, inClusterConfigErr := rest.InClusterConfig()


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Resolve Kubernetes config with the follow precedence:

1. Check for config under $KUBECONFIG
2. Check for config under $HOME/.kube/config
3. Use the 'In-cluster config' if present.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2051

## Does this PR require a documentation change ?

Not required, but it would be nice (especially for IKS which generally recommends exporting `KUBECONFIG`)

## Any special notes for your reviewer ?

This PR is still a WIP. I would like advice regarding:

• Best practises for writing/modifying code (e.g. code styling, or do I need to update the CLI's help text)
• Should I apply this fix to other [remote] operations (e.g. https://github.com/eclipse/codewind-installer/blob/master/pkg/remote/remove.go#L207-L209)