### PR TITLE
Remove extra implementation of PrettyPrintJSON

### DIFF
--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -22,6 +22,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/project"
+	"github.com/eclipse/codewind-installer/pkg/utils"
 	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -109,7 +110,7 @@ func UpgradeProjects(c *cli.Context) {
 		HandleProjectError(err)
 		os.Exit(1)
 	}
-	PrettyPrintJSON(response)
+	utils.PrettyPrintJSON(response)
 	os.Exit(0)
 }
 

--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -12,7 +12,6 @@
 package actions
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -34,7 +33,7 @@ func ListTemplates(c *cli.Context) {
 		return
 	}
 	if len(templates) > 0 {
-		PrettyPrintJSON(templates)
+		utils.PrettyPrintJSON(templates)
 	} else {
 		fmt.Println(templates)
 	}
@@ -49,7 +48,7 @@ func ListTemplateStyles(c *cli.Context) {
 		HandleTemplateError(templateErr)
 		return
 	}
-	PrettyPrintJSON(styles)
+	utils.PrettyPrintJSON(styles)
 }
 
 // ListTemplateRepos lists all template repos of which Codewind is aware.
@@ -61,7 +60,7 @@ func ListTemplateRepos(c *cli.Context) {
 		HandleTemplateError(templateErr)
 		return
 	}
-	PrettyPrintJSON(repos)
+	utils.PrettyPrintJSON(repos)
 }
 
 // AddTemplateRepo adds the provided template repo to PFE.
@@ -80,7 +79,7 @@ func AddTemplateRepo(c *cli.Context) {
 	if err == nil {
 		utils.OnAddTemplateRepo(extensions, url, repos)
 	}
-	PrettyPrintJSON(repos)
+	utils.PrettyPrintJSON(repos)
 }
 
 // DeleteTemplateRepo deletes the provided template repo from PFE.
@@ -100,7 +99,7 @@ func DeleteTemplateRepo(c *cli.Context) {
 		HandleTemplateError(templateErr)
 		return
 	}
-	PrettyPrintJSON(repos)
+	utils.PrettyPrintJSON(repos)
 }
 
 // EnableTemplateRepos enables templates repo of which Codewind is aware.
@@ -112,7 +111,7 @@ func EnableTemplateRepos(c *cli.Context) {
 		HandleTemplateError(templateErr)
 		return
 	}
-	PrettyPrintJSON(repos)
+	utils.PrettyPrintJSON(repos)
 }
 
 // DisableTemplateRepos disables templates repo of which Codewind is aware.
@@ -124,11 +123,5 @@ func DisableTemplateRepos(c *cli.Context) {
 		HandleTemplateError(templateErr)
 		return
 	}
-	PrettyPrintJSON(repos)
-}
-
-// PrettyPrintJSON prints JSON prettily.
-func PrettyPrintJSON(i interface{}) {
-	s, _ := json.MarshalIndent(i, "", "\t")
-	fmt.Println(string(s))
+	utils.PrettyPrintJSON(repos)
 }

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -20,6 +20,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/utils"
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
 	"github.com/eclipse/codewind-installer/pkg/remote"
@@ -58,7 +59,7 @@ func GetSingleConnectionVersion(c *cli.Context) {
 	}
 
 	if printAsJSON {
-		PrettyPrintJSON(containerVersions)
+		utils.PrettyPrintJSON(containerVersions)
 	} else {
 		var tableContent []string
 		tableContent = append(tableContent, "CWCTL VERSION: "+containerVersions.CwctlVersion+"\n")
@@ -84,7 +85,7 @@ func GetAllConnectionVersions() {
 	}
 
 	if printAsJSON {
-		PrettyPrintJSON(containerVersionsList)
+		utils.PrettyPrintJSON(containerVersionsList)
 	} else {
 		var tableContent []string
 		tableContent = append(tableContent, "CWCTL VERSION: "+containerVersionsList.CwctlVersion+"\n")
@@ -113,7 +114,7 @@ func RemoteListAll(c *cli.Context) {
 		os.Exit(1)
 	}
 	if printAsJSON {
-		PrettyPrintJSON(remoteInstalls)
+		utils.PrettyPrintJSON(remoteInstalls)
 	} else {
 		var tableContent []string
 		tableContent = append(tableContent, "Workspace ID \tNamespace \tVersion \tInstall Date \tAuth Realm \tURL")


### PR DESCRIPTION
##  What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?

It removes an extra implementation of `PrettyPrintJSON` from `pkg/actions/templates.go` and switches that file and other files in that package to use the version from our `utils` package. The other files in our actions package were using a mixture of `PrettyPrintJSON` from templates.go and the utils package. Both versions of `PrettyPrintJSON` were identical.

## Which issue(s) does this PR fix ?

N/A - Nit, fix for consistency.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?

No.

## Any special notes for your reviewer ?
