### PR TITLE
Handle bad JSON in the response from /api/v1/projects/bind/start

### DIFF
--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -158,8 +158,10 @@ func bindToPFE(client utils.HTTPClient, bindRequest BindRequest, conInfo *connec
 	}
 
 	var projectInfo *BindResponse
-	if err := json.Unmarshal(bodyBytes, &projectInfo); err != nil {
+	err = json.Unmarshal(bodyBytes, &projectInfo)
+	if err != nil {
 		logr.Errorln(err)
+		return nil, &ProjectError{errOpResponse, err, err.Error()}
 	}
 
 	return projectInfo, nil


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
- Returns an error on bad JSON from a call to /api/v1/projects/bind/start in `bindToPFE()`
- Adds a test for `bindToPFE()` with a bad JSON response.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2319

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2319

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
There are other locations in the installer where we aren't checking the response we receive is valid JSON. These need fixing and testing too but there's more than one PR's worth. @liamchampton is raising an issue about test coverage and I will add these problems to that.