### PR TITLE
Change project remove to check for 202 Accepted rather than 200 OK

### DIFF
--- a/pkg/project/unbind.go
+++ b/pkg/project/unbind.go
@@ -34,7 +34,7 @@ func Unbind(httpClient utils.HTTPClient, connection *connections.Connection, url
 
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusAccepted {
 		err := fmt.Errorf("Project unbind failed with status code %d", res.StatusCode)
 		return &ProjectError{errOpUnbind, err, err.Error()}
 	}

--- a/pkg/project/unbind_test.go
+++ b/pkg/project/unbind_test.go
@@ -27,14 +27,14 @@ func TestUnbind(t *testing.T) {
 
 	body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 	t.Run("Expect success - project unbinds", func(t *testing.T) {
-		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusAccepted, Body: body}
 		err := Unbind(mockClient, &mockConnection, "dummyurl", "mockID")
 		if err != nil {
 			t.Errorf("Unbind() failed with error %s", err)
 		}
 	})
 
-	t.Run("Expect failure - pfe returns non 200 status", func(t *testing.T) {
+	t.Run("Expect failure - pfe returns non 202 status", func(t *testing.T) {
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: body}
 		err := Unbind(mockClient, &mockConnection, "dummyurl", "mockID")
 		assert.Error(t, err)


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Changes the `unbind` command to check for a `202` HTTP code rather than a `200` code which is what we should be returning as seen in the API spec: https://eclipse.github.io/codewind/#/paths/~1api~1v1~1projects~1{id}~1unbind/post

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2193

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
