### PR TITLE
logging tests call incorrect function

### DIFF
--- a/pkg/apiroutes/logging_test.go
+++ b/pkg/apiroutes/logging_test.go
@@ -46,7 +46,7 @@ func Test_GetLogLevels(t *testing.T) {
 	})
 	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
 		mockClientFalse := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: nil}
-		_, err := GetIgnoredPaths(mockClientFalse, &mockConnection, "nodejs", "dummyurl")
+		_, err := GetLogLevel(&mockConnection, "mockURL", mockClientFalse)
 		assert.Error(t, err)
 	})
 }
@@ -61,7 +61,7 @@ func Test_SetLogLevels(t *testing.T) {
 	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
 		mockConnection := connections.Connection{ID: "local"}
 		mockClientFalse := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: nil}
-		_, err := GetIgnoredPaths(mockClientFalse, &mockConnection, "nodejs", "dummyurl")
+		err := SetLogLevel(&mockConnection, "mockURL", mockClientFalse, "debug")
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

These tests mistakingly called function from ignoredPaths, as a consequence of copying and pasting boilerplate code. 

This PR calls the correct functions from logging. The setup and assertions remain the same.

## Does this PR require a documentation change ?

No

## Any special notes for your reviewer ?

Sorry! 🙈 


