### PR TITLE
test: fail PR build when tests fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,8 +135,9 @@ spec:
 
                         cd ../../$CODE_DIRECTORY_FOR_GO
                         go test ./... -short -coverprofile=coverage.txt -covermode=count
-                        if [ $? -ne 0 ]; then
-                            exit $?
+                        TEST_RESULT=$?
+                        if [ $TEST_RESULT -ne 0 ]; then
+                            exit $TEST_RESULT
                         fi
 
                         # Report coverage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,6 +135,9 @@ spec:
 
                         cd ../../$CODE_DIRECTORY_FOR_GO
                         go test ./... -short -coverprofile=coverage.txt -covermode=count
+                        if [ $? -ne 0 ]; then
+                            exit $?
+                        fi
 
                         # Report coverage
                         if [ -n "$CODECOV_TOKEN" ]; then


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [x] Test bug fix
- [ ] Enhancement

## What does this PR do ?
Fails the Jenkins PR build when our tests fail. 

For probably 2 months, our Jenkins PR builds have been passing even when our tests have a failure (see incorrectly passing builds on https://github.com/eclipse/codewind-installer/pull/405). 

I'm not sure what the cause is - perhaps https://github.com/eclipse/codewind-installer/pull/311/files#diff-58231b16fdee45a03a4ee3cf94a9f2c3R137-R139 inserted another command (`rm`) after the final `go test` command, maybe making our PR build pass/fail reflecting the status of `rm` not `go test`.

My fix is similar to what we've done in the Codewind PFE repo, e.g.: https://github.com/eclipse/codewind/blob/master/Jenkinsfile#L62, https://github.com/eclipse/codewind/blob/master/Jenkinsfile#L105

## Which issue(s) does this PR fix ?
None directly. Discovered while working on https://github.com/eclipse/codewind-installer/pull/405

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
