### PR TITLE
Add support for persisting the docker registry credentials

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -15,6 +15,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"os"
+	"path"
 
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	desktoputils "github.com/eclipse/codewind-installer/pkg/desktop_utils"
@@ -24,7 +25,7 @@ import (
 )
 
 var homeDir = desktoputils.GetHomeDir()
-var dockerComposeFile = homeDir + "/.codewind/docker-compose.yaml"
+var dockerComposeFile = path.Join(homeDir, ".codewind", "docker-compose.yaml")
 var printAsJSON = false
 
 const healthEndpoint = "/api/v1/environment"

--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -50,6 +50,14 @@ func AddRegistrySecret(c *cli.Context) {
 		HandleRegistryError(registryErr)
 		os.Exit(1)
 	}
+
+	// If this is a local we need to persist the details in the keychain for
+	// the next time Codewind starts.
+	// (On Kubernetes PFE persists them in a secret inside Kubernetes itself.)
+	if conInfo.ID == "local" {
+		utils.AddDockerCredential(conInfo.ID, address, username, password)
+	}
+
 	utils.PrettyPrintJSON(registrySecrets)
 }
 
@@ -65,6 +73,9 @@ func RemoveRegistrySecret(c *cli.Context) {
 		HandleRegistryError(registryErr)
 		os.Exit(1)
 	}
+	// Remove secret from our keychain entry.
+	// (But don't logout of docker locally.)
+	utils.RemoveDockerCredential(conInfo.ID, address)
 	utils.PrettyPrintJSON(registrySecrets)
 }
 

--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -51,11 +51,15 @@ func AddRegistrySecret(c *cli.Context) {
 		os.Exit(1)
 	}
 
-	// If this is a local we need to persist the details in the keychain for
+	// If this is a local connection we need to persist the details in the keychain for
 	// the next time Codewind starts.
 	// (On Kubernetes PFE persists them in a secret inside Kubernetes itself.)
 	if conInfo.ID == "local" {
-		utils.AddDockerCredential(conInfo.ID, address, username, password)
+		dockerErr := utils.AddDockerCredential(conInfo.ID, address, username, password)
+		if dockerErr != nil {
+			HandleDockerError(dockerErr)
+			os.Exit(1)
+		}
 	}
 
 	utils.PrettyPrintJSON(registrySecrets)
@@ -75,7 +79,11 @@ func RemoveRegistrySecret(c *cli.Context) {
 	}
 	// Remove secret from our keychain entry.
 	// (But don't logout of docker locally.)
-	utils.RemoveDockerCredential(conInfo.ID, address)
+	dockerErr := utils.RemoveDockerCredential(conInfo.ID, address)
+	if dockerErr != nil {
+		HandleDockerError(dockerErr)
+		os.Exit(1)
+	}
 	utils.PrettyPrintJSON(registrySecrets)
 }
 

--- a/pkg/apiroutes/registrysecrets.go
+++ b/pkg/apiroutes/registrysecrets.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -71,10 +70,10 @@ func AddRegistrySecret(conInfo *connections.Connection, conURL string, httpClien
 	jsonPayload, _ := json.Marshal(registryParameters)
 
 	req, err := http.NewRequest("POST", conURL+"/api/v1/registrysecrets", bytes.NewBuffer(jsonPayload))
-	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusCreated)
 }
@@ -87,10 +86,10 @@ func RemoveRegistrySecret(conInfo *connections.Connection, conURL string, httpCl
 	jsonPayload, _ := json.Marshal(addressParameter)
 
 	req, err := http.NewRequest("DELETE", conURL+"/api/v1/registrysecrets", bytes.NewBuffer(jsonPayload))
-	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusOK)
 }
@@ -109,7 +108,7 @@ func handleRegistrySecretsResponse(req *http.Request, conInfo *connections.Conne
 	}
 
 	if resp.StatusCode != successCode {
-		return nil, errors.New(fmt.Sprintf("%s - %s\n", http.StatusText(resp.StatusCode), string(byteArray)))
+		return nil, fmt.Errorf("%s - %s", http.StatusText(resp.StatusCode), string(byteArray))
 	}
 
 	var registrySecrets []RegistryResponse

--- a/pkg/apiroutes/registrysecrets_test.go
+++ b/pkg/apiroutes/registrysecrets_test.go
@@ -54,7 +54,7 @@ func Test_GetRegistrySecrets(t *testing.T) {
 		_, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
 		assert.Error(t, err)
 	})
-	t.Run("success case - returns error when request fails", func(t *testing.T) {
+	t.Run("error case - returns error when request fails", func(t *testing.T) {
 		mockClient := &security.ClientMockRequestFail{}
 		mockConnection := connections.Connection{ID: "local"}
 		actualRegistrySecrets, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
@@ -68,6 +68,7 @@ func Test_GetRegistrySecrets(t *testing.T) {
 		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
 		mockConnection := connections.Connection{ID: "local"}
+		// Use control characters to create an invalid URL and trigger an error from http.NewRequest
 		_, err = GetRegistrySecrets(&mockConnection, "\x00\x01\x02\x03\x04\x05\x06\x05\x7F", mockClient)
 		fmt.Println(err)
 		assert.Error(t, err)
@@ -110,7 +111,7 @@ func Test_AddRegistrySecret(t *testing.T) {
 		_, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
 		assert.Error(t, err)
 	})
-	t.Run("success case - returns error when request fails", func(t *testing.T) {
+	t.Run("error case - returns error when request fails", func(t *testing.T) {
 		mockClient := &security.ClientMockRequestFail{}
 		mockConnection := connections.Connection{ID: "local"}
 		actualRegistrySecrets, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
@@ -124,6 +125,7 @@ func Test_AddRegistrySecret(t *testing.T) {
 		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusCreated, Body: resBody}
 		mockConnection := connections.Connection{ID: "local"}
+		// Use control characters to create an invalid URL and trigger an error from http.NewRequest
 		_, err = AddRegistrySecret(&mockConnection, "\x00\x01\x02\x03\x04\x05\x06\x05\x7F", mockClient, "testdockerregistry", "testuser", "testpassword")
 		fmt.Println(err)
 		assert.Error(t, err)
@@ -166,7 +168,7 @@ func Test_DeleteRegistrySecret(t *testing.T) {
 		_, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "afakeregistry")
 		assert.Error(t, err)
 	})
-	t.Run("success case - returns error when request fails", func(t *testing.T) {
+	t.Run("error case - returns error when request fails", func(t *testing.T) {
 		mockClient := &security.ClientMockRequestFail{}
 		mockConnection := connections.Connection{ID: "local"}
 		actualRegistrySecrets, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "anothertestdockerregistry")
@@ -180,6 +182,7 @@ func Test_DeleteRegistrySecret(t *testing.T) {
 		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
 		mockConnection := connections.Connection{ID: "local"}
+		// Use control characters to create an invalid URL and trigger an error from http.NewRequest
 		_, err = RemoveRegistrySecret(&mockConnection, "\x00\x01\x02\x03\x04\x05\x06\x05\x7F", mockClient, "anothertestdockerregistry")
 		fmt.Println(err)
 		assert.Error(t, err)

--- a/pkg/security/testutils.go
+++ b/pkg/security/testutils.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"errors"
 	"io"
 	"net/http"
 )
@@ -20,4 +21,12 @@ func (c *ClientMockAuthenticate) Do(req *http.Request) (*http.Response, error) {
 		StatusCode: c.StatusCode,
 		Body:       c.Body,
 	}, nil
+}
+
+type ClientMockRequestFail struct {
+}
+
+// Do : perform do function
+func (c *ClientMockRequestFail) Do(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("mock http request failure")
 }

--- a/pkg/utils/docker.go
+++ b/pkg/utils/docker.go
@@ -14,6 +14,7 @@ package utils
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	goErr "errors"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -32,7 +34,9 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
+	desktoputils "github.com/eclipse/codewind-installer/pkg/desktop_utils"
 	logr "github.com/sirupsen/logrus"
+	"github.com/zalando/go-keyring"
 )
 
 const pfeImageName = "eclipse/codewind-pfe"
@@ -51,9 +55,12 @@ var containerNames = [...]string{
 	performanceContainerName,
 }
 
+var homeDir = desktoputils.GetHomeDir()
+var dockerConfigSecretFile = path.Join(homeDir, ".codewind", "dockerconfig")
+
 // codewind-docker-compose.yaml data
 var data = `
-version: 2
+version: 3.3
 services:
  ` + pfeContainerName + `:
   image: ${PFE_IMAGE_NAME}${PLATFORM}:${TAG}
@@ -72,6 +79,7 @@ services:
   ports: ["127.0.0.1:${PFE_EXTERNAL_PORT}:9090"]
   volumes: ["/var/run/docker.sock:/var/run/docker.sock","cw-workspace:/codewind-workspace","${WORKSPACE_DIRECTORY}:/mounted-workspace"]
   networks: [network]
+  secrets: [dockerconfig]
  ` + performanceContainerName + `:
   image: ${PERFORMANCE_IMAGE_NAME}${PLATFORM}:${TAG}
   ports: ["127.0.0.1:9095:9095"]
@@ -83,6 +91,9 @@ networks:
     com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"
 volumes:
   cw-workspace:
+secrets:
+  dockerconfig:
+    file: ` + dockerConfigSecretFile + `
 `
 
 // Compose struct for the docker compose yaml file
@@ -98,6 +109,7 @@ type Compose struct {
 			Ports         []string `yaml:"ports"`
 			Volumes       []string `yaml:"volumes"`
 			Networks      []string `yaml:"networks"`
+			Secrets       []string `yaml:"secrets"`
 		} `yaml:"codewind-pfe"`
 		PERFORMANCE struct {
 			Image         string   `yaml:"image"`
@@ -117,7 +129,26 @@ type Compose struct {
 			} `yaml:"driver_opts"`
 		} `yaml:"network"`
 	} `yaml:"networks"`
+	SECRETS struct {
+		DOCKERCONFIG struct {
+			File string `yaml:"file"`
+		} `yaml:"dockerconfig"`
+	} `yaml:"secrets"`
 }
+
+type (
+	// DockerCredential : A single login for a docker registry.
+	DockerCredential struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		Auth     string `json:"auth"`
+	}
+
+	// DockerConfig : The docker config.json object.
+	DockerConfig struct {
+		Auths map[string]DockerCredential `json:"auths"`
+	}
+)
 
 // constant to identify the internal port of PFE in its container
 const internalPFEPort = 9090
@@ -139,6 +170,7 @@ type DockerClient interface {
 	ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error
 	ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error
 	DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error)
+	RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error)
 }
 
 // NewDockerClient creates a new client for the docker API
@@ -161,6 +193,7 @@ func DockerCompose(dockerComposeFile string, tag string, loglevel string) *Docke
 		//print out docker-compose sysout & syserr for error diagnosis
 		fmt.Printf(output.String())
 		DeleteTempFile(dockerComposeFile)
+		ClearDockerConfigSecret()
 		return &DockerError{errOpDockerComposeStart, err, err.Error()}
 	}
 	fmt.Printf("Please wait while containers initialize... %s \n", output.String())
@@ -168,17 +201,20 @@ func DockerCompose(dockerComposeFile string, tag string, loglevel string) *Docke
 		//print out docker-compose sysout & syserr for error diagnosis
 		fmt.Printf(output.String())
 		DeleteTempFile(dockerComposeFile)
+		ClearDockerConfigSecret()
 		return &DockerError{errOpDockerComposeStart, err, err.Error()}
 	}
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
 		DeleteTempFile(dockerComposeFile)
+		ClearDockerConfigSecret()
 		os.Exit(1)
 	}
 
 	if strings.Contains(output.String(), "The image for the service you're trying to recreate has been removed") {
 		DeleteTempFile(dockerComposeFile)
+		ClearDockerConfigSecret()
 		os.Exit(1)
 	}
 	return nil
@@ -187,6 +223,10 @@ func DockerCompose(dockerComposeFile string, tag string, loglevel string) *Docke
 // DockerComposeStop to stop Codewind containers
 func DockerComposeStop(tag, dockerComposeFile string) *DockerError {
 	setupDockerComposeEnvs(tag, "stop", "")
+
+	// Delete the docker configuration file whether we have a clean shutdown or not.
+	ClearDockerConfigSecret()
+
 	cmd := exec.Command("docker-compose", "-f", dockerComposeFile, "rm", "--stop", "-f")
 	output := new(bytes.Buffer)
 	cmd.Stdout = output
@@ -593,4 +633,58 @@ func GetContainerTags(dockerClient DockerClient) ([]string, *DockerError) {
 	}
 	tagArr = RemoveDuplicateEntries(tagArr)
 	return tagArr, nil
+}
+
+// AddDockerCredential : Add (or update) a single docker login in the keychain entry.
+func AddDockerCredential(connectionID string, address string, username string, password string) {
+	dockerConfig := getDockerCredentials(connectionID)
+	authStr := fmt.Sprintf("%s:%s", username, password)
+	authEncoded := base64.StdEncoding.EncodeToString([]byte(authStr))
+	newDockerCredential := DockerCredential{Auth: authEncoded, Username: username, Password: password}
+	dockerConfig.Auths[address] = newDockerCredential
+	setDockerCredentials(connectionID, dockerConfig)
+}
+
+// RemoveDockerCredential : Remove a single docker login in the keychain entry.
+func RemoveDockerCredential(connectionID string, address string) {
+	dockerConfig := getDockerCredentials(connectionID)
+	delete(dockerConfig.Auths, address)
+	setDockerCredentials(connectionID, dockerConfig)
+}
+
+// getDockerCredentials : Get the existing docker credentials from the keychain.
+func getDockerCredentials(connectionID string) *DockerConfig {
+	secret, error := keyring.Get("org.eclipse.codewind"+"."+connectionID, "docker_credentials")
+	if error != nil {
+		if error == keyring.ErrNotFound {
+			secret = "{\"auths\": {}}"
+		} else {
+			fmt.Println("Unable to find registry secrets in keychain")
+			os.Exit(1)
+		}
+	}
+
+	dockerConfig := DockerConfig{}
+
+	jsonErr := json.Unmarshal([]byte(secret), &dockerConfig)
+
+	if jsonErr != nil {
+		fmt.Printf("Error, invalid json in docker config keychain entry - %s\n", jsonErr)
+		os.Exit(1)
+	}
+
+	return &dockerConfig
+}
+
+// setDockerCredentials : Set the docker credentials in the keychain.
+func setDockerCredentials(connectionID string, dockerConfig *DockerConfig) {
+	newSecretBytes, jsonErr := json.MarshalIndent(dockerConfig, "", "  ")
+	// This shouldn't happen as we don't add anything that can't be encoded to the
+	// structure.
+	if jsonErr != nil {
+		fmt.Printf("Error, invalid json in docker config structure - %s\n", jsonErr)
+		os.Exit(1)
+	}
+	newSecret := string(newSecretBytes)
+	keyring.Set("org.eclipse.codewind"+"."+connectionID, "docker_credentials", newSecret)
 }

--- a/pkg/utils/docker_error.go
+++ b/pkg/utils/docker_error.go
@@ -36,6 +36,7 @@ const (
 	errOpImageDigest         = "IMAGE_DIGEST_ERROR"
 	errOpContainerList       = "CONTAINER_LIST_ERROR"
 	errOpImageList           = "IMAGE_LIST_ERROR"
+	errDockerCredential      = "DOCKER_CREDENTIAL_ERROR"
 )
 
 const (

--- a/pkg/utils/docker_test.go
+++ b/pkg/utils/docker_test.go
@@ -495,11 +495,11 @@ func TestAddAndRemoveDockerCredentials(t *testing.T) {
 	auth2Str := fmt.Sprintf("%s:%s", username2, password2)
 	auth2Encoded := base64.StdEncoding.EncodeToString([]byte(auth2Str))
 
-	beforeCredentials := getDockerCredentials("test")
+	beforeCredentials, _ := getDockerCredentials("test")
 
 	// Add the first credential.
 	AddDockerCredential("test", address1, username1, password1)
-	afterAddCredentials1 := getDockerCredentials("test")
+	afterAddCredentials1, _ := getDockerCredentials("test")
 	assert.Equal(t, len(beforeCredentials.Auths)+1, len(afterAddCredentials1.Auths))
 	assert.Equal(t, username1, afterAddCredentials1.Auths[address1].Username)
 	assert.Equal(t, password1, afterAddCredentials1.Auths[address1].Password)
@@ -507,7 +507,7 @@ func TestAddAndRemoveDockerCredentials(t *testing.T) {
 
 	// Add the second credential.
 	AddDockerCredential("test", address2, username2, password2)
-	afterAddCredentials2 := getDockerCredentials("test")
+	afterAddCredentials2, _ := getDockerCredentials("test")
 	assert.Equal(t, len(beforeCredentials.Auths)+2, len(afterAddCredentials2.Auths))
 	assert.Equal(t, username2, afterAddCredentials2.Auths[address2].Username)
 	assert.Equal(t, password2, afterAddCredentials2.Auths[address2].Password)
@@ -515,16 +515,15 @@ func TestAddAndRemoveDockerCredentials(t *testing.T) {
 
 	// Remove the *second* credential. Check we are back where we were after the first add.
 	RemoveDockerCredential("test", address2)
-	afterRemoveCredentials1 := getDockerCredentials("test")
+	afterRemoveCredentials1, _ := getDockerCredentials("test")
 	assert.Equal(t, len(beforeCredentials.Auths)+1, len(afterRemoveCredentials1.Auths))
 	assert.Equal(t, afterAddCredentials1, afterRemoveCredentials1)
 	assert.Equal(t, DockerCredential{}, afterRemoveCredentials1.Auths[address2])
 
 	// Remove the *first* credential. Check we are back where we were at the start.
 	RemoveDockerCredential("test", address1)
-	afterRemoveCredentials2 := getDockerCredentials("test")
+	afterRemoveCredentials2, _ := getDockerCredentials("test")
 	assert.Equal(t, len(beforeCredentials.Auths), len(afterRemoveCredentials2.Auths))
 	assert.Equal(t, beforeCredentials, afterRemoveCredentials2)
 	assert.Equal(t, DockerCredential{}, afterRemoveCredentials2.Auths[address2])
-
 }

--- a/pkg/utils/docker_test.go
+++ b/pkg/utils/docker_test.go
@@ -14,7 +14,9 @@ package utils
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -117,6 +119,10 @@ func (m *mockDockerClientWithCw) DistributionInspect(ctx context.Context, image,
 	}, nil
 }
 
+func (m *mockDockerClientWithCw) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
+}
+
 // This mock client will return valid image and containers lists, without Codewind items
 type mockDockerClientWithoutCw struct {
 }
@@ -160,6 +166,10 @@ func (m *mockDockerClientWithoutCw) DistributionInspect(ctx context.Context, ima
 	}, nil
 }
 
+func (m *mockDockerClientWithoutCw) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
+}
+
 // This mock client will return errors for each call to a docker function
 type mockDockerErrorClient struct {
 }
@@ -199,6 +209,10 @@ func (m *mockDockerErrorClient) ContainerInspect(ctx context.Context, containerI
 
 func (m *mockDockerErrorClient) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
 	return registry.DistributionInspect{}, errDistributionInspect
+}
+
+func (m *mockDockerErrorClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
 }
 
 func TestPullImage(t *testing.T) {
@@ -466,4 +480,51 @@ func TestRemoveDuplicateEntries(t *testing.T) {
 	if len(result) != 0 {
 		log.Fatal("Test 3: Failed to identify empty array values")
 	}
+}
+
+func TestAddAndRemoveDockerCredentials(t *testing.T) {
+	address1 := "myrepository:5000"
+	username1 := "user1"
+	password1 := "obviouspassword"
+	auth1Str := fmt.Sprintf("%s:%s", username1, password1)
+	auth1Encoded := base64.StdEncoding.EncodeToString([]byte(auth1Str))
+
+	address2 := "myrepository2:5000"
+	username2 := "user2"
+	password2 := "obviouspasswordtoo"
+	auth2Str := fmt.Sprintf("%s:%s", username2, password2)
+	auth2Encoded := base64.StdEncoding.EncodeToString([]byte(auth2Str))
+
+	beforeCredentials := getDockerCredentials("test")
+
+	// Add the first credential.
+	AddDockerCredential("test", address1, username1, password1)
+	afterAddCredentials1 := getDockerCredentials("test")
+	assert.Equal(t, len(beforeCredentials.Auths)+1, len(afterAddCredentials1.Auths))
+	assert.Equal(t, username1, afterAddCredentials1.Auths[address1].Username)
+	assert.Equal(t, password1, afterAddCredentials1.Auths[address1].Password)
+	assert.Equal(t, auth1Encoded, afterAddCredentials1.Auths[address1].Auth)
+
+	// Add the second credential.
+	AddDockerCredential("test", address2, username2, password2)
+	afterAddCredentials2 := getDockerCredentials("test")
+	assert.Equal(t, len(beforeCredentials.Auths)+2, len(afterAddCredentials2.Auths))
+	assert.Equal(t, username2, afterAddCredentials2.Auths[address2].Username)
+	assert.Equal(t, password2, afterAddCredentials2.Auths[address2].Password)
+	assert.Equal(t, auth2Encoded, afterAddCredentials2.Auths[address2].Auth)
+
+	// Remove the *second* credential. Check we are back where we were after the first add.
+	RemoveDockerCredential("test", address2)
+	afterRemoveCredentials1 := getDockerCredentials("test")
+	assert.Equal(t, len(beforeCredentials.Auths)+1, len(afterRemoveCredentials1.Auths))
+	assert.Equal(t, afterAddCredentials1, afterRemoveCredentials1)
+	assert.Equal(t, DockerCredential{}, afterRemoveCredentials1.Auths[address2])
+
+	// Remove the *first* credential. Check we are back where we were at the start.
+	RemoveDockerCredential("test", address1)
+	afterRemoveCredentials2 := getDockerCredentials("test")
+	assert.Equal(t, len(beforeCredentials.Auths), len(afterRemoveCredentials2.Auths))
+	assert.Equal(t, beforeCredentials, afterRemoveCredentials2)
+	assert.Equal(t, DockerCredential{}, afterRemoveCredentials2.Auths[address2])
+
 }

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -17,6 +17,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	goErr "errors"
 	"fmt"
 	"io"
@@ -58,6 +60,7 @@ func WriteToComposeFile(dockerComposeFile string, debug bool) bool {
 		return false
 	}
 
+	writeDockerConfigSecretFile()
 	dataStruct := Compose{}
 
 	unmarshDataErr := yaml.Unmarshal([]byte(data), &dataStruct)
@@ -81,6 +84,24 @@ func WriteToComposeFile(dockerComposeFile string, debug bool) bool {
 	err = ioutil.WriteFile(dockerComposeFile, marshalledData, 0644)
 	errors.CheckErr(err, 204, "")
 	return true
+}
+
+func writeDockerConfigSecretFile() {
+	dockerConfig := getDockerCredentials("local")
+	dockerConfigBytes, jsonErr := json.MarshalIndent(dockerConfig, "", "  ")
+	if jsonErr != nil {
+		errors.CheckErr(jsonErr, 208, "")
+	}
+	encoded := base64.StdEncoding.EncodeToString(dockerConfigBytes)
+	err := ioutil.WriteFile(dockerConfigSecretFile, []byte(encoded), 0600)
+	errors.CheckErr(err, 204, "")
+}
+
+// ClearDockerConfigSecret We erase the contents rather than deleting
+// the file as the docker-compose file expects the secret to be present.
+func ClearDockerConfigSecret() {
+	err := ioutil.WriteFile(dockerConfigSecretFile, []byte{}, 0600)
+	errors.CheckErr(err, 204, "")
 }
 
 // DeleteTempFile once the the Codewind environment has been created


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement
## What does this PR do ?

This PR adds support for persisting the docker registry credentials between Codewind restarts.
It stores the docker logins added via the 'registrysecrets' command for local connections in the local keychain.
In the docker compose file they are mounted into the docker codewind-pfe container as a text file based secret.
The text file containing the secret is cleared on shutdown or startup failure and is read only to the user to try to provide as much protection as possible. (Unfortunately writing the docker secrets back out to the file system seems unavoidable.) The secret is also base64 encoded, this matches what happens in kubernetes and just protects passwords from accidental casual inspection, it is not intended as a substitute for encryption.
The docker compose file version is updated to 3.3 as that supports secrets and is also the level supported by docker 17.06 which is the minimum version we pre-req:

https://docs.docker.com/compose/compose-file/#secrets (Docker levels and docker compose file versions.)
https://www.eclipse.org/codewind/mdt-vsc-getting-started.html (Docker level required for codewind.)

This PR also includes test cases.

## Which issue(s) does this PR fix ?
This is part of https://github.com/eclipse/codewind/issues/1306

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1306

Note that I still need to raise one further PR to log the local user (outside the PFE container on the host machine) into their registry with the provided docker credentials so that appsody can also pull images. This PR (and it's companion) just solve persisting docker credentials across PFE restarts.

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
This PR requires the change in https://github.com/eclipse/codewind/pull/2417 for PFE to actually use the secret that is created.
(They can be merged independently but can't be tested without each other as one creates the secret and the other reads it.)