### PR TITLE
Fix unbind error messages

### DIFF
--- a/pkg/project/remove.go
+++ b/pkg/project/remove.go
@@ -53,13 +53,13 @@ func RemoveProject(c *cli.Context) *ProjectError {
 	}
 
 	// Unbind the project from codewind
-	err := Unbind(http.DefaultClient, conInfo, conURL, projectID)
-	if err != nil {
-		return &ProjectError{errOpUnbind, err, err.Error()}
+	projError := Unbind(http.DefaultClient, conInfo, conURL, projectID)
+	if projError != nil {
+		return projError
 	}
 
 	// Delete the associated connection file
-	projError := RemoveConnectionFile(projectID)
+	projError = RemoveConnectionFile(projectID)
 	if projError != nil {
 		return projError
 	}

--- a/pkg/project/unbind.go
+++ b/pkg/project/unbind.go
@@ -35,7 +35,7 @@ func Unbind(httpClient utils.HTTPClient, connection *connections.Connection, url
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		err := fmt.Errorf("Project unbind failed with status code %s", string(res.StatusCode))
+		err := fmt.Errorf("Project unbind failed with status code %d", res.StatusCode)
 		return &ProjectError{errOpUnbind, err, err.Error()}
 	}
 


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This formats the http status code as an integer instead of using its byte value to create a string which was causing strange characters to be printed on error.
It also removes re-wrapping of the ProjectError returned by unbind inside another project error to fix the nesting of the JSON error.


## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2193
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2193
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
