### PR TITLE
refactor: move docker logic to new docker package

### DIFF
--- a/pkg/actions/install.go
+++ b/pkg/actions/install.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/eclipse/codewind-installer/pkg/project"
 	"github.com/eclipse/codewind-installer/pkg/remote"
 	"github.com/eclipse/codewind-installer/pkg/utils"
@@ -38,26 +39,26 @@ func InstallCommand(c *cli.Context) {
 	}
 
 	// creates a new docker client, which is passed into the functions that interact with the docker API
-	dockerClient, dockerErr := utils.NewDockerClient()
+	dockerClient, dockerErr := docker.NewDockerClient()
 	if dockerErr != nil {
 		HandleDockerError(dockerErr)
 		os.Exit(1)
 	}
 
 	for i := 0; i < len(imageArr); i++ {
-		utils.PullImage(dockerClient, imageArr[i], printAsJSON)
-		imageID, dockerError := utils.ValidateImageDigest(dockerClient, imageArr[i])
+		docker.PullImage(dockerClient, imageArr[i], printAsJSON)
+		imageID, dockerError := docker.ValidateImageDigest(dockerClient, imageArr[i])
 
 		if dockerError != nil {
 			logr.Tracef("%v checksum validation failed. Trying to pull image again", imageArr[i])
 			// remove bad image
-			utils.RemoveImage(imageID)
+			docker.RemoveImage(imageID)
 
 			// pull image again
-			utils.PullImage(dockerClient, imageArr[i], printAsJSON)
+			docker.PullImage(dockerClient, imageArr[i], printAsJSON)
 
 			// validate the new image
-			_, dockerError = utils.ValidateImageDigest(dockerClient, imageArr[i])
+			_, dockerError = docker.ValidateImageDigest(dockerClient, imageArr[i])
 
 			if dockerError != nil {
 				if printAsJSON {
@@ -66,7 +67,7 @@ func InstallCommand(c *cli.Context) {
 					logr.Errorf("Validation of image '%v' checksum failed - Removing image", imageArr[i])
 				}
 				// Clean up the second bad image
-				utils.RemoveImage(imageID)
+				docker.RemoveImage(imageID)
 				os.Exit(1)
 			}
 		}

--- a/pkg/actions/remove.go
+++ b/pkg/actions/remove.go
@@ -16,8 +16,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/eclipse/codewind-installer/pkg/remote"
-	"github.com/eclipse/codewind-installer/pkg/utils"
 	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -32,13 +32,13 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 		"cw-",
 	}
 
-	dockerClient, dockerErr := utils.NewDockerClient()
+	dockerClient, dockerErr := docker.NewDockerClient()
 	if dockerErr != nil {
 		HandleDockerError(dockerErr)
 		os.Exit(1)
 	}
 
-	images, err := utils.GetImageList(dockerClient)
+	images, err := docker.GetImageList(dockerClient)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)
@@ -56,12 +56,12 @@ func RemoveCommand(c *cli.Context, dockerComposeFile string) {
 				} else {
 					fmt.Println("Deleting Image ", image.ID, "... ")
 				}
-				utils.RemoveImage(image.ID)
+				docker.RemoveImage(image.ID)
 			}
 		}
 	}
 
-	dockerErr = utils.DockerComposeRemove(dockerComposeFile, tag)
+	dockerErr = docker.DockerComposeRemove(dockerComposeFile, tag)
 	if dockerErr != nil {
 		HandleDockerError(dockerErr)
 		os.Exit(1)

--- a/pkg/actions/start.go
+++ b/pkg/actions/start.go
@@ -15,19 +15,20 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/urfave/cli"
 )
 
 // StartCommand : start the codewind containers
 func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint string) {
-	dockerClient, dockerErr := utils.NewDockerClient()
+	dockerClient, dockerErr := docker.NewDockerClient()
 	if dockerErr != nil {
 		HandleDockerError(dockerErr)
 		os.Exit(1)
 	}
 
-	status, err := utils.CheckContainerStatus(dockerClient)
+	status, err := docker.CheckContainerStatus(dockerClient)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)
@@ -42,15 +43,15 @@ func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint strin
 		fmt.Println("Debug:", debug)
 
 		utils.CreateTempFile(dockerComposeFile)
-		utils.WriteToComposeFile(dockerComposeFile, debug)
+		docker.WriteToComposeFile(dockerComposeFile, debug)
 
-		err := utils.DockerCompose(dockerComposeFile, tag, loglevel)
+		err := docker.DockerCompose(dockerComposeFile, tag, loglevel)
 		if err != nil {
 			HandleDockerError(err)
 			os.Exit(1)
 		}
 
-		_, pingHealthErr := utils.PingHealth(healthEndpoint)
+		_, pingHealthErr := docker.PingHealth(healthEndpoint)
 		if pingHealthErr != nil {
 			HandleDockerError(pingHealthErr)
 			os.Exit(1)

--- a/pkg/actions/status.go
+++ b/pkg/actions/status.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
 	"github.com/eclipse/codewind-installer/pkg/connections"
-	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/urfave/cli"
 )
 
@@ -86,13 +86,13 @@ func StatusCommandRemoteConnection(c *cli.Context) {
 
 // StatusCommandLocalConnection : Output local connection details
 func StatusCommandLocalConnection(c *cli.Context) {
-	dockerClient, dockerErr := utils.NewDockerClient()
+	dockerClient, dockerErr := docker.NewDockerClient()
 	if dockerErr != nil {
 		HandleDockerError(dockerErr)
 		os.Exit(1)
 	}
 
-	containersAreRunning, err := utils.CheckContainerStatus(dockerClient)
+	containersAreRunning, err := docker.CheckContainerStatus(dockerClient)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)
@@ -100,19 +100,19 @@ func StatusCommandLocalConnection(c *cli.Context) {
 
 	if containersAreRunning {
 		// Started
-		hostname, port, err := utils.GetPFEHostAndPort(dockerClient)
+		hostname, port, err := docker.GetPFEHostAndPort(dockerClient)
 		if err != nil {
 			HandleDockerError(err)
 			os.Exit(1)
 		}
 		if printAsJSON {
-			imageTagArr, err := utils.GetImageTags(dockerClient)
+			imageTagArr, err := docker.GetImageTags(dockerClient)
 			if err != nil {
 				fmt.Println(err.Error())
 				os.Exit(1)
 			}
 
-			containerTagArr, err := utils.GetContainerTags(dockerClient)
+			containerTagArr, err := docker.GetContainerTags(dockerClient)
 			if err != nil {
 				fmt.Println(err.Error())
 				os.Exit(1)
@@ -140,7 +140,7 @@ func StatusCommandLocalConnection(c *cli.Context) {
 		os.Exit(0)
 	}
 
-	imagesAreInstalled, err := utils.CheckImageStatus(dockerClient)
+	imagesAreInstalled, err := docker.CheckImageStatus(dockerClient)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)
@@ -150,7 +150,7 @@ func StatusCommandLocalConnection(c *cli.Context) {
 		// Installed but not started
 		if printAsJSON {
 
-			imageTagArr, err := utils.GetImageTags(dockerClient)
+			imageTagArr, err := docker.GetImageTags(dockerClient)
 			if err != nil {
 				fmt.Println(err.Error())
 				os.Exit(1)

--- a/pkg/actions/stop-all.go
+++ b/pkg/actions/stop-all.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/urfave/cli"
 )
 
@@ -23,28 +23,28 @@ import (
 func StopAllCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
 
-	dockerClient, dockerErr := utils.NewDockerClient()
+	dockerClient, dockerErr := docker.NewDockerClient()
 	if dockerErr != nil {
 		HandleDockerError(dockerErr)
 		os.Exit(1)
 	}
 
-	containers, err := utils.GetContainerList(dockerClient)
+	containers, err := docker.GetContainerList(dockerClient)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)
 	}
 
-	dockerErr = utils.DockerComposeStop(tag, dockerComposeFile)
+	dockerErr = docker.DockerComposeStop(tag, dockerComposeFile)
 	if dockerErr != nil {
 		HandleDockerError(dockerErr)
 		os.Exit(1)
 	}
 
 	fmt.Println("Stopping Project containers")
-	containersToRemove := utils.GetContainersToRemove(containers)
+	containersToRemove := docker.GetContainersToRemove(containers)
 	for _, container := range containersToRemove {
 		fmt.Println("Stopping container ", container.Names[0], "... ")
-		utils.StopContainer(dockerClient, container)
+		docker.StopContainer(dockerClient, container)
 	}
 }

--- a/pkg/actions/stop.go
+++ b/pkg/actions/stop.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/urfave/cli"
 )
 
@@ -23,7 +23,7 @@ import (
 func StopCommand(c *cli.Context, dockerComposeFile string) {
 	tag := c.String("tag")
 	fmt.Println("Only stopping Codewind containers. To stop project containers, please use 'stop-all'")
-	err := utils.DockerComposeStop(tag, dockerComposeFile)
+	err := docker.DockerComposeStop(tag, dockerComposeFile)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -18,14 +18,14 @@ import (
 
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/eclipse/codewind-installer/pkg/project"
 	"github.com/eclipse/codewind-installer/pkg/remote"
-	"github.com/eclipse/codewind-installer/pkg/utils"
 	logr "github.com/sirupsen/logrus"
 )
 
 // HandleDockerError prints a Docker error, in JSON format if the global flag is set and as a string if not
-func HandleDockerError(err *utils.DockerError) {
+func HandleDockerError(err *docker.DockerError) {
 	// printAsJSON is a global variable, set in commands.go
 	if printAsJSON {
 		fmt.Println(err.Error())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ import (
 	"os"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
-	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/eclipse/codewind-installer/pkg/docker"
 )
 
 // ConfigError : config package errors
@@ -56,7 +56,7 @@ func PFEOriginFromConnection(connection *connections.Connection) (string, *Confi
 }
 
 func getLocalHostnameAndPort() (string, *ConfigError) {
-	dockerClient, err := utils.NewDockerClient()
+	dockerClient, err := docker.NewDockerClient()
 	if err != nil {
 		return "", &ConfigError{errOpConfPFEHostnamePortNotFound, err, err.Error()}
 	}
@@ -66,7 +66,7 @@ func getLocalHostnameAndPort() (string, *ConfigError) {
 		return "https://localhost:9090", nil
 	}
 
-	hostname, port, err := utils.GetPFEHostAndPort(dockerClient)
+	hostname, port, err := docker.GetPFEHostAndPort(dockerClient)
 	if err != nil {
 		return "", &ConfigError{errOpConfPFEHostnamePortNotFound, err, err.Desc}
 	} else if hostname == "" || port == "" {

--- a/pkg/docker/docker_error.go
+++ b/pkg/docker/docker_error.go
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package utils
+package docker
 
 import "encoding/json"
 

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package utils
+package docker
 
 import (
 	"bytes"
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"log"
 	"testing"
 	"time"
 
@@ -444,26 +443,5 @@ func TestGetContainersToRemove(t *testing.T) {
 				assert.Contains(t, test.expectedContainers, container.Names[0])
 			}
 		})
-	}
-}
-
-func TestRemoveDuplicateEntries(t *testing.T) {
-	dupArr := []string{"test", "test", "test"}
-	result := RemoveDuplicateEntries(dupArr)
-
-	if len(result) != 1 {
-		log.Fatal("Test 1: Failed to delete duplicate array index")
-	}
-
-	dupArr = []string{"", "test", "test"}
-	result = RemoveDuplicateEntries(dupArr)
-	if len(result) != 1 {
-		log.Fatal("Test 2: Failed to delete duplicate array index")
-	}
-
-	dupArr = []string{"", "", ""}
-	result = RemoveDuplicateEntries(dupArr)
-	if len(result) != 0 {
-		log.Fatal("Test 3: Failed to identify empty array values")
 	}
 }

--- a/pkg/docker/filesystem.go
+++ b/pkg/docker/filesystem.go
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package docker
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/eclipse/codewind-installer/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// WriteToComposeFile the contents of the docker compose yaml
+func WriteToComposeFile(dockerComposeFile string, debug bool) bool {
+	if dockerComposeFile == "" {
+		return false
+	}
+
+	dataStruct := Compose{}
+
+	unmarshDataErr := yaml.Unmarshal([]byte(data), &dataStruct)
+	errors.CheckErr(unmarshDataErr, 202, "")
+
+	if debug == true && len(dataStruct.SERVICES.PFE.Ports) > 0 {
+		debugPort := DetermineDebugPortForPFE()
+		// Add the debug port to the docker compose data
+		dataStruct.SERVICES.PFE.Ports = append(dataStruct.SERVICES.PFE.Ports, "127.0.0.1:"+debugPort+":9777")
+	}
+
+	marshalledData, err := yaml.Marshal(&dataStruct)
+	errors.CheckErr(err, 203, "")
+
+	if debug == true {
+		fmt.Printf("==> %s structure is: \n%s\n\n", dockerComposeFile, string(marshalledData))
+	} else {
+		fmt.Println("==> environment structure written to " + filepath.ToSlash(dockerComposeFile))
+	}
+
+	err = ioutil.WriteFile(dockerComposeFile, marshalledData, 0644)
+	errors.CheckErr(err, 204, "")
+	return true
+}
+
+// PingHealth - pings environment api every 15 seconds to check if containers started
+func PingHealth(healthEndpoint string) (bool, *DockerError) {
+	var started = false
+	fmt.Println("Waiting for Codewind to start")
+
+	dockerClient, err := NewDockerClient()
+	if err != nil {
+		return false, err
+	}
+
+	hostname, port, err := GetPFEHostAndPort(dockerClient)
+	if err != nil {
+		return false, err
+	}
+	for i := 0; i < 120; i++ {
+		resp, err := http.Get("http://" + hostname + ":" + port + healthEndpoint)
+		if err != nil {
+			fmt.Printf(".")
+		} else {
+			if resp.StatusCode == 200 {
+				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
+				fmt.Println("Codewind successfully started on http://" + hostname + ":" + port)
+				started = true
+				break
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if started != true {
+		log.Fatal("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
+	}
+	return started, nil
+}

--- a/pkg/docker/filesystem_test.go
+++ b/pkg/docker/filesystem_test.go
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package docker
+
+import (
+	"os"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteToComposeFile(t *testing.T) {
+	t.Run("docker compose should be written to the filepath", func(t *testing.T) {
+		testFile := "TestFile.yaml"
+		os.Create(testFile)
+		_ = WriteToComposeFile("TestFile.yaml", false)
+
+		pathExists := utils.PathExists(testFile)
+		assert.True(t, pathExists)
+		os.Remove(testFile)
+	})
+
+	t.Run("docker compose should be written to the filepath", func(t *testing.T) {
+		testFile := "TestFile.yaml"
+		os.Create(testFile)
+		composeWritten := WriteToComposeFile("TestFile.yaml", false)
+
+		pathExists := utils.PathExists(testFile)
+		assert.True(t, pathExists)
+		assert.True(t, composeWritten)
+		os.Remove(testFile)
+	})
+	t.Run("empty path returns nil", func(t *testing.T) {
+		composeWritten := WriteToComposeFile("", false)
+		assert.False(t, composeWritten)
+	})
+}

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -27,12 +27,10 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/eclipse/codewind-installer/pkg/errors"
 	"github.com/google/go-github/github"
 	logr "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 // CreateTempFile in the same directory as the binary for docker compose
@@ -52,37 +50,6 @@ func CreateTempFile(filePath string) bool {
 	return false
 }
 
-// WriteToComposeFile the contents of the docker compose yaml
-func WriteToComposeFile(dockerComposeFile string, debug bool) bool {
-	if dockerComposeFile == "" {
-		return false
-	}
-
-	dataStruct := Compose{}
-
-	unmarshDataErr := yaml.Unmarshal([]byte(data), &dataStruct)
-	errors.CheckErr(unmarshDataErr, 202, "")
-
-	if debug == true && len(dataStruct.SERVICES.PFE.Ports) > 0 {
-		debugPort := DetermineDebugPortForPFE()
-		// Add the debug port to the docker compose data
-		dataStruct.SERVICES.PFE.Ports = append(dataStruct.SERVICES.PFE.Ports, "127.0.0.1:"+debugPort+":9777")
-	}
-
-	marshalledData, err := yaml.Marshal(&dataStruct)
-	errors.CheckErr(err, 203, "")
-
-	if debug == true {
-		fmt.Printf("==> %s structure is: \n%s\n\n", dockerComposeFile, string(marshalledData))
-	} else {
-		fmt.Println("==> environment structure written to " + filepath.ToSlash(dockerComposeFile))
-	}
-
-	err = ioutil.WriteFile(dockerComposeFile, marshalledData, 0644)
-	errors.CheckErr(err, 204, "")
-	return true
-}
-
 // DeleteTempFile once the the Codewind environment has been created
 func DeleteTempFile(filePath string) (bool, error) {
 	var _, file = os.Stat(filePath)
@@ -95,41 +62,6 @@ func DeleteTempFile(filePath string) (bool, error) {
 	os.Remove(filePath)
 	// fmt.Printf("==> Deleted file: %s\n", filePath)
 	return true, nil
-}
-
-// PingHealth - pings environment api every 15 seconds to check if containers started
-func PingHealth(healthEndpoint string) (bool, *DockerError) {
-	var started = false
-	fmt.Println("Waiting for Codewind to start")
-
-	dockerClient, err := NewDockerClient()
-	if err != nil {
-		return false, err
-	}
-
-	hostname, port, err := GetPFEHostAndPort(dockerClient)
-	if err != nil {
-		return false, err
-	}
-	for i := 0; i < 120; i++ {
-		resp, err := http.Get("http://" + hostname + ":" + port + healthEndpoint)
-		if err != nil {
-			fmt.Printf(".")
-		} else {
-			if resp.StatusCode == 200 {
-				fmt.Println("\nHTTP Response Status:", resp.StatusCode, http.StatusText(resp.StatusCode))
-				fmt.Println("Codewind successfully started on http://" + hostname + ":" + port)
-				started = true
-				break
-			}
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	if started != true {
-		log.Fatal("Codewind containers are taking a while to start. Please check the container logs and/or restart Codewind")
-	}
-	return started, nil
 }
 
 // GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref

--- a/pkg/utils/filesystem_test.go
+++ b/pkg/utils/filesystem_test.go
@@ -116,33 +116,6 @@ func TestDirIsEmpty(t *testing.T) {
 	})
 }
 
-func TestWriteToComposeFile(t *testing.T) {
-	t.Run("docker compose should be written to the filepath", func(t *testing.T) {
-		testFile := "TestFile.yaml"
-		os.Create(testFile)
-		_ = WriteToComposeFile("TestFile.yaml", false)
-
-		pathExists := PathExists(testFile)
-		assert.True(t, pathExists)
-		os.Remove(testFile)
-	})
-
-	t.Run("docker compose should be written to the filepath", func(t *testing.T) {
-		testFile := "TestFile.yaml"
-		os.Create(testFile)
-		composeWritten := WriteToComposeFile("TestFile.yaml", false)
-
-		pathExists := PathExists(testFile)
-		assert.True(t, pathExists)
-		assert.True(t, composeWritten)
-		os.Remove(testFile)
-	})
-	t.Run("empty path returns nil", func(t *testing.T) {
-		composeWritten := WriteToComposeFile("", false)
-		assert.False(t, composeWritten)
-	})
-}
-
 func TestReplaceInFiles(t *testing.T) {
 	t.Run("replaces placeholder in file", func(t *testing.T) {
 		testFile, removeFile := CreateTempTestFile(t, "[PROJ_NAME_PLACEHOLDER] test")

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+import (
+	"log"
+	"testing"
+)
+
+func TestRemoveDuplicateEntries(t *testing.T) {
+	dupArr := []string{"test", "test", "test"}
+	result := RemoveDuplicateEntries(dupArr)
+
+	if len(result) != 1 {
+		log.Fatal("Test 1: Failed to delete duplicate array index")
+	}
+
+	dupArr = []string{"", "test", "test"}
+	result = RemoveDuplicateEntries(dupArr)
+	if len(result) != 1 {
+		log.Fatal("Test 2: Failed to delete duplicate array index")
+	}
+
+	dupArr = []string{"", "", ""}
+	result = RemoveDuplicateEntries(dupArr)
+	if len(result) != 0 {
+		log.Fatal("Test 3: Failed to identify empty array values")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Refactor
- [ ] Enhancement

## What does this PR do ?
Moves our docker logic from the `utils` package to a new `docker` package, so that we avoid circular imports in future, e.g. when we tried to combine our insecure keyring with our docker credential mechanism introduced in https://github.com/eclipse/codewind-installer/pull/394

## Which issue(s) does this PR fix ?
Helps https://github.com/eclipse/codewind/issues/1306

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
