### PR TITLE
Pass docker config remerge

### DIFF
--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -15,6 +15,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"os"
+	"path"
 
 	"github.com/eclipse/codewind-installer/pkg/appconstants"
 	desktoputils "github.com/eclipse/codewind-installer/pkg/desktop_utils"
@@ -25,7 +26,7 @@ import (
 )
 
 var homeDir = desktoputils.GetHomeDir()
-var dockerComposeFile = homeDir + "/.codewind/docker-compose.yaml"
+var dockerComposeFile = path.Join(homeDir, ".codewind", "docker-compose.yaml")
 var printAsJSON = false
 
 const healthEndpoint = "/api/v1/environment"

--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/urfave/cli"
 )
@@ -50,6 +51,18 @@ func AddRegistrySecret(c *cli.Context) {
 		HandleRegistryError(registryErr)
 		os.Exit(1)
 	}
+
+	// If this is a local connection we need to persist the details in the keychain for
+	// the next time Codewind starts.
+	// (On Kubernetes PFE persists them in a secret inside Kubernetes itself.)
+	if conInfo.ID == "local" {
+		dockerErr := docker.AddDockerCredential(conInfo.ID, address, username, password)
+		if dockerErr != nil {
+			HandleDockerError(dockerErr)
+			os.Exit(1)
+		}
+	}
+
 	utils.PrettyPrintJSON(registrySecrets)
 }
 
@@ -63,6 +76,13 @@ func RemoveRegistrySecret(c *cli.Context) {
 	if err != nil {
 		registryErr := &RegistryError{errOpRemoveRegistry, err, err.Error()}
 		HandleRegistryError(registryErr)
+		os.Exit(1)
+	}
+	// Remove secret from our keychain entry.
+	// (But don't logout of docker locally.)
+	dockerErr := docker.RemoveDockerCredential(conInfo.ID, address)
+	if dockerErr != nil {
+		HandleDockerError(dockerErr)
 		os.Exit(1)
 	}
 	utils.PrettyPrintJSON(registrySecrets)

--- a/pkg/apiroutes/registrysecrets.go
+++ b/pkg/apiroutes/registrysecrets.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -71,10 +70,10 @@ func AddRegistrySecret(conInfo *connections.Connection, conURL string, httpClien
 	jsonPayload, _ := json.Marshal(registryParameters)
 
 	req, err := http.NewRequest("POST", conURL+"/api/v1/registrysecrets", bytes.NewBuffer(jsonPayload))
-	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusCreated)
 }
@@ -87,10 +86,10 @@ func RemoveRegistrySecret(conInfo *connections.Connection, conURL string, httpCl
 	jsonPayload, _ := json.Marshal(addressParameter)
 
 	req, err := http.NewRequest("DELETE", conURL+"/api/v1/registrysecrets", bytes.NewBuffer(jsonPayload))
-	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	return handleRegistrySecretsResponse(req, conInfo, httpClient, http.StatusOK)
 }
@@ -109,7 +108,7 @@ func handleRegistrySecretsResponse(req *http.Request, conInfo *connections.Conne
 	}
 
 	if resp.StatusCode != successCode {
-		return nil, errors.New(fmt.Sprintf("%s - %s\n", http.StatusText(resp.StatusCode), string(byteArray)))
+		return nil, fmt.Errorf("%s - %s", http.StatusText(resp.StatusCode), string(byteArray))
 	}
 
 	var registrySecrets []RegistryResponse

--- a/pkg/apiroutes/registrysecrets_test.go
+++ b/pkg/apiroutes/registrysecrets_test.go
@@ -14,8 +14,11 @@ package apiroutes
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
@@ -24,6 +27,13 @@ import (
 )
 
 const exampleBadJSON = "<This is not JSON>"
+
+type ErrorReader struct {
+}
+
+func (r ErrorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("fake error reading body")
+}
 
 func Test_GetRegistrySecrets(t *testing.T) {
 	t.Run("success case - returns nil error when PFE status code 200", func(t *testing.T) {
@@ -44,6 +54,25 @@ func Test_GetRegistrySecrets(t *testing.T) {
 		_, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
 		assert.Error(t, err)
 	})
+	t.Run("error case - returns error when request fails", func(t *testing.T) {
+		mockClient := &security.ClientMockRequestFail{}
+		mockConnection := connections.Connection{ID: "local"}
+		actualRegistrySecrets, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
+		assert.Nil(t, actualRegistrySecrets)
+		assert.True(t, strings.Contains(err.Error(), "mock http request failure"))
+	})
+	t.Run("error case - returns error creating bad request", func(t *testing.T) {
+		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
+		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
+		assert.Nil(t, err)
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
+		mockConnection := connections.Connection{ID: "local"}
+		// Use control characters to create an invalid URL and trigger an error from http.NewRequest
+		_, err = GetRegistrySecrets(&mockConnection, "\x00\x01\x02\x03\x04\x05\x06\x05\x7F", mockClient)
+		fmt.Println(err)
+		assert.Error(t, err)
+	})
 	t.Run("error case -  badJSONResponse", func(t *testing.T) {
 		resBody := ioutil.NopCloser(bytes.NewReader([]byte(exampleBadJSON)))
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
@@ -52,6 +81,14 @@ func Test_GetRegistrySecrets(t *testing.T) {
 		var registrySecrets []RegistryResponse
 		expectedError := json.Unmarshal([]byte(exampleBadJSON), &registrySecrets)
 		assert.Equal(t, expectedError, err)
+	})
+	t.Run("error case - returns error on error reading response body", func(t *testing.T) {
+		errorBody := ioutil.NopCloser(ErrorReader{})
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: errorBody}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := GetRegistrySecrets(&mockConnection, "mockURL", mockClient)
+		assert.Error(t, err)
+		assert.Equal(t, "fake error reading body", err.Error())
 	})
 }
 
@@ -74,6 +111,25 @@ func Test_AddRegistrySecret(t *testing.T) {
 		_, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
 		assert.Error(t, err)
 	})
+	t.Run("error case - returns error when request fails", func(t *testing.T) {
+		mockClient := &security.ClientMockRequestFail{}
+		mockConnection := connections.Connection{ID: "local"}
+		actualRegistrySecrets, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
+		assert.Nil(t, actualRegistrySecrets)
+		assert.True(t, strings.Contains(err.Error(), "mock http request failure"))
+	})
+	t.Run("error case - returns error creating bad request", func(t *testing.T) {
+		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
+		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
+		assert.Nil(t, err)
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusCreated, Body: resBody}
+		mockConnection := connections.Connection{ID: "local"}
+		// Use control characters to create an invalid URL and trigger an error from http.NewRequest
+		_, err = AddRegistrySecret(&mockConnection, "\x00\x01\x02\x03\x04\x05\x06\x05\x7F", mockClient, "testdockerregistry", "testuser", "testpassword")
+		fmt.Println(err)
+		assert.Error(t, err)
+	})
 	t.Run("error case -  badJSONResponse", func(t *testing.T) {
 		resBody := ioutil.NopCloser(bytes.NewReader([]byte(exampleBadJSON)))
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusCreated, Body: resBody}
@@ -82,6 +138,14 @@ func Test_AddRegistrySecret(t *testing.T) {
 		var registrySecrets []RegistryResponse
 		expectedError := json.Unmarshal([]byte(exampleBadJSON), &registrySecrets)
 		assert.Equal(t, expectedError, err)
+	})
+	t.Run("error case - returns error on error reading response body", func(t *testing.T) {
+		errorBody := ioutil.NopCloser(ErrorReader{})
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: errorBody}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := AddRegistrySecret(&mockConnection, "mockURL", mockClient, "testdockerregistry", "testuser", "testpassword")
+		assert.Error(t, err)
+		assert.Equal(t, "fake error reading body", err.Error())
 	})
 }
 
@@ -104,6 +168,25 @@ func Test_DeleteRegistrySecret(t *testing.T) {
 		_, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "afakeregistry")
 		assert.Error(t, err)
 	})
+	t.Run("error case - returns error when request fails", func(t *testing.T) {
+		mockClient := &security.ClientMockRequestFail{}
+		mockConnection := connections.Connection{ID: "local"}
+		actualRegistrySecrets, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "anothertestdockerregistry")
+		assert.Nil(t, actualRegistrySecrets)
+		assert.True(t, strings.Contains(err.Error(), "mock http request failure"))
+	})
+	t.Run("error case - returns error creating bad request", func(t *testing.T) {
+		expectedRegistrySecrets := []RegistryResponse{RegistryResponse{Address: "testdockerregistry", Username: "testuser"}}
+		jsonResponse, err := json.Marshal(expectedRegistrySecrets)
+		assert.Nil(t, err)
+		resBody := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
+		mockConnection := connections.Connection{ID: "local"}
+		// Use control characters to create an invalid URL and trigger an error from http.NewRequest
+		_, err = RemoveRegistrySecret(&mockConnection, "\x00\x01\x02\x03\x04\x05\x06\x05\x7F", mockClient, "anothertestdockerregistry")
+		fmt.Println(err)
+		assert.Error(t, err)
+	})
 	t.Run("error case -  badJSONResponse", func(t *testing.T) {
 		resBody := ioutil.NopCloser(bytes.NewReader([]byte(exampleBadJSON)))
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: resBody}
@@ -112,5 +195,13 @@ func Test_DeleteRegistrySecret(t *testing.T) {
 		var registrySecrets []RegistryResponse
 		expectedError := json.Unmarshal([]byte(exampleBadJSON), &registrySecrets)
 		assert.Equal(t, expectedError, err)
+	})
+	t.Run("error case - returns error on error reading response body", func(t *testing.T) {
+		errorBody := ioutil.NopCloser(ErrorReader{})
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusBadRequest, Body: errorBody}
+		mockConnection := connections.Connection{ID: "local"}
+		_, err := RemoveRegistrySecret(&mockConnection, "mockURL", mockClient, "anothertestdockerregistry")
+		assert.Error(t, err)
+		assert.Equal(t, "fake error reading body", err.Error())
 	})
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -58,10 +57,11 @@ var containerNames = [...]string{
 }
 
 var homeDir = desktoputils.GetHomeDir()
-var dockerConfigSecretFile = path.Join(homeDir, ".codewind", "dockerconfig")
+
+var dockerConfigSecretFile = "dockerconfig"
 
 // codewind-docker-compose.yaml data
-var data = `
+var composeTemplate = `
 version: 3.3
 services:
  ` + pfeContainerName + `:
@@ -95,7 +95,7 @@ volumes:
   cw-workspace:
 secrets:
   dockerconfig:
-    file: ` + dockerConfigSecretFile + `
+    file: %s
 `
 
 // Compose struct for the docker compose yaml file

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -692,8 +692,6 @@ func setDockerCredentials(connectionID string, dockerConfig *DockerConfig) error
 	// structure.
 	if jsonErr != nil {
 		return jsonErr
-		// fmt.Printf("Error, invalid json in docker config structure - %s\n", jsonErr)
-		// os.Exit(1)
 	}
 	newSecret := string(newSecretBytes)
 	err := security.StoreSecretInKeyring(connectionID, "docker_credentials", newSecret)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -194,7 +195,7 @@ func DockerCompose(dockerComposeFile string, tag string, loglevel string) *Docke
 		//print out docker-compose sysout & syserr for error diagnosis
 		fmt.Printf(output.String())
 		utils.DeleteTempFile(dockerComposeFile)
-		ClearDockerConfigSecret()
+		ClearDockerConfigSecret(path.Dir(dockerComposeFile))
 		return &DockerError{errOpDockerComposeStart, err, err.Error()}
 	}
 	fmt.Printf("Please wait while containers initialize... %s \n", output.String())
@@ -202,20 +203,20 @@ func DockerCompose(dockerComposeFile string, tag string, loglevel string) *Docke
 		//print out docker-compose sysout & syserr for error diagnosis
 		fmt.Printf(output.String())
 		utils.DeleteTempFile(dockerComposeFile)
-		ClearDockerConfigSecret()
+		ClearDockerConfigSecret(path.Dir(dockerComposeFile))
 		return &DockerError{errOpDockerComposeStart, err, err.Error()}
 	}
 	fmt.Printf(output.String()) // Wait to finish execution, so we can read all output
 
 	if strings.Contains(output.String(), "ERROR") || strings.Contains(output.String(), "error") {
 		utils.DeleteTempFile(dockerComposeFile)
-		ClearDockerConfigSecret()
+		ClearDockerConfigSecret(path.Dir(dockerComposeFile))
 		os.Exit(1)
 	}
 
 	if strings.Contains(output.String(), "The image for the service you're trying to recreate has been removed") {
 		utils.DeleteTempFile(dockerComposeFile)
-		ClearDockerConfigSecret()
+		ClearDockerConfigSecret(path.Dir(dockerComposeFile))
 		os.Exit(1)
 	}
 	return nil
@@ -226,7 +227,7 @@ func DockerComposeStop(tag, dockerComposeFile string) *DockerError {
 	setupDockerComposeEnvs(tag, "stop", "")
 
 	// Delete the docker configuration file whether we have a clean shutdown or not.
-	ClearDockerConfigSecret()
+	ClearDockerConfigSecret(path.Dir(dockerComposeFile))
 
 	cmd := exec.Command("docker-compose", "-f", dockerComposeFile, "rm", "--stop", "-f")
 	output := new(bytes.Buffer)

--- a/pkg/docker/docker_error.go
+++ b/pkg/docker/docker_error.go
@@ -36,6 +36,7 @@ const (
 	errOpImageDigest         = "IMAGE_DIGEST_ERROR"
 	errOpContainerList       = "CONTAINER_LIST_ERROR"
 	errOpImageList           = "IMAGE_LIST_ERROR"
+	errDockerCredential      = "DOCKER_CREDENTIAL_ERROR"
 )
 
 const (

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -116,6 +116,10 @@ func (m *mockDockerClientWithCw) DistributionInspect(ctx context.Context, image,
 	}, nil
 }
 
+func (m *mockDockerClientWithCw) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
+}
+
 // This mock client will return valid image and containers lists, without Codewind items
 type mockDockerClientWithoutCw struct {
 }
@@ -159,6 +163,10 @@ func (m *mockDockerClientWithoutCw) DistributionInspect(ctx context.Context, ima
 	}, nil
 }
 
+func (m *mockDockerClientWithoutCw) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
+}
+
 // This mock client will return errors for each call to a docker function
 type mockDockerErrorClient struct {
 }
@@ -198,6 +206,10 @@ func (m *mockDockerErrorClient) ContainerInspect(ctx context.Context, containerI
 
 func (m *mockDockerErrorClient) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
 	return registry.DistributionInspect{}, errDistributionInspect
+}
+
+func (m *mockDockerErrorClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
 }
 
 func TestPullImage(t *testing.T) {

--- a/pkg/docker/filesystem.go
+++ b/pkg/docker/filesystem.go
@@ -78,9 +78,10 @@ func writeDockerConfigSecretFile(parentPath string) (string, error) {
 
 // ClearDockerConfigSecret We erase the contents rather than deleting
 // the file as the docker-compose file expects the secret to be present.
-func ClearDockerConfigSecret() error {
+func ClearDockerConfigSecret(parentPath string) error {
 	// Most callers won't handle this error as this shouldn't block shutdown.
-	return ioutil.WriteFile(dockerConfigSecretFile, []byte{}, 0600)
+	secretFile := path.Join(parentPath, dockerConfigSecretFile)
+	return ioutil.WriteFile(secretFile, []byte{}, 0600)
 }
 
 // PingHealth - pings environment api every 15 seconds to check if containers started

--- a/pkg/docker/filesystem_test.go
+++ b/pkg/docker/filesystem_test.go
@@ -15,11 +15,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/eclipse/codewind-installer/pkg/globals"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWriteToComposeFile(t *testing.T) {
+	originalUseInsecureKeyring := globals.UseInsecureKeyring
+	globals.SetUseInsecureKeyring(true)
 	t.Run("docker compose should be written to the filepath", func(t *testing.T) {
 		testFile := "TestFile.yaml"
 		os.Create(testFile)
@@ -44,4 +47,5 @@ func TestWriteToComposeFile(t *testing.T) {
 		composeWritten := WriteToComposeFile("", false)
 		assert.False(t, composeWritten)
 	})
+	globals.SetUseInsecureKeyring(originalUseInsecureKeyring)
 }

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -156,12 +156,16 @@ func GetSecretFromKeyring(connectionID, uName string) (string, *SecError) {
 				return string(secret.Password), nil
 			}
 		}
-		err := errors.New("secret not found in keyring")
+		err := errors.New(textSecretNotFound)
 		return "", &SecError{errOpKeyring, err, err.Error()}
 	}
 	// else get from system keyring
 	secret, err := keyring.Get(service, uName)
 	if err != nil {
+		if err == keyring.ErrNotFound {
+			err := errors.New(textSecretNotFound)
+			return "", &SecError{errOpKeyring, err, err.Error()}
+		}
 		return "", &SecError{errOpKeyring, err, err.Error()}
 	}
 	return secret, nil
@@ -218,6 +222,10 @@ func DeleteSecretFromKeyring(connectionID, uName string) *SecError {
 func readInsecureKeyring() ([]KeyringSecret, *SecError) {
 	file, readErr := ioutil.ReadFile(GetPathToInsecureKeyring())
 	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			err := errors.New(textSecretNotFound)
+			return nil, &SecError{errOpKeyring, err, err.Error()}
+		}
 		return nil, &SecError{errOpKeyring, readErr, readErr.Error()}
 	}
 	secrets := []KeyringSecret{}

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -163,8 +163,8 @@ func GetSecretFromKeyring(connectionID, uName string) (string, *SecError) {
 	secret, err := keyring.Get(service, uName)
 	if err != nil {
 		if err == keyring.ErrNotFound {
-			err := errors.New(textSecretNotFound)
-			return "", &SecError{errOpKeyring, err, err.Error()}
+			errNotFound := errors.New(textSecretNotFound)
+			return "", &SecError{errOpKeyring, errNotFound, errNotFound.Error()}
 		}
 		return "", &SecError{errOpKeyring, err, err.Error()}
 	}

--- a/pkg/security/security_utils.go
+++ b/pkg/security/security_utils.go
@@ -57,6 +57,7 @@ const (
 	textUnableToParse  = "Unable to parse Keycloak response"
 	textInvalidOptions = "Invalid or missing command line options"
 	textAuthIsDown     = "Authentication service unavailable"
+	textSecretNotFound = "Secret not found in keyring"
 )
 
 // SecError : Error formatted in JSON containing an errorOp and a description from
@@ -94,4 +95,9 @@ func parseKeycloakError(body string, httpCode int) *KeycloakAPIError {
 		keycloakAPIError.ErrorDescription = keycloakAPIError.ErrorMessage
 	}
 	return &keycloakAPIError
+}
+
+// IsSecretNotFoundError : Test whether a secret error is due to the secret not exisiting.
+func IsSecretNotFoundError(se *SecError) bool {
+	return se.Desc == textSecretNotFound
 }

--- a/pkg/security/testutils.go
+++ b/pkg/security/testutils.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"errors"
 	"io"
 	"net/http"
 )
@@ -20,4 +21,12 @@ func (c *ClientMockAuthenticate) Do(req *http.Request) (*http.Response, error) {
 		StatusCode: c.StatusCode,
 		Body:       c.Body,
 	}, nil
+}
+
+type ClientMockRequestFail struct {
+}
+
+// Do : perform do function
+func (c *ClientMockRequestFail) Do(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("mock http request failure")
 }


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement
## What does this PR do ?

This PR adds support for persisting the docker registry credentials between Codewind restarts.
It stores the docker logins added via the 'registrysecrets' command for local connections in the local keychain.
In the docker compose file they are mounted into the docker codewind-pfe container as a text file based secret.
The text file containing the secret is cleared on shutdown or startup failure and is read only to the user to try to provide as much protection as possible. (Unfortunately writing the docker secrets back out to the file system seems unavoidable.) The secret is also base64 encoded, this matches what happens in kubernetes and just protects passwords from accidental casual inspection, it is not intended as a substitute for encryption.
The docker compose file version is updated to 3.3 as that supports secrets and is also the level supported by docker 17.06 which is the minimum version we pre-req:

https://docs.docker.com/compose/compose-file/#secrets (Docker levels and docker compose file versions.)
https://www.eclipse.org/codewind/mdt-vsc-getting-started.html (Docker level required for codewind.)

This PR also includes test cases.

## Which issue(s) does this PR fix ?
This is part of https://github.com/eclipse/codewind/issues/1306

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1306

Note that I still need to raise one further PR to log the local user (outside the PFE container on the host machine) into their registry with the provided docker credentials so that appsody can also pull images. This PR (and it's companion) just solve persisting docker credentials across PFE restarts.

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
This PR requires the change in https://github.com/eclipse/codewind/pull/2417 for PFE to actually use the secret that is created.
(They can be merged independently but can't be tested without each other as one creates the secret and the other reads it.)

This is a rebase of https://github.com/eclipse/codewind-installer/pull/394 on top of the changes to add an insecure keyring. A change to use the insecure keyring in the codewind builds:
https://github.com/eclipse/codewind/pull/2507 *must* be merged first or this change will break the master build on the codewind repository.