### PR TITLE
Add 'registrysecrets' command to manipulate docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,26 +141,27 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 
 ### CLI Commands
 
-| Command     | Alias | Usage                                                               |
-| ----------- | ----- | ------------------------------------------------------------------- |
-| project     |       | 'Manage Codewind projects'                                          |
-| install     | `in`  | 'Pull pfe & performance images from dockerhub'                      |
-| start       |       | 'Start the Codewind containers'                                     |
-| status      |       | 'Print the installation status of Codewind'                         |
-| stop        |       | 'Stop the running Codewind containers'                              |
-| stop-all    |       | 'Stop all of the Codewind and project containers'                   |
-| remove      | `rm`  | 'Remove Codewind and Project docker images'                         |
-| templates   |       | 'Manage project templates'                                          |
-| version     |       | 'Print the versions of Codewind containers, for a given connection' |
-| sectoken    | `st`  | 'Authenticate with username and password to obtain an access_token' |
-| secrole     | `sl`  | 'Manage realm based ACCESS roles'                                   |
-| secrealm    | `sr`  | 'Manage new or existing REALM configurations'                       |
-| secclient   | `sc`  | 'Manage new or existing APPLICATION access configurations'          |
-| seckeyring  | `sk`  | 'Manage Codewind keys in the desktop keyring'                       |
-| secuser     | `su`  | 'Manage new or existing USER access configurations'                 |
-| connections | `con` | 'Manage connections configuration list'                             |
-| loglevels   | `log` | 'Get or set logging levels for Codewind containers'                 |
-| help        | `h`   | 'Shows a list of commands or help for one command'                  |
+| Command         | Alias | Usage                                                               |
+| ----------------| ----- | ------------------------------------------------------------------- |
+| project         |       | 'Manage Codewind projects'                                          |
+| install         | `in`  | 'Pull pfe & performance images from dockerhub'                      |
+| start           |       | 'Start the Codewind containers'                                     |
+| status          |       | 'Print the installation status of Codewind'                         |
+| stop            |       | 'Stop the running Codewind containers'                              |
+| stop-all        |       | 'Stop all of the Codewind and project containers'                   |
+| remove          | `rm`  | 'Remove Codewind and Project docker images'                         |
+| templates       |       | 'Manage project templates'                                          |
+| version         |       | 'Print the versions of Codewind containers, for a given connection' |
+| sectoken        | `st`  | 'Authenticate with username and password to obtain an access_token' |
+| secrole         | `sl`  | 'Manage realm based ACCESS roles'                                   |
+| secrealm        | `sr`  | 'Manage new or existing REALM configurations'                       |
+| secclient       | `sc`  | 'Manage new or existing APPLICATION access configurations'          |
+| seckeyring      | `sk`  | 'Manage Codewind keys in the desktop keyring'                       |
+| secuser         | `su`  | 'Manage new or existing USER access configurations'                 |
+| connections     | `con` | 'Manage connections configuration list'                             |
+| loglevels       | `log` | 'Get or set logging levels for Codewind containers'                 |
+| registrysecrets | `rs`  | 'Manage docker registry secrets'                                    |
+| help            | `h`   | 'Shows a list of commands or help for one command'                  |
 
 ### Command Options:
 
@@ -481,6 +482,29 @@ Subcommands:</br>
 
 > **Flags:**
 > --namespace value The namespace to check (defaults to all)
+
+## registrysecrets
+
+Subcommands:</br>
+
+`add/a` - Add a new docker registry secret
+
+> **Flags:**
+> --conid value Connection ID (see the connections cmd). Defaults to `local`.
+> --address value The address of the docker registry
+> --username value The username for the docker registry
+> --password value The the password for the docker registry
+
+`list/ls` - List the docker registries and usernames
+
+> **Flags:**
+> --conid value Connection ID (see the connections cmd). Defaults to `local`.
+
+`remove/rm` - Remove a docker registry secret
+
+> **Flags:**
+> --conid value Connection ID (see the connections cmd). Defaults to `local`.
+> --address value The address of the docker registry to remove
 
 ## help
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Subcommands:</br>
 
 Subcommands:</br>
 
-`add/a` - Add a new docker registry secret
+`add/a` - Add a new docker registry secret and return the updated list of secrets
 
 > **Flags:**
 > --conid value Connection ID (see the connections cmd). Defaults to `local`.
@@ -495,12 +495,12 @@ Subcommands:</br>
 > --username value The username for the docker registry
 > --password value The password for the docker registry
 
-`list/ls` - List the docker registries and usernames
+`list/ls` - List the docker secrets (registries and usernames)
 
 > **Flags:**
 > --conid value Connection ID (see the connections cmd). Defaults to `local`.
 
-`remove/rm` - Remove a docker registry secret
+`remove/rm` - Remove a docker registry secret and return the updated list of secrets
 
 > **Flags:**
 > --conid value Connection ID (see the connections cmd). Defaults to `local`.

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Subcommands:</br>
 > --conid value Connection ID (see the connections cmd). Defaults to `local`.
 > --address value The address of the docker registry
 > --username value The username for the docker registry
-> --password value The the password for the docker registry
+> --password value The password for the docker registry
 
 `list/ls` - List the docker registries and usernames
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -868,6 +868,53 @@ func Commands() {
 			},
 		},
 		{
+			Name:    "registrysecrets",
+			Aliases: []string{"rs"},
+			Usage:   "List, add or remove docker registry secrets for Codewind containers",
+			Subcommands: []cli.Command{
+				{
+					Name:    "add",
+					Aliases: []string{"a"},
+					Usage:   "Add a new docker registry secret",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "conid", Value: "local", Usage: "Connection ID", Required: false},
+						cli.StringFlag{Name: "address,a", Value: "local", Usage: "Registry address", Required: true},
+						cli.StringFlag{Name: "username,u", Value: "local", Usage: "Registry username", Required: true},
+						cli.StringFlag{Name: "password,p", Value: "local", Usage: "Registry password", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						AddRegistrySecret(c)
+						return nil
+					},
+				},
+				{
+					Name:    "list",
+					Aliases: []string{"ls"},
+					Usage:   "List docker registries and usernames",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "conid", Value: "local", Usage: "Connection ID", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						GetRegistrySecrets(c)
+						return nil
+					},
+				},
+				{
+					Name:    "remove",
+					Aliases: []string{"rm"},
+					Usage:   "Remove a docker registry secret",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "conid", Value: "local", Usage: "Connection ID", Required: false},
+						cli.StringFlag{Name: "address,a", Value: "local", Usage: "Registry address", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						RemoveRegistrySecret(c)
+						return nil
+					},
+				},
+			},
+		},
+		{
 			Name:    "version",
 			Aliases: []string{"v"},
 			Usage:   "Get versions of deployed Codewind containers",

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -875,12 +875,12 @@ func Commands() {
 				{
 					Name:    "add",
 					Aliases: []string{"a"},
-					Usage:   "Add a new docker registry secret",
+					Usage:   "Add a new docker registry secret and return the updated list of secrets",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "Connection ID", Required: false},
-						cli.StringFlag{Name: "address,a", Value: "local", Usage: "Registry address", Required: true},
-						cli.StringFlag{Name: "username,u", Value: "local", Usage: "Registry username", Required: true},
-						cli.StringFlag{Name: "password,p", Value: "local", Usage: "Registry password", Required: true},
+						cli.StringFlag{Name: "address,a", Usage: "Registry address", Required: true},
+						cli.StringFlag{Name: "username,u", Usage: "Registry username", Required: true},
+						cli.StringFlag{Name: "password,p", Usage: "Registry password", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						AddRegistrySecret(c)
@@ -890,7 +890,7 @@ func Commands() {
 				{
 					Name:    "list",
 					Aliases: []string{"ls"},
-					Usage:   "List docker registries and usernames",
+					Usage:   "List the docker secrets (registries and usernames)",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "Connection ID", Required: false},
 					},
@@ -902,10 +902,10 @@ func Commands() {
 				{
 					Name:    "remove",
 					Aliases: []string{"rm"},
-					Usage:   "Remove a docker registry secret",
+					Usage:   "Remove a docker registry secret and return the updated list of secrets",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "Connection ID", Required: false},
-						cli.StringFlag{Name: "address,a", Value: "local", Usage: "Registry address", Required: true},
+						cli.StringFlag{Name: "address,a", Usage: "Registry address", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						RemoveRegistrySecret(c)

--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -24,21 +24,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-// GetRegistrySecrets : Optionally set retrieve docker registry secrets.
+// GetRegistrySecrets : Retrieve docker registry secrets.
 func GetRegistrySecrets(c *cli.Context) {
-	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-
-	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
-	if conInfoErr != nil {
-		fmt.Println(conInfoErr.Err)
-		os.Exit(1)
-	}
-
-	conURL, conErr := config.PFEOriginFromConnection(conInfo)
-	if conErr != nil {
-		fmt.Println(conErr.Err)
-		os.Exit(1)
-	}
+	conInfo, conURL := getConnectionDetailsOrExit(c)
 
 	registrySecrets, err := apiroutes.GetRegistrySecrets(conInfo, conURL, http.DefaultClient)
 	if err != nil {
@@ -48,20 +36,9 @@ func GetRegistrySecrets(c *cli.Context) {
 	utils.PrettyPrintJSON(registrySecrets)
 }
 
+// AddRegistrySecret : Set a docker registry secret.
 func AddRegistrySecret(c *cli.Context) {
-	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-
-	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
-	if conInfoErr != nil {
-		fmt.Println(conInfoErr.Err)
-		os.Exit(1)
-	}
-
-	conURL, conErr := config.PFEOriginFromConnection(conInfo)
-	if conErr != nil {
-		fmt.Println(conErr.Err)
-		os.Exit(1)
-	}
+	conInfo, conURL := getConnectionDetailsOrExit(c)
 
 	address := strings.TrimSpace(c.String("address"))
 	username := strings.TrimSpace(c.String("username"))
@@ -75,20 +52,9 @@ func AddRegistrySecret(c *cli.Context) {
 	utils.PrettyPrintJSON(registrySecrets)
 }
 
+// RemoveRegistrySecret : Delete a docker registry secret.
 func RemoveRegistrySecret(c *cli.Context) {
-	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-
-	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
-	if conInfoErr != nil {
-		fmt.Println(conInfoErr.Err)
-		os.Exit(1)
-	}
-
-	conURL, conErr := config.PFEOriginFromConnection(conInfo)
-	if conErr != nil {
-		fmt.Println(conErr.Err)
-		os.Exit(1)
-	}
+	conInfo, conURL := getConnectionDetailsOrExit(c)
 
 	address := strings.TrimSpace(c.String("address"))
 
@@ -98,4 +64,21 @@ func RemoveRegistrySecret(c *cli.Context) {
 		os.Exit(1)
 	}
 	utils.PrettyPrintJSON(registrySecrets)
+}
+
+func getConnectionDetailsOrExit(c *cli.Context) (*connections.Connection, string) {
+	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
+
+	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
+	if conInfoErr != nil {
+		HandleConnectionError(conInfoErr)
+		os.Exit(1)
+	}
+
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		fmt.Println(conErr.Err)
+		os.Exit(1)
+	}
+	return conInfo, conURL
 }

--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/config"
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/urfave/cli"
+)
+
+// GetRegistrySecrets : Optionally set retrieve docker registry secrets.
+func GetRegistrySecrets(c *cli.Context) {
+	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
+
+	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
+	if conInfoErr != nil {
+		fmt.Println(conInfoErr.Err)
+		os.Exit(1)
+	}
+
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		fmt.Println(conErr.Err)
+		os.Exit(1)
+	}
+
+	registrySecrets, err := apiroutes.GetRegistrySecrets(conInfo, conURL, http.DefaultClient)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	utils.PrettyPrintJSON(registrySecrets)
+}
+
+func AddRegistrySecret(c *cli.Context) {
+	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
+
+	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
+	if conInfoErr != nil {
+		fmt.Println(conInfoErr.Err)
+		os.Exit(1)
+	}
+
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		fmt.Println(conErr.Err)
+		os.Exit(1)
+	}
+
+	address := strings.TrimSpace(c.String("address"))
+	username := strings.TrimSpace(c.String("username"))
+	password := strings.TrimSpace(c.String("password"))
+
+	registrySecrets, err := apiroutes.AddRegistrySecret(conInfo, conURL, http.DefaultClient, address, username, password)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	utils.PrettyPrintJSON(registrySecrets)
+}
+
+func RemoveRegistrySecret(c *cli.Context) {
+	connectionID := strings.TrimSpace(strings.ToLower(c.String("conid")))
+
+	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
+	if conInfoErr != nil {
+		fmt.Println(conInfoErr.Err)
+		os.Exit(1)
+	}
+
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		fmt.Println(conErr.Err)
+		os.Exit(1)
+	}
+
+	address := strings.TrimSpace(c.String("address"))
+
+	registrySecrets, err := apiroutes.RemoveRegistrySecret(conInfo, conURL, http.DefaultClient, address)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	utils.PrettyPrintJSON(registrySecrets)
+}

--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -12,7 +12,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -30,7 +29,8 @@ func GetRegistrySecrets(c *cli.Context) {
 
 	registrySecrets, err := apiroutes.GetRegistrySecrets(conInfo, conURL, http.DefaultClient)
 	if err != nil {
-		fmt.Println(err.Error())
+		registryErr := &RegistryError{errOpListRegistries, err, err.Error()}
+		HandleRegistryError(registryErr)
 		os.Exit(1)
 	}
 	utils.PrettyPrintJSON(registrySecrets)
@@ -46,7 +46,8 @@ func AddRegistrySecret(c *cli.Context) {
 
 	registrySecrets, err := apiroutes.AddRegistrySecret(conInfo, conURL, http.DefaultClient, address, username, password)
 	if err != nil {
-		fmt.Println(err.Error())
+		registryErr := &RegistryError{errOpAddRegistry, err, err.Error()}
+		HandleRegistryError(registryErr)
 		os.Exit(1)
 	}
 	utils.PrettyPrintJSON(registrySecrets)
@@ -60,7 +61,8 @@ func RemoveRegistrySecret(c *cli.Context) {
 
 	registrySecrets, err := apiroutes.RemoveRegistrySecret(conInfo, conURL, http.DefaultClient, address)
 	if err != nil {
-		fmt.Println(err.Error())
+		registryErr := &RegistryError{errOpRemoveRegistry, err, err.Error()}
+		HandleRegistryError(registryErr)
 		os.Exit(1)
 	}
 	utils.PrettyPrintJSON(registrySecrets)
@@ -77,7 +79,7 @@ func getConnectionDetailsOrExit(c *cli.Context) (*connections.Connection, string
 
 	conURL, conErr := config.PFEOriginFromConnection(conInfo)
 	if conErr != nil {
-		fmt.Println(conErr.Err)
+		HandleConfigError(conErr)
 		os.Exit(1)
 	}
 	return conInfo, conURL

--- a/pkg/actions/registrysecrets_error.go
+++ b/pkg/actions/registrysecrets_error.go
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import "encoding/json"
+
+// RegistryError struct will format the error
+type RegistryError struct {
+	Op   string
+	Err  error
+	Desc string
+}
+
+const (
+	errOpListRegistries = "LIST_REGISTRIES_ERROR"
+	errOpAddRegistry    = "ADD_REGISTRY_ERROR"
+	errOpRemoveRegistry = "DELETE_REGISTRY_ERROR"
+)
+
+// RegistryError : Error formatted in JSON containing an errorOp and a description
+func (te *RegistryError) Error() string {
+	type Output struct {
+		Operation   string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	tempOutput := &Output{Operation: te.Op, Description: te.Err.Error()}
+	jsonError, _ := json.Marshal(tempOutput)
+	return string(jsonError)
+}

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -80,6 +80,16 @@ func HandleRemInstError(err *remote.RemInstError) {
 	}
 }
 
+// HandleRegistryError prints a Registry error, in JSON format if the global flag is set, and as a string if not
+func HandleRegistryError(err *RegistryError) {
+	// printAsJSON is a global variable, set in commands.go
+	if printAsJSON {
+		fmt.Println(err.Error())
+	} else {
+		logr.Error(err.Desc)
+	}
+}
+
 // PrintTable prints a formatted table into the terminal
 func PrintTable(content []string) {
 	w := new(tabwriter.Writer)

--- a/pkg/apiroutes/registrysecrets.go
+++ b/pkg/apiroutes/registrysecrets.go
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+)
+
+type (
+	// RegistryResponse : The registry information
+	RegistryResponse struct {
+		Address  string `json:"address"`
+		Username string `json:"username"`
+	}
+
+	// Registry details: The request structure to set the log level
+	RegistryParameters struct {
+		Address     string `json:"address"`
+		Credentials string `json:"credentials"`
+	}
+
+	// Credentials structure. Sent as a base64 encoded string.
+	Credentials struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	// Address parameter, used when removing credentials.
+	AddressParameter struct {
+		Address string `json:"address"`
+	}
+)
+
+// GetRegistrySecrets : Get the current registry secrets for the PFE container
+func GetRegistrySecrets(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient) ([]RegistryResponse, error) {
+	req, err := http.NewRequest("GET", conURL+"/api/v1/registrysecrets", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusOK)
+}
+
+// AddRegistrySecrets : Set a registry secret in the PFE container
+func AddRegistrySecret(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, address string, username string, password string) ([]RegistryResponse, error) {
+
+	// The username and password are sent inside a base64 encoded field in the jsonPayload.
+	credentials := &Credentials{Username: username, Password: password}
+	credentialsStr, _ := json.Marshal(credentials)
+	credentialsBase64 := base64.StdEncoding.EncodeToString([]byte(credentialsStr))
+	registryParameters := &RegistryParameters{Address: address, Credentials: credentialsBase64}
+	jsonPayload, _ := json.Marshal(registryParameters)
+
+	req, err := http.NewRequest("POST", conURL+"/api/v1/registrysecrets", bytes.NewBuffer(jsonPayload))
+	req.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusCreated)
+}
+
+// RemoveRegistrySecret : Remove a registry secret from the PFE container
+func RemoveRegistrySecret(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, address string) ([]RegistryResponse, error) {
+
+	// The username and password are sent inside a base64 encoded field in the jsonPayload.
+	addressParameter := &AddressParameter{Address: address}
+	jsonPayload, _ := json.Marshal(addressParameter)
+
+	req, err := http.NewRequest("DELETE", conURL+"/api/v1/registrysecrets", bytes.NewBuffer(jsonPayload))
+	req.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusOK)
+}
+
+// All three API calls (GET, POST and DELETE) return the same response.
+func handleRegistrySecretsResponse(req *http.Request, conInfo *connections.Connection, httpClient utils.HTTPClient, successCode int) ([]RegistryResponse, error) {
+	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
+	if httpSecError != nil {
+		return nil, httpSecError
+	}
+
+	if resp.StatusCode != successCode {
+		return nil, errors.New(http.StatusText(resp.StatusCode))
+	}
+
+	defer resp.Body.Close()
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var registrySecrets []RegistryResponse
+	err = json.Unmarshal(byteArray, &registrySecrets)
+	if err != nil {
+		return nil, err
+	}
+
+	return registrySecrets, nil
+}

--- a/pkg/apiroutes/registrysecrets.go
+++ b/pkg/apiroutes/registrysecrets.go
@@ -31,19 +31,19 @@ type (
 		Username string `json:"username"`
 	}
 
-	// Registry details: The request structure to set the log level
+	// RegistryParameters : The request structure to set the log level
 	RegistryParameters struct {
 		Address     string `json:"address"`
 		Credentials string `json:"credentials"`
 	}
 
-	// Credentials structure. Sent as a base64 encoded string.
+	// Credentials : Sent as a base64 encoded string.
 	Credentials struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
 	}
 
-	// Address parameter, used when removing credentials.
+	// AddressParameter : Used when removing credentials.
 	AddressParameter struct {
 		Address string `json:"address"`
 	}
@@ -59,7 +59,7 @@ func GetRegistrySecrets(conInfo *connections.Connection, conURL string, httpClie
 	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusOK)
 }
 
-// AddRegistrySecrets : Set a registry secret in the PFE container
+// AddRegistrySecret : Set a registry secret in the PFE container
 func AddRegistrySecret(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, address string, username string, password string) ([]RegistryResponse, error) {
 
 	// The username and password are sent inside a base64 encoded field in the jsonPayload.

--- a/pkg/apiroutes/registrysecrets.go
+++ b/pkg/apiroutes/registrysecrets.go
@@ -16,6 +16,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -101,14 +102,14 @@ func handleRegistrySecretsResponse(req *http.Request, conInfo *connections.Conne
 		return nil, httpSecError
 	}
 
-	if resp.StatusCode != successCode {
-		return nil, errors.New(http.StatusText(resp.StatusCode))
-	}
-
 	defer resp.Body.Close()
 	byteArray, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != successCode {
+		return nil, errors.New(fmt.Sprintf("%s - %s\n", http.StatusText(resp.StatusCode), string(byteArray)))
 	}
 
 	var registrySecrets []RegistryResponse

--- a/pkg/apiroutes/registrysecrets.go
+++ b/pkg/apiroutes/registrysecrets.go
@@ -37,7 +37,7 @@ type (
 		Credentials string `json:"credentials"`
 	}
 
-	// Credentials : Sent as a base64 encoded string.
+	// Credentials : The registry credentials, sent as a base64 encoded string.
 	Credentials struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
@@ -50,7 +50,7 @@ type (
 )
 
 // GetRegistrySecrets : Get the current registry secrets for the PFE container
-func GetRegistrySecrets(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient) ([]RegistryResponse, error) {
+func GetRegistrySecrets(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient) (*[]RegistryResponse, error) {
 	req, err := http.NewRequest("GET", conURL+"/api/v1/registrysecrets", nil)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func GetRegistrySecrets(conInfo *connections.Connection, conURL string, httpClie
 }
 
 // AddRegistrySecret : Set a registry secret in the PFE container
-func AddRegistrySecret(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, address string, username string, password string) ([]RegistryResponse, error) {
+func AddRegistrySecret(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, address string, username string, password string) (*[]RegistryResponse, error) {
 
 	// The username and password are sent inside a base64 encoded field in the jsonPayload.
 	credentials := &Credentials{Username: username, Password: password}
@@ -79,7 +79,7 @@ func AddRegistrySecret(conInfo *connections.Connection, conURL string, httpClien
 }
 
 // RemoveRegistrySecret : Remove a registry secret from the PFE container
-func RemoveRegistrySecret(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, address string) ([]RegistryResponse, error) {
+func RemoveRegistrySecret(conInfo *connections.Connection, conURL string, httpClient utils.HTTPClient, address string) (*[]RegistryResponse, error) {
 
 	// The username and password are sent inside a base64 encoded field in the jsonPayload.
 	addressParameter := &AddressParameter{Address: address}
@@ -95,7 +95,7 @@ func RemoveRegistrySecret(conInfo *connections.Connection, conURL string, httpCl
 }
 
 // All three API calls (GET, POST and DELETE) return the same response.
-func handleRegistrySecretsResponse(req *http.Request, conInfo *connections.Connection, httpClient utils.HTTPClient, successCode int) ([]RegistryResponse, error) {
+func handleRegistrySecretsResponse(req *http.Request, conInfo *connections.Connection, httpClient utils.HTTPClient, successCode int) (*[]RegistryResponse, error) {
 	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
@@ -117,5 +117,5 @@ func handleRegistrySecretsResponse(req *http.Request, conInfo *connections.Conne
 		return nil, err
 	}
 
-	return registrySecrets, nil
+	return &registrySecrets, nil
 }

--- a/pkg/apiroutes/registrysecrets_test.go
+++ b/pkg/apiroutes/registrysecrets_test.go
@@ -46,7 +46,6 @@ func Test_GetRegistrySecrets(t *testing.T) {
 }
 
 func Test_AddRegistrySecret(t *testing.T) {
-
 	t.Run("success case - returns nil error when PFE status code 201", func(t *testing.T) {
 		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
 		jsonResponse, err := json.Marshal(expectedRegistrySecrets)

--- a/pkg/apiroutes/registrysecrets_test.go
+++ b/pkg/apiroutes/registrysecrets_test.go
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package apiroutes
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetRegistrySecrets(t *testing.T) {
+	t.Run("success case - returns nil error when PFE status code 200", func(t *testing.T) {
+		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
+		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
+		if err != nil {
+			t.Fail()
+		}
+		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		mockConnection := connections.Connection{ID: "local"}
+		actualRegistrySecrets, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedRegistrySecrets, actualRegistrySecrets)
+	})
+	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
+		assert.Error(t, err)
+	})
+}
+
+func Test_AddRegistrySecret(t *testing.T) {
+
+	t.Run("success case - returns nil error when PFE status code 201", func(t *testing.T) {
+		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
+		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
+		if err != nil {
+			t.Fail()
+		}
+		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusCreated, Body: body}
+		mockConnection := connections.Connection{ID: "local"}
+		actualRegistrySecrets, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
+		assert.Nil(t, err)
+		assert.Equal(t, expectedRegistrySecrets, actualRegistrySecrets)
+	})
+	t.Run("error case - returns error when PFE status code non 201", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
+		assert.Error(t, err)
+	})
+}
+
+func Test_DeleteRegistrySecret(t *testing.T) {
+	t.Run("success case - returns nil error when PFE status code 200", func(t *testing.T) {
+		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
+		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
+		if err != nil {
+			t.Fail()
+		}
+		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		mockConnection := connections.Connection{ID: "local"}
+		actualRegistrySecrets, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "anothertestdockerregistry")
+		assert.Nil(t, err)
+		assert.Equal(t, expectedRegistrySecrets, actualRegistrySecrets)
+	})
+	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "afakeregistry")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/apiroutes/registrysecrets_test.go
+++ b/pkg/apiroutes/registrysecrets_test.go
@@ -23,19 +23,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const exampleBadJSON = "<This is not JSON>"
+
 func Test_GetRegistrySecrets(t *testing.T) {
 	t.Run("success case - returns nil error when PFE status code 200", func(t *testing.T) {
 		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
 		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
-		if err != nil {
-			t.Fail()
-		}
-		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
-		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		assert.Nil(t, err)
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
 		mockConnection := connections.Connection{ID: "local"}
 		actualRegistrySecrets, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
 		assert.Nil(t, err)
-		assert.Equal(t, expectedRegistrySecrets, actualRegistrySecrets)
+		assert.Equal(t, expectedRegistrySecrets, *actualRegistrySecrets)
 	})
 	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
@@ -43,21 +43,28 @@ func Test_GetRegistrySecrets(t *testing.T) {
 		_, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
 		assert.Error(t, err)
 	})
+	t.Run("error case -  badJSONResponse", func(t *testing.T) {
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(exampleBadJSON)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
+		var registrySecrets []RegistryResponse
+		expectedError := json.Unmarshal([]byte(exampleBadJSON), &registrySecrets)
+		assert.Equal(t, expectedError, err)
+	})
 }
 
 func Test_AddRegistrySecret(t *testing.T) {
 	t.Run("success case - returns nil error when PFE status code 201", func(t *testing.T) {
 		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
 		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
-		if err != nil {
-			t.Fail()
-		}
-		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
-		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusCreated, Body: body}
+		assert.Nil(t, err)
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusCreated, Body: resBody}
 		mockConnection := connections.Connection{ID: "local"}
 		actualRegistrySecrets, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
 		assert.Nil(t, err)
-		assert.Equal(t, expectedRegistrySecrets, actualRegistrySecrets)
+		assert.Equal(t, expectedRegistrySecrets, *actualRegistrySecrets)
 	})
 	t.Run("error case - returns error when PFE status code non 201", func(t *testing.T) {
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
@@ -65,26 +72,42 @@ func Test_AddRegistrySecret(t *testing.T) {
 		_, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
 		assert.Error(t, err)
 	})
+	t.Run("error case -  badJSONResponse", func(t *testing.T) {
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(exampleBadJSON)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusCreated, Body: resBody}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
+		var registrySecrets []RegistryResponse
+		expectedError := json.Unmarshal([]byte(exampleBadJSON), &registrySecrets)
+		assert.Equal(t, expectedError, err)
+	})
 }
 
 func Test_DeleteRegistrySecret(t *testing.T) {
 	t.Run("success case - returns nil error when PFE status code 200", func(t *testing.T) {
 		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
 		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
-		if err != nil {
-			t.Fail()
-		}
-		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
-		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		assert.Nil(t, err)
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
 		mockConnection := connections.Connection{ID: "local"}
 		actualRegistrySecrets, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "anothertestdockerregistry")
 		assert.Nil(t, err)
-		assert.Equal(t, expectedRegistrySecrets, actualRegistrySecrets)
+		assert.Equal(t, expectedRegistrySecrets, *actualRegistrySecrets)
 	})
 	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
 		mockConnection := connections.Connection{ID: "local"}
 		_, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "afakeregistry")
 		assert.Error(t, err)
+	})
+	t.Run("error case -  badJSONResponse", func(t *testing.T) {
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(exampleBadJSON)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "anothertestdockerregistry")
+		var registrySecrets []RegistryResponse
+		expectedError := json.Unmarshal([]byte(exampleBadJSON), &registrySecrets)
+		assert.Equal(t, expectedError, err)
 	})
 }

--- a/pkg/apiroutes/registrysecrets_test.go
+++ b/pkg/apiroutes/registrysecrets_test.go
@@ -38,7 +38,8 @@ func Test_GetRegistrySecrets(t *testing.T) {
 		assert.Equal(t, expectedRegistrySecrets, *actualRegistrySecrets)
 	})
 	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
-		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
+		emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: emptyBody}
 		mockConnection := connections.Connection{ID: "local"}
 		_, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
 		assert.Error(t, err)
@@ -67,7 +68,8 @@ func Test_AddRegistrySecret(t *testing.T) {
 		assert.Equal(t, expectedRegistrySecrets, *actualRegistrySecrets)
 	})
 	t.Run("error case - returns error when PFE status code non 201", func(t *testing.T) {
-		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
+		emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: emptyBody}
 		mockConnection := connections.Connection{ID: "local"}
 		_, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
 		assert.Error(t, err)
@@ -96,7 +98,8 @@ func Test_DeleteRegistrySecret(t *testing.T) {
 		assert.Equal(t, expectedRegistrySecrets, *actualRegistrySecrets)
 	})
 	t.Run("error case - returns error when PFE status code non 200", func(t *testing.T) {
-		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: nil}
+		emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: emptyBody}
 		mockConnection := connections.Connection{ID: "local"}
 		_, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "afakeregistry")
 		assert.Error(t, err)


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?

Adds 'registrysecrets' command to manipulate docker registry secrets through the /api/v1/registrysecrets REST API.
 - Adds commands to add a secret, delete a secret and list
secrets.
 - Adds testcases.
 - Updates README.md with the details of the new command.

## Which issue(s) does this PR fix ?
This is part of https://github.com/eclipse/codewind/issues/1306 and adds the `cwctl registrysecrets` command to wrap the /api/v1/registrysecrets REST API.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1306


## Does this PR require a documentation change ?
We don't expect users to use cwctl directly. The README.md for cwctl is updated as part of this PR.

## Any special notes for your reviewer ?
