### PR TITLE
feat, test: allow insecure keyring mode

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -361,9 +361,12 @@
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
+  digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
   pruneopts = "UT"
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
@@ -798,6 +801,7 @@
     "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
     "github.com/urfave/cli",
     "github.com/zalando/go-keyring",
     "gopkg.in/yaml.v3",

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -26,6 +26,10 @@ const cwctlName = "cwctl_test"
 const cwctl = "./" + cwctlName
 
 func TestCwctl(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
+
 	err := exec.Command("go", "build", "-o", cwctlName).Run()
 	require.Nil(t, err)
 

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/stretchr/testify/require"
+)
+
+const cwctlName = "cwctl_test"
+const cwctl = "./" + cwctlName
+
+func TestCwctl(t *testing.T) {
+	err := exec.Command("go", "build", "-o", cwctlName).Run()
+	require.Nil(t, err)
+
+	testBasicUsage(t)
+	testUseInsecureKeyring(t)
+
+	os.Remove(cwctlName)
+}
+
+func testBasicUsage(t *testing.T) {
+	t.Run("cwctl", func(t *testing.T) {
+		out, err := exec.Command(cwctl).Output()
+		require.Nil(t, err)
+		require.NotNil(t, out)
+	})
+}
+
+func testUseInsecureKeyring(t *testing.T) {
+	t.Run("cwctl --insecureKeyring seckeyring update", func(t *testing.T) {
+		os.Remove(security.GetPathToInsecureKeyring())
+
+		cmd := exec.Command(cwctl, "--insecureKeyring", "seckeyring", "update",
+			"--conid=local",
+			"--username=testuser",
+			"--password=seCretphrase",
+		)
+		out, err := cmd.Output()
+		require.Nil(t, err)
+		require.Equal(t, "{\"status\":\"OK\"}\n", string(out))
+
+		file, readErr := ioutil.ReadFile(security.GetPathToInsecureKeyring())
+		require.Nil(t, readErr)
+		require.NotNil(t, file)
+
+		secrets := []security.KeyringSecret{}
+		unmarshalErr := json.Unmarshal([]byte(file), &secrets)
+		require.Nil(t, unmarshalErr)
+		require.Len(t, secrets, 1)
+
+		secret := secrets[0]
+		require.Equal(t, "testuser", string(secret.Username))
+		require.Equal(t, "seCretphrase", string(secret.Password))
+
+		os.Remove(security.GetPathToInsecureKeyring())
+	})
+	t.Run("INSECURE_KEYRING=true cwctl seckeyring update", func(t *testing.T) {
+		os.Remove(security.GetPathToInsecureKeyring())
+
+		cmd := exec.Command(cwctl, "seckeyring", "update",
+			"--conid=local",
+			"--username=testuser",
+			"--password=seCretphrase",
+		)
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, "INSECURE_KEYRING=true")
+		out, err := cmd.Output()
+		require.Nil(t, err)
+		require.Equal(t, "{\"status\":\"OK\"}\n", string(out))
+
+		file, readErr := ioutil.ReadFile(security.GetPathToInsecureKeyring())
+		require.Nil(t, readErr)
+		require.NotNil(t, file)
+
+		secrets := []security.KeyringSecret{}
+		unmarshalErr := json.Unmarshal([]byte(file), &secrets)
+		require.Nil(t, unmarshalErr)
+		require.Len(t, secrets, 1)
+
+		secret := secrets[0]
+		require.Equal(t, "testuser", string(secret.Username))
+		require.Equal(t, "seCretphrase", string(secret.Password))
+
+		os.Remove(security.GetPathToInsecureKeyring())
+	})
+}

--- a/integration.bats
+++ b/integration.bats
@@ -128,7 +128,9 @@
 # Keyring command tests #
 #########################
 
-@test "invoke seckeyring update command - create a key" {
+# use system keyring (secure)
+
+@test "invoke seckeyring update command (using secure keyring) - create a key" {
   cd cmd/cli/
   run go run main.go seckeyring update --conid local --username testuser --password seCretphrase
   echo "status = ${status}"
@@ -137,7 +139,7 @@
   [ "$status" -eq 0 ]
 }
 
-@test "invoke seckeyring update command - update a key" {
+@test "invoke seckeyring update command (using secure keyring) - update a key" {
   cd cmd/cli/
   run go run main.go seckeyring update --conid local --username testuser --password new_secretPhrase
   echo "status = ${status}"
@@ -146,7 +148,7 @@
   [ "$status" -eq 0 ]
 }
 
-@test "invoke seckeyring validate command - validate a key" {
+@test "invoke seckeyring validate command (using secure keyring) - validate a key" {
   cd cmd/cli/
   run go run main.go seckeyring validate --conid local --username testuser
   echo "status = ${status}"
@@ -155,7 +157,7 @@
   [ "$status" -eq 0 ]
 }
 
-@test "invoke seckeyring validate command - key not found (incorrect connection)" {
+@test "invoke seckeyring validate command (using secure keyring) - key not found (incorrect connection)" {
   cd cmd/cli/
   run go run main.go seckeyring validate --conid remoteNotKnown --username testuser
   echo "status = ${status}"
@@ -165,7 +167,7 @@
   [ "$status" -eq 1 ]
 }
 
-@test "invoke seckeyring validate command - key not found (incorrect username)"  {
+@test "invoke seckeyring validate command (using secure keyring) - key not found (incorrect username)"  {
   cd cmd/cli/
   run go run main.go seckeyring validate --conid local --username testuser_unknown
   echo "status = ${status}"
@@ -175,3 +177,51 @@
   [ "$status" -eq 1 ]
 }
 
+# use our keyring (insecure)
+
+@test "invoke seckeyring update command (using insecure keyring) - create a key" {
+  cd cmd/cli/
+  run go run main.go --insecureKeyring seckeyring update --conid local --username testuser --password seCretphrase
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"status":"OK"}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke seckeyring update command (using insecure keyring) - update a key" {
+  cd cmd/cli/
+  run go run main.go --insecureKeyring seckeyring update --conid local --username testuser --password new_secretPhrase
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"status":"OK"}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke seckeyring validate command (using insecure keyring) - validate a key" {
+  cd cmd/cli/
+  run go run main.go --insecureKeyring seckeyring validate --conid local --username testuser
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "$output" = '{"status":"OK"}' ]
+  [ "$status" -eq 0 ]
+}
+
+@test "invoke seckeyring validate command (using insecure keyring) - key not found (incorrect connection)" {
+  cd cmd/cli/
+  run go run main.go --insecureKeyring seckeyring validate --conid remoteNotKnown --username testuser
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
+  [ "${lines[1]}" = "exit status 1" ]
+  [ "$status" -eq 1 ]
+}
+
+@test "invoke seckeyring validate command (using insecure keyring) - key not found (incorrect username)"  {
+  cd cmd/cli/
+  run go run main.go --insecureKeyring seckeyring validate --conid local --username testuser_unknown
+  echo "status = ${status}"
+  echo "output trace = ${output}"
+  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
+  [ "${lines[1]}" = "exit status 1" ]
+  [ "$status" -eq 1 ]
+}

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -942,7 +942,9 @@ func Commands() {
 
 		printAsJSON = c.GlobalBool("json")
 
-		globals.SetUseInsecureKeyring(c.GlobalBool("insecureKeyring"))
+		if c.GlobalBool("insecureKeyring") || os.Getenv("INSECURE_KEYRING") == "true" {
+			globals.SetUseInsecureKeyring(true)
+		}
 
 		// Handle Global log level flag
 		switch loglevel := c.GlobalString("loglevel"); {

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -45,7 +45,7 @@ func Commands() {
 		},
 		cli.BoolFlag{
 			Name:  "insecureKeyring",
-			Usage: "use our keyring instead of system keyring",
+			Usage: "use insecure keyring instead of system keyring",
 		},
 		cli.BoolFlag{
 			Name:  "json, j",

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	desktoputils "github.com/eclipse/codewind-installer/pkg/desktop_utils"
 	"github.com/eclipse/codewind-installer/pkg/errors"
+	"github.com/eclipse/codewind-installer/pkg/globals"
 	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -41,6 +42,10 @@ func Commands() {
 		cli.BoolFlag{
 			Name:  "insecure",
 			Usage: "disable certificate checking",
+		},
+		cli.BoolFlag{
+			Name:  "insecureKeyring",
+			Usage: "use our keyring instead of system keyring",
 		},
 		cli.BoolFlag{
 			Name:  "json, j",
@@ -937,8 +942,9 @@ func Commands() {
 
 		printAsJSON = c.GlobalBool("json")
 
-		// Handle Global log level flag
+		globals.SetUseInsecureKeyring(c.GlobalBool("insecureKeyring"))
 
+		// Handle Global log level flag
 		switch loglevel := c.GlobalString("loglevel"); {
 		case loglevel == "trace":
 			logr.SetLevel(logr.TraceLevel)

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -54,7 +54,7 @@ const actionAddEntry = 0x02
 func InitConfigFileIfRequired() *ConError {
 	_, err := os.Stat(GetConnectionConfigFilename())
 	if os.IsNotExist(err) {
-		os.MkdirAll(getConnectionConfigDir(), 0777)
+		os.MkdirAll(GetConnectionConfigDir(), 0777)
 		return ResetConnectionsFile()
 	}
 	return applySchemaUpdates()
@@ -298,8 +298,8 @@ func saveConnectionsConfigFile(ConnectionConfig *ConnectionConfig) *ConError {
 	return nil
 }
 
-// getConnectionConfigDir : get directory path to the connections file
-func getConnectionConfigDir() string {
+// GetConnectionConfigDir : get path to the connections config directory
+func GetConnectionConfigDir() string {
 	val, isSet := os.LookupEnv("CHE_API_EXTERNAL")
 	homeDir := ""
 	if isSet && (val != "") {
@@ -323,7 +323,7 @@ func getConnectionConfigDir() string {
 
 // GetConnectionConfigFilename  : get full file path of connections file
 func GetConnectionConfigFilename() string {
-	return path.Join(getConnectionConfigDir(), "connections.json")
+	return path.Join(GetConnectionConfigDir(), "connections.json")
 }
 
 func loadRawConnectionsFile() ([]byte, *ConError) {

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package globals
+
+// UseInsecureKeyring decides whether we should use the insecure keyring or the (secure) system keyring
+var UseInsecureKeyring = false
+
+// SetUseInsecureKeyring sets useInsecureKeyring
+func SetUseInsecureKeyring(newUseInsecureKeyring bool) {
+	UseInsecureKeyring = newUseInsecureKeyring
+}

--- a/pkg/project/getproject.go
+++ b/pkg/project/getproject.go
@@ -23,7 +23,7 @@ type (
 	}
 )
 
-// GetProject : Get project details from Codewind
+// GetProjectFromID : Get project details from Codewind
 func GetProjectFromID(httpClient utils.HTTPClient, connection *connections.Connection, url, projectID string) (*Project, *ProjectError) {
 	req, requestErr := http.NewRequest("GET", url+"/api/v1/projects/"+projectID+"/", nil)
 	if requestErr != nil {

--- a/pkg/sechttp/httpclient_test.go
+++ b/pkg/sechttp/httpclient_test.go
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package sechttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/globals"
+	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/stretchr/testify/assert"
+)
+
+const connectionID = "testcon"
+
+// MockResponse mocks the response of a http client
+type MockResponse struct {
+	StatusCode int
+	Body       io.ReadCloser
+}
+
+// Do makes a http request
+func (c *MockResponse) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: c.StatusCode,
+		Body:       c.Body,
+	}, nil
+}
+
+func TestDispatchHTTPRequest(t *testing.T) {
+
+	// remove insecureKeychain.json if it already exists
+	os.Remove(security.GetPathToInsecureKeyring())
+
+	tests := map[string]struct {
+		useInsecureKeyring bool
+	}{
+		"use secure keyring":   {useInsecureKeyring: false},
+		"use insecure keyring": {useInsecureKeyring: true},
+	}
+	for name, test := range tests {
+		var originalUseInsecureKeyring = globals.UseInsecureKeyring
+		globals.SetUseInsecureKeyring(test.useInsecureKeyring)
+		t.Run(name, func(t *testing.T) {
+			testDispatchHTTPRequest(t)
+		})
+		globals.SetUseInsecureKeyring(originalUseInsecureKeyring)
+	}
+
+	// remove insecureKeychain.json if it still exists
+	os.Remove(security.GetPathToInsecureKeyring())
+}
+
+func testDispatchHTTPRequest(t *testing.T) {
+
+	t.Run("returns the response from PFE when PFE is local and responds (with 200)", func(t *testing.T) {
+		mockClientReturning200 := &MockResponse{StatusCode: http.StatusOK, Body: nil}
+		mockConnection := connections.Connection{ID: "local"}
+		mockRequest := httptest.NewRequest("GET", "/", nil)
+		expectedResp, _ := mockClientReturning200.Do(mockRequest)
+
+		gotResp, err := DispatchHTTPRequest(mockClientReturning200, mockRequest, &mockConnection)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedResp, gotResp)
+	})
+	t.Run("returns the response from PFE when PFE is not local, "+
+		"we can get an access token from the keyring, "+
+		"and PFE responds (with 200)", func(t *testing.T) {
+		security.DeleteSecretFromKeyring(connectionID, "access_token")
+		security.StoreSecretInKeyring(connectionID, "access_token", "mockAccessToken")
+
+		mockClientReturning200 := &MockResponse{StatusCode: http.StatusOK, Body: nil}
+		mockConnection := connections.Connection{ID: connectionID}
+		mockRequest := httptest.NewRequest("GET", "/", nil)
+		expectedResp, _ := mockClientReturning200.Do(mockRequest)
+
+		gotResp, err := DispatchHTTPRequest(mockClientReturning200, mockRequest, &mockConnection)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedResp, gotResp)
+
+		// cleanup
+		security.DeleteSecretFromKeyring(connectionID, "access_token")
+	})
+	t.Run("returns the response from PFE when PFE is not local, "+
+		"we cannot get an access token from the keyring, "+
+		"we can get a refresh token from the keyring, "+
+		"and PFE responds (with 200)", func(t *testing.T) {
+		security.DeleteSecretFromKeyring(connectionID, "access_token")
+		security.StoreSecretInKeyring(connectionID, "refresh_token", "mockRefreshToken")
+
+		mockAuthTokenBytes, _ := json.Marshal(&security.AuthToken{})
+		mockBody := ioutil.NopCloser(bytes.NewReader(mockAuthTokenBytes))
+		mockClientReturning200 := &MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{ID: connectionID}
+		mockRequest := httptest.NewRequest("GET", "/", nil)
+		expectedResp, _ := mockClientReturning200.Do(mockRequest)
+
+		gotResp, err := DispatchHTTPRequest(mockClientReturning200, mockRequest, &mockConnection)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedResp, gotResp)
+
+		// cleanup
+		security.DeleteSecretFromKeyring(connectionID, "refresh_token")
+	})
+	t.Run("returns the correct error when PFE is not local, "+
+		"we cannot get an access token from the keyring, "+
+		"we cannot get a refresh token from the keyring, "+
+		"and we cannot get cached credentials from the keyring", func(t *testing.T) {
+		mockConnectionUsername := "mockconnectionusername"
+		security.DeleteSecretFromKeyring(connectionID, "access_token")
+		security.DeleteSecretFromKeyring(connectionID, "refresh_token")
+		security.DeleteSecretFromKeyring(connectionID, mockConnectionUsername)
+
+		mockClientReturning200 := &MockResponse{StatusCode: http.StatusOK, Body: nil}
+		mockConnection := connections.Connection{ID: connectionID, Username: mockConnectionUsername}
+		mockRequest := httptest.NewRequest("GET", "/", nil)
+
+		gotResp, gotErr := DispatchHTTPRequest(mockClientReturning200, mockRequest, &mockConnection)
+		assert.Nil(t, gotResp)
+		errMissingPassword := "Unable to find password in keychain"
+		expectedErr := &HTTPSecError{errOpNoPassword, errors.New(errMissingPassword), errMissingPassword}
+		assert.Equal(t, expectedErr, gotErr)
+	})
+	t.Run("returns the response from PFE when PFE is not local, "+
+		"we cannot get an access token from the keyring, "+
+		"we cannot get a refresh token from the keyring, "+
+		"and we can get cached credentials from the keyring"+
+		"and PFE responds (with 200)", func(t *testing.T) {
+		mockConnectionUsername := "mockconnectionusername"
+		mockCachedCredentials := "mockCachedCredentials"
+		security.DeleteSecretFromKeyring(connectionID, "access_token")
+		security.DeleteSecretFromKeyring(connectionID, "refresh_token")
+		security.StoreSecretInKeyring(connectionID, mockConnectionUsername, mockCachedCredentials)
+
+		mockAuthTokenBytes, _ := json.Marshal(&security.AuthToken{})
+		mockBody := ioutil.NopCloser(bytes.NewReader(mockAuthTokenBytes))
+		mockClientReturning200 := &MockResponse{StatusCode: http.StatusOK, Body: mockBody}
+		mockConnection := connections.Connection{
+			ID:       connectionID,
+			Username: mockConnectionUsername,
+			AuthURL:  "mockAuthURL",
+			Realm:    "mockRealm",
+			ClientID: "mockClientID",
+		}
+		mockRequest := httptest.NewRequest("GET", "/", nil)
+		expectedResp, _ := mockClientReturning200.Do(mockRequest)
+
+		gotResp, err := DispatchHTTPRequest(mockClientReturning200, mockRequest, &mockConnection)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedResp, gotResp)
+
+		// cleanup
+		security.DeleteSecretFromKeyring(connectionID, mockConnectionUsername)
+	})
+}

--- a/pkg/sechttp/httpclient_test.go
+++ b/pkg/sechttp/httpclient_test.go
@@ -45,6 +45,9 @@ func (c *MockResponse) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestDispatchHTTPRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
 
 	// remove insecureKeychain.json if it already exists
 	os.Remove(security.GetPathToInsecureKeyring())

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -83,7 +83,7 @@ func StoreSecretInKeyring(connectionID, uName, pass string) *SecError {
 	if globals.UseInsecureKeyring {
 		_, statErr := os.Stat(GetPathToInsecureKeyring())
 		if os.IsNotExist(statErr) {
-			os.MkdirAll(insecureKeyringDir, 0777)
+			os.MkdirAll(insecureKeyringDir, 0600)
 			os.OpenFile(GetPathToInsecureKeyring(), os.O_CREATE, 0666)
 		}
 

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -84,7 +84,7 @@ func StoreSecretInKeyring(connectionID, uName, pass string) *SecError {
 		_, statErr := os.Stat(GetPathToInsecureKeyring())
 		if os.IsNotExist(statErr) {
 			os.MkdirAll(insecureKeyringDir, 0600)
-			os.OpenFile(GetPathToInsecureKeyring(), os.O_CREATE, 0666)
+			os.OpenFile(GetPathToInsecureKeyring(), os.O_CREATE, 0600)
 		}
 
 		existingSecrets := []KeyringSecret{}

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -83,8 +83,14 @@ func StoreSecretInKeyring(connectionID, uName, pass string) *SecError {
 	if globals.UseInsecureKeyring {
 		_, statErr := os.Stat(GetPathToInsecureKeyring())
 		if os.IsNotExist(statErr) {
-			os.MkdirAll(insecureKeyringDir, 0600)
-			os.OpenFile(GetPathToInsecureKeyring(), os.O_CREATE, 0600)
+			mkdirErr := os.MkdirAll(insecureKeyringDir, 0600)
+			if mkdirErr != nil {
+				return &SecError{errOpKeyring, mkdirErr, mkdirErr.Error()}
+			}
+			_, openFileErr := os.OpenFile(GetPathToInsecureKeyring(), os.O_CREATE, 0600)
+			if openFileErr != nil {
+				return &SecError{errOpKeyring, openFileErr, openFileErr.Error()}
+			}
 		}
 
 		existingSecrets := []KeyringSecret{}

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -12,17 +12,26 @@
 package security
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"io/ioutil"
+	"os"
+	"path"
 	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/globals"
 	"github.com/zalando/go-keyring"
 )
 
+var insecureKeyringDir = connections.GetConnectionConfigDir()
+
 // KeyringSecret : Secret
 type KeyringSecret struct {
-	ID       string `json:"id"`
-	ClientID string `json:"clientId"`
+	Service  []byte `json:"service"`
+	Username []byte `json:"username"`
+	Password []byte `json:"password"`
 }
 
 // SecKeyUpdate : Creates or updates a key in the platforms keyring
@@ -39,14 +48,14 @@ func SecKeyUpdate(connectionID string, username string, password string) *SecErr
 		return &SecError{errOpNotFound, err, conErr.Error()}
 	}
 
-	err := keyring.Set(KeyringServiceName+"."+conID, uName, pass)
-	if err != nil {
-		return &SecError{errOpKeyring, err, err.Error()}
+	keyringErr := StoreSecretInKeyring(conID, uName, pass)
+	if keyringErr != nil {
+		return keyringErr
 	}
 
 	/// check password can be retrieved
 	secret, secErr := SecKeyGetSecret(conID, uName)
-	if err != nil {
+	if secErr != nil {
 		return secErr
 	}
 	if secret != pass {
@@ -58,14 +67,176 @@ func SecKeyUpdate(connectionID string, username string, password string) *SecErr
 }
 
 // SecKeyGetSecret : retrieve secret / credentials from the keyring
-func SecKeyGetSecret(connectionID string, username string) (string, *SecError) {
-
+func SecKeyGetSecret(connectionID, username string) (string, *SecError) {
 	conID := strings.TrimSpace(strings.ToLower(connectionID))
 	uName := strings.TrimSpace(strings.ToLower(username))
+	secret, err := GetSecretFromKeyring(conID, uName)
+	if err != nil {
+		return "", err
+	}
+	return secret, nil
+}
 
-	secret, err := keyring.Get(KeyringServiceName+"."+conID, uName)
+// StoreSecretInKeyring stores the secret in either the system keyring or our insecure keyring.
+func StoreSecretInKeyring(connectionID, uName, pass string) *SecError {
+	service := connectionIDToService(connectionID)
+	if globals.UseInsecureKeyring {
+		_, statErr := os.Stat(GetPathToInsecureKeyring())
+		if os.IsNotExist(statErr) {
+			os.MkdirAll(insecureKeyringDir, 0777)
+			os.OpenFile(GetPathToInsecureKeyring(), os.O_CREATE, 0666)
+		}
+
+		existingSecrets := []KeyringSecret{}
+		file, readErr := ioutil.ReadFile(GetPathToInsecureKeyring())
+		if readErr != nil {
+			return &SecError{errOpKeyring, readErr, readErr.Error()}
+		}
+		if len(file) != 0 {
+			unmarshalErr := json.Unmarshal([]byte(file), &existingSecrets)
+			if unmarshalErr != nil {
+				return &SecError{errOpKeyring, unmarshalErr, unmarshalErr.Error()}
+			}
+		}
+		newSecret := KeyringSecret{
+			Service:  []byte(service),
+			Username: []byte(uName),
+			Password: []byte(pass),
+		}
+		indexOfSecretToUpdate := -1
+
+		for i, existingSecret := range existingSecrets {
+			if doSecretsMatch(existingSecret, newSecret) {
+				indexOfSecretToUpdate = i
+			}
+		}
+		if indexOfSecretToUpdate > -1 {
+			// remove existing secret
+			existingSecrets = append(existingSecrets[:indexOfSecretToUpdate], existingSecrets[indexOfSecretToUpdate+1:]...)
+		}
+		secrets := append(existingSecrets, newSecret)
+		body, marshallErr := json.MarshalIndent(secrets, "", "\t")
+		if marshallErr != nil {
+			return &SecError{errOpKeyring, marshallErr, marshallErr.Error()}
+		}
+		writeErr := ioutil.WriteFile(GetPathToInsecureKeyring(), body, 0644)
+		if writeErr != nil {
+			return &SecError{errOpKeyring, writeErr, writeErr.Error()}
+		}
+		return nil
+	}
+
+	// else store it in system keyring
+	err := keyring.Set(service, uName, pass)
+	if err != nil {
+		return &SecError{errOpKeyring, err, err.Error()}
+	}
+	return nil
+}
+
+// GetSecretFromKeyring gets the secret from either the system keyring or our insecure keyring.
+func GetSecretFromKeyring(connectionID, uName string) (string, *SecError) {
+	service := connectionIDToService(connectionID)
+	if globals.UseInsecureKeyring {
+		secrets, readErr := readInsecureKeyring()
+		if readErr != nil {
+			return "", readErr
+		}
+		for _, secret := range secrets {
+			sameService := string(secret.Service) == service
+			sameUsername := string(secret.Username) == uName
+			matchingSecret := sameService && sameUsername
+			if matchingSecret {
+				return string(secret.Password), nil
+			}
+		}
+		err := errors.New("secret not found in keyring")
+		return "", &SecError{errOpKeyring, err, err.Error()}
+	}
+	// else get from system keyring
+	secret, err := keyring.Get(service, uName)
 	if err != nil {
 		return "", &SecError{errOpKeyring, err, err.Error()}
 	}
 	return secret, nil
+}
+
+// DeleteSecretFromKeyring deletes the secret from either the system keyring or our insecure keyring.
+func DeleteSecretFromKeyring(connectionID, uName string) *SecError {
+	service := connectionIDToService(connectionID)
+	if globals.UseInsecureKeyring {
+		secrets, readErr := readInsecureKeyring()
+		if readErr != nil {
+			return readErr
+		}
+		indexOfSecretToDelete := -1
+		for i, secret := range secrets {
+			sameService := string(secret.Service) == service
+			sameUsername := string(secret.Username) == uName
+			matchingSecret := sameService && sameUsername
+			if matchingSecret {
+				indexOfSecretToDelete = i
+			}
+		}
+		if indexOfSecretToDelete == -1 {
+			err := errors.New("secret not found in keyring")
+			return &SecError{errOpKeyring, err, err.Error()}
+		}
+		// remove existing secret
+		secrets = append(secrets[:indexOfSecretToDelete], secrets[indexOfSecretToDelete+1:]...)
+		if len(secrets) == 0 {
+			err := os.Remove(GetPathToInsecureKeyring())
+			if err != nil {
+				return &SecError{errOpKeyring, err, err.Error()}
+			}
+			return nil
+		}
+		body, marshallErr := json.MarshalIndent(secrets, "", "\t")
+		if marshallErr != nil {
+			return &SecError{errOpKeyring, marshallErr, marshallErr.Error()}
+		}
+		writeErr := ioutil.WriteFile(GetPathToInsecureKeyring(), body, 0644)
+		if writeErr != nil {
+			return &SecError{errOpKeyring, writeErr, writeErr.Error()}
+		}
+		return nil
+	}
+	// else delete from system keyring
+	err := keyring.Delete(service, uName)
+	if err != nil {
+		return &SecError{errOpKeyring, err, err.Error()}
+	}
+	return nil
+}
+
+func readInsecureKeyring() ([]KeyringSecret, *SecError) {
+	file, readErr := ioutil.ReadFile(GetPathToInsecureKeyring())
+	if readErr != nil {
+		return nil, &SecError{errOpKeyring, readErr, readErr.Error()}
+	}
+	secrets := []KeyringSecret{}
+	if len(file) != 0 {
+		unmarshalErr := json.Unmarshal([]byte(file), &secrets)
+		if unmarshalErr != nil {
+			return nil, &SecError{errOpKeyring, unmarshalErr, unmarshalErr.Error()}
+		}
+	}
+	return secrets, nil
+}
+
+func connectionIDToService(connectionID string) string {
+	conID := strings.TrimSpace(strings.ToLower(connectionID))
+	return KeyringServiceName + "." + conID
+}
+
+// GetPathToInsecureKeyring gets the path to the insecureKeychain.json
+func GetPathToInsecureKeyring() string {
+	return path.Join(insecureKeyringDir, "insecureKeychain.json")
+}
+
+func doSecretsMatch(secret1, secret2 KeyringSecret) bool {
+	sameService := bytes.Compare(secret1.Service, secret2.Service) == 0
+	sameUsername := bytes.Compare(secret1.Username, secret2.Username) == 0
+	matchingSecret := sameService && sameUsername
+	return matchingSecret
 }

--- a/pkg/security/keychain_test.go
+++ b/pkg/security/keychain_test.go
@@ -24,13 +24,13 @@ const testPassword = "pAss%-w0rd-&'cha*s"
 const testPasswordUpdated = "pAss%-w0rd-&'cha*s-with_more_chars"
 
 func Test_Keychain_Secure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
 
 	var originalUseInsecureKeyring = globals.UseInsecureKeyring
 	globals.SetUseInsecureKeyring(false)
 
-	if testing.Short() {
-		t.Skip("skipping testing in short mode")
-	}
 	// remove test key if it already exists
 	DeleteSecretFromKeyring(testConnection, testUsername)
 
@@ -77,6 +77,9 @@ func Test_Keychain_Secure(t *testing.T) {
 }
 
 func Test_Keychain_Insecure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
 
 	var originalUseInsecureKeyring = globals.UseInsecureKeyring
 	globals.SetUseInsecureKeyring(true)

--- a/pkg/security/keychain_test.go
+++ b/pkg/security/keychain_test.go
@@ -12,67 +12,167 @@
 package security
 
 import (
-	"strings"
+	"os"
 	"testing"
 
+	"github.com/eclipse/codewind-installer/pkg/globals"
+
 	"github.com/stretchr/testify/assert"
-	"github.com/zalando/go-keyring"
 )
 
 const testPassword = "pAss%-w0rd-&'cha*s"
 const testPasswordUpdated = "pAss%-w0rd-&'cha*s-with_more_chars"
 
-func Test_Keychain(t *testing.T) {
+func Test_Keychain_Secure(t *testing.T) {
+
+	var originalUseInsecureKeyring = globals.UseInsecureKeyring
+	globals.SetUseInsecureKeyring(false)
 
 	if testing.Short() {
 		t.Skip("skipping testing in short mode")
 	}
-	// remove test key if one exists
-	keyring.Delete(strings.ToLower(KeyringServiceName+"."+testConnection), testUsername)
+	// remove test key if it already exists
+	DeleteSecretFromKeyring(testConnection, testUsername)
 
-	t.Run("Secret can not be retrieved for an unknown account", func(t *testing.T) {
+	t.Run("Secret cannot be retrieved for an unknown account", func(t *testing.T) {
 		retrievedSecret, err := SecKeyGetSecret(testConnection, testUsername)
-		if err == nil {
-			t.Fail()
-		}
+		assert.NotNil(t, err)
 		assert.Equal(t, "", retrievedSecret)
 	})
 
 	t.Run("A new key can be created in the platform keychain", func(t *testing.T) {
 		err := SecKeyUpdate(testConnection, testUsername, testPassword)
-		if err != nil {
-			t.Fail()
-		}
+		assert.Nil(t, err)
 	})
 
 	t.Run("The secret can be retrieved from the keychain", func(t *testing.T) {
 		storedSecret, err := SecKeyGetSecret(testConnection, testUsername)
-		if err != nil {
-			t.Fail()
-		}
+		assert.Nil(t, err)
 		assert.Equal(t, testPassword, storedSecret)
 	})
 
 	t.Run("An existing key in the keychain can be updated", func(t *testing.T) {
 		err := SecKeyUpdate(testConnection, testUsername, testPasswordUpdated)
-		if err != nil {
-			t.Fail()
-		}
+		assert.Nil(t, err)
 	})
 
 	t.Run("Retrieved secret matches the saved secret", func(t *testing.T) {
 		storedSecret, err := SecKeyGetSecret(testConnection, testUsername)
-		if err != nil {
-			t.Fail()
-		}
+		assert.Nil(t, err)
 		assert.Equal(t, testPasswordUpdated, storedSecret)
 	})
 
 	t.Run("Test keyring entry can be removed", func(t *testing.T) {
-		err := keyring.Delete(strings.ToLower(KeyringServiceName+"."+testConnection), testUsername)
-		if err != nil {
-			t.Fail()
-		}
+		err := DeleteSecretFromKeyring(testConnection, testUsername)
+		assert.Nil(t, err)
 	})
 
+	t.Run("Test keyring returns an error when trying to delete a non-existent secret", func(t *testing.T) {
+		err := DeleteSecretFromKeyring(testConnection, testUsername)
+		assert.NotNil(t, err)
+		assert.Equal(t, "secret not found in keyring", err.Desc)
+	})
+
+	globals.SetUseInsecureKeyring(originalUseInsecureKeyring)
+}
+
+func Test_Keychain_Insecure(t *testing.T) {
+
+	var originalUseInsecureKeyring = globals.UseInsecureKeyring
+	globals.SetUseInsecureKeyring(true)
+
+	// remove insecureKeychain.json if it already exists
+	os.Remove(GetPathToInsecureKeyring())
+
+	t.Run("Secret cannot be retrieved when keychain file does not exist", func(t *testing.T) {
+		retrievedSecret, err := SecKeyGetSecret(testConnection, testUsername)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Desc, "insecureKeychain.json: no such file or directory")
+		assert.Equal(t, "", retrievedSecret)
+	})
+
+	t.Run("A new secret is stored in a new keychain file when the keychain file didn't exist", func(t *testing.T) {
+		err := SecKeyUpdate(testConnection, testUsername, testPassword)
+		assert.Nil(t, err)
+		assert.FileExists(t, GetPathToInsecureKeyring())
+	})
+
+	t.Run("The secret can be retrieved from the keychain", func(t *testing.T) {
+		storedSecret, err := SecKeyGetSecret(testConnection, testUsername)
+		assert.Nil(t, err)
+		assert.Equal(t, testPassword, storedSecret)
+	})
+
+	t.Run("Secret cannot be retrieved for an unknown account", func(t *testing.T) {
+		retrievedSecret, err := SecKeyGetSecret(testConnection, "unknownaccount")
+		assert.NotNil(t, err)
+		assert.Equal(t, "secret not found in keyring", err.Desc)
+		assert.Equal(t, "", retrievedSecret)
+	})
+
+	t.Run("An existing key in the keychain can be updated", func(t *testing.T) {
+		err := SecKeyUpdate(testConnection, testUsername, testPasswordUpdated)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Retrieved secret matches the saved secret", func(t *testing.T) {
+		storedSecret, err := SecKeyGetSecret(testConnection, testUsername)
+		assert.Nil(t, err)
+		assert.Equal(t, testPasswordUpdated, storedSecret)
+	})
+
+	t.Run("Test keyring returns an error when trying to delete from a non-existent keyring", func(t *testing.T) {
+		err := DeleteSecretFromKeyring("mockConnectionID", "mockUsername")
+		assert.NotNil(t, err)
+		assert.Equal(t, "secret not found in keyring", err.Desc)
+	})
+
+	t.Run("Secret can be removed without deleting keychain", func(t *testing.T) {
+		StoreSecretInKeyring("mockConnectionID", "mockUsername", "mockPassword")
+
+		err := DeleteSecretFromKeyring("mockConnectionID", "mockUsername")
+		assert.Nil(t, err)
+
+		// check this secret has been deleted
+		secretFromThisTest, err := GetSecretFromKeyring("mockConnectionID", "mockUsername")
+		assert.Equal(t, "", secretFromThisTest)
+		assert.Equal(t, "secret not found in keyring", err.Desc)
+
+		// check the secret created before this test has not been deleted
+		existingSecret, err2 := GetSecretFromKeyring(testConnection, testUsername)
+		assert.Equal(t, testPasswordUpdated, existingSecret)
+		assert.Nil(t, err2)
+		assert.FileExists(t, GetPathToInsecureKeyring())
+	})
+
+	t.Run("Keychain is deleted when last secret is removed", func(t *testing.T) {
+		err := DeleteSecretFromKeyring(testConnection, testUsername)
+		assert.Nil(t, err)
+		assert.True(t, noFileExists(GetPathToInsecureKeyring()))
+	})
+
+	t.Run("Test keyring returns an error when trying to delete from a non-existent keyring", func(t *testing.T) {
+		err := DeleteSecretFromKeyring(testConnection, testUsername)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Desc, "insecureKeychain.json: no such file or directory")
+	})
+
+	// remove insecureKeychain.json if it still exists
+	os.Remove(GetPathToInsecureKeyring())
+
+	globals.SetUseInsecureKeyring(originalUseInsecureKeyring)
+}
+
+func noFileExists(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true
+		}
+		return true
+	}
+	if info.IsDir() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Implements the functionality requested in https://github.com/eclipse/codewind/issues/1735#issuecomment-593967702:
- [x] No IDE
```
export ALLOW_INSECURE_KEYRING=true
cwctl templates list --conid $CONID
```
- [x] No IDE
```
cwctl --use-insecure-keyring templates list --conid $CONID
```
- [x] IDE (e.g. theia)
```
export ALLOW_INSECURE_KEYRING=true
yarn theia start /home/project --hostname=0.0.0.0
# ide should now leverage this envVar when running cwctl
```

I'm implementing part 1 and 3 now

## Which issue(s) does this PR fix ?
for https://github.com/eclipse/codewind/issues/1735

## Does this PR require a documentation change ?
yes

## Any special notes for your reviewer ?
