### PR TITLE
Retry template request on lock

### DIFF
--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
@@ -78,7 +79,8 @@ func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template,
 	}
 	req.URL.RawQuery = query.Encode()
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
+
+	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -110,7 +112,7 @@ func GetTemplateStyles(conID string) ([]string, error) {
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
+	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -142,7 +144,7 @@ func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
+	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -189,7 +191,7 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
+	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -232,7 +234,7 @@ func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
 	req, _ := http.NewRequest("DELETE", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
+	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -335,7 +337,7 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
-	resp, httpSecError := sechttp.DispatchHTTPRequest(client, req, conInfo)
+	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -354,4 +356,23 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 	json.Unmarshal(byteArray, &subResponsesFromBatchOperation)
 
 	return subResponsesFromBatchOperation, nil
+}
+
+// HTTPRequestWithRetryOnLock : Retries a request until either the maxHTTPRetries limit has been hit or the response status code is not equal to 423 (templates locked HTTP code)
+func HTTPRequestWithRetryOnLock(httpClient utils.HTTPClient, originalRequest *http.Request, connection *connections.Connection) (*http.Response, *sechttp.HTTPSecError) {
+	var maxHTTPRetries int = 5
+	var templatesLockedHTTPStatusCode = 423
+	var response *http.Response
+	for i := 0; i < maxHTTPRetries; i++ {
+		resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, originalRequest, connection)
+		if httpSecError != nil {
+			return nil, httpSecError
+		} else if resp.StatusCode != templatesLockedHTTPStatusCode || i+1 == maxHTTPRetries {
+			response = resp
+			break
+		} else {
+			time.Sleep(time.Second)
+		}
+	}
+	return response, nil
 }

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -80,7 +80,7 @@ func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template,
 	req.URL.RawQuery = query.Encode()
 	client := &http.Client{}
 
-	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
+	resp, httpSecError := httpRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -112,7 +112,7 @@ func GetTemplateStyles(conID string) ([]string, error) {
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
+	resp, httpSecError := httpRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -144,7 +144,7 @@ func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
+	resp, httpSecError := httpRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -191,7 +191,7 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 		return nil, err
 	}
 	client := &http.Client{}
-	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
+	resp, httpSecError := httpRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -234,7 +234,7 @@ func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
 	req, _ := http.NewRequest("DELETE", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
-	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
+	resp, httpSecError := httpRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -337,7 +337,7 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
-	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
+	resp, httpSecError := httpRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
@@ -358,8 +358,8 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 	return subResponsesFromBatchOperation, nil
 }
 
-// HTTPRequestWithRetryOnLock : Retries a request until either the maxHTTPRetries limit has been hit or the response status code is not equal to 423 (templates locked HTTP code)
-func HTTPRequestWithRetryOnLock(httpClient utils.HTTPClient, originalRequest *http.Request, connection *connections.Connection) (*http.Response, *sechttp.HTTPSecError) {
+// httpRequestWithRetryOnLock : Retries a request until either the maxHTTPRetries limit has been hit or the response status code is not equal to 423 (templates locked HTTP code)
+func httpRequestWithRetryOnLock(httpClient utils.HTTPClient, originalRequest *http.Request, connection *connections.Connection) (*http.Response, *sechttp.HTTPSecError) {
 	var maxHTTPRetries int = 5
 	var templatesLockedHTTPStatusCode = 423
 	var response *http.Response

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -360,20 +360,20 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 
 // HTTPRequestWithRetryOnLock : Retries a request until either the maxHTTPRetries limit has been hit or the response status code is not equal to 423 (templates locked HTTP code)
 func HTTPRequestWithRetryOnLock(httpClient utils.HTTPClient, originalRequest *http.Request, connection *connections.Connection) (*http.Response, *sechttp.HTTPSecError) {
-	// maxHTTPRequests is the total number of requests, 1 for the intial and the rest are retries
+	// maxHTTPRequests is the total number of requests, 1 for the initial and the rest are retries
 	var maxHTTPRequests = 5
 	var templatesLockedHTTPStatusCode = http.StatusLocked
-	var response *http.Response
 	for i := 0; i < maxHTTPRequests; i++ {
 		resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, originalRequest, connection)
 		if httpSecError != nil {
 			return nil, httpSecError
-		} else if resp.StatusCode != templatesLockedHTTPStatusCode || i+1 == maxHTTPRequests {
-			response = resp
-			break
-		} else {
-			time.Sleep(time.Second)
 		}
+
+		if resp.StatusCode != templatesLockedHTTPStatusCode || i+1 == maxHTTPRequests {
+			return resp, nil
+		}
+
+		time.Sleep(time.Second)
 	}
-	return response, nil
+	return nil, nil
 }

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -361,15 +361,14 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 // HTTPRequestWithRetryOnLock : Retries a request until either the maxHTTPRetries limit has been hit or the response status code is not equal to 423 (templates locked HTTP code)
 func HTTPRequestWithRetryOnLock(httpClient utils.HTTPClient, originalRequest *http.Request, connection *connections.Connection) (*http.Response, *sechttp.HTTPSecError) {
 	// maxHTTPRequests is the total number of requests, 1 for the initial and the rest are retries
-	var maxHTTPRequests = 5
-	var templatesLockedHTTPStatusCode = http.StatusLocked
+	maxHTTPRequests := 5
 	for i := 0; i < maxHTTPRequests; i++ {
 		resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, originalRequest, connection)
 		if httpSecError != nil {
 			return nil, httpSecError
 		}
 
-		if resp.StatusCode != templatesLockedHTTPStatusCode || i+1 == maxHTTPRequests {
+		if resp.StatusCode != http.StatusLocked || i+1 == maxHTTPRequests {
 			return resp, nil
 		}
 

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -481,8 +481,8 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 	// This test block cleans up after itself, assuming that the template repo tested was initially enabled. (This test block resets it to 'enabled')
 }
 
-func Test_HTTPRequestWithRetryOnLock(t *testing.T) {
-	t.Run("Checks that the 423 is returned if the response StatusCode is always 423", func(t *testing.T) {
+func TestHTTPRequestWithRetryOnLock(t *testing.T) {
+	t.Run("Checks 423 is returned if the response StatusCode is always 423", func(t *testing.T) {
 		mockClient := &MockResponse{StatusCode: http.StatusLocked}
 		mockConnection := connections.Connection{ID: "local"}
 		mockReq, _ := http.NewRequest("", "", nil)
@@ -494,7 +494,7 @@ func Test_HTTPRequestWithRetryOnLock(t *testing.T) {
 		assert.Equal(t, expectedResp, resp)
 		assert.Nil(t, httpSecError)
 	})
-	t.Run("Checks that a non 423 status code can be returned", func(t *testing.T) {
+	t.Run("Checks that a non 423 StatusCode can be returned", func(t *testing.T) {
 		mockClient := &MockResponse{StatusCode: http.StatusInternalServerError}
 		mockConnection := connections.Connection{ID: "local"}
 		mockReq, _ := http.NewRequest("", "", nil)

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -14,8 +14,10 @@ package apiroutes
 import (
 	"errors"
 	"log"
+	"net/http"
 	"testing"
 
+	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -477,4 +479,39 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 	}
 
 	// This test block cleans up after itself, assuming that the template repo tested was initially enabled. (This test block resets it to 'enabled')
+}
+
+func Test_HTTPRequestWithRetryOnLock(t *testing.T) {
+	t.Run("Checks that the 423 is returned if the response StatusCode is always 423", func(t *testing.T) {
+		mockClient := &MockResponse{StatusCode: http.StatusLocked}
+		mockConnection := connections.Connection{ID: "local"}
+		mockReq, _ := http.NewRequest("", "", nil)
+
+		resp, httpSecError := HTTPRequestWithRetryOnLock(mockClient, mockReq, &mockConnection)
+		expectedResp := &http.Response{
+			StatusCode: http.StatusLocked,
+		}
+		assert.Equal(t, expectedResp, resp)
+		assert.Nil(t, httpSecError)
+	})
+	t.Run("Checks that a non 423 status code can be returned", func(t *testing.T) {
+		mockClient := &MockResponse{StatusCode: http.StatusInternalServerError}
+		mockConnection := connections.Connection{ID: "local"}
+		mockReq, _ := http.NewRequest("", "", nil)
+
+		resp, httpSecError := HTTPRequestWithRetryOnLock(mockClient, mockReq, &mockConnection)
+		expectedResp := &http.Response{
+			StatusCode: http.StatusInternalServerError,
+		}
+		assert.Equal(t, expectedResp, resp)
+		assert.Nil(t, httpSecError)
+	})
+	t.Run("Checks secError is returned by not using a mocked client (URL doesn't exist)", func(t *testing.T) {
+		mockConnection := connections.Connection{ID: "local"}
+		req, _ := http.NewRequest("GET", "nonexistanturl", nil)
+
+		resp, httpSecError := HTTPRequestWithRetryOnLock(http.DefaultClient, req, &mockConnection)
+		assert.Nil(t, resp)
+		assert.Equal(t, "tx_connection", httpSecError.Op)
+	})
 }


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Accompanies https://github.com/eclipse/codewind/pull/2346.
This PR allows the CLI to retry a HTTP request to the Templates API up to five times (const value).
This is to reduce the probability of the IDEs seeing the `423 locked` response code.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: Accompanies https://github.com/eclipse/codewind/pull/2346

## Does this PR require a documentation change ?
No.

## Any special notes for your reviewer ?
