### PR TITLE
Add project restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ When using a project ID the CLI will automatically detect which connection it re
 > --name                        Project name
 > --conid                       Connection ID
 
+`restart` - Restart a project
+> **Flags**
+> --id, i                       Project ID
+> --conid                       Connection ID
+> --startMode                   "run" | "debug" | "debugNoInit"
+
 `connection/con` - Manage the connection targets for a project
 
 `set,s` - Sets the connection for a projectID

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -208,7 +208,7 @@ func Commands() {
 					Usage: "Restart a single project, requires 'id' and 'startMode'",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
-						cli.StringFlag{Name: "startmode, s", Usage: "Start Mode, either run or debug", Required: true},
+						cli.StringFlag{Name: "startmode, s", Usage: "Start Mode of the project; can be run, debug, or debugNoInit", Required: true},
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id of the remote deployment to use", Required: false},
 					},
 					Action: func(c *cli.Context) error {

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -203,6 +203,19 @@ func Commands() {
 						return nil
 					},
 				},
+				{
+					Name:  "restart",
+					Usage: "Restart a single project, requires 'id' and 'startMode'",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
+						cli.StringFlag{Name: "startmode, s", Usage: "Start Mode, either run or debug", Required: true},
+						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id of the remote deployment to use", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						ProjectRestart(c)
+						return nil
+					},
+				},
 			},
 		},
 

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -255,3 +255,32 @@ func ProjectGet(c *cli.Context) {
 	}
 	os.Exit(0)
 }
+
+// ProjectRestart : restarts a project
+func ProjectRestart(c *cli.Context) {
+	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
+	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
+	startMode := strings.TrimSpace(c.String("startmode"))
+
+	conInfo, conInfoErr := connections.GetConnectionByID(conID)
+	if conInfoErr != nil {
+		HandleConnectionError(conInfoErr)
+		os.Exit(1)
+	}
+
+	conURL, conErr := config.PFEOriginFromConnection(conInfo)
+	if conErr != nil {
+		HandleConfigError(conErr)
+		os.Exit(1)
+	}
+
+	err := project.RestartProject(http.DefaultClient, conInfo, conURL, projectID, startMode)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project restart request accepted"})
+	fmt.Println(string(response))
+	os.Exit(0)
+}

--- a/pkg/project/restartproject.go
+++ b/pkg/project/restartproject.go
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package project
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/sechttp"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+)
+
+type (
+	// RestartParameters : The request structure to restart a project
+	RestartParameters struct {
+		StartMode string `json:"startMode"`
+	}
+)
+
+// RestartProject calls the restart API on the connected PFE, for the given projectID and startMode
+func RestartProject(httpClient utils.HTTPClient, conInfo *connections.Connection, conURL string, projectID string, startMode string) error {
+	requestURL := conURL + "/api/v1/projects/" + projectID + "/restart"
+	parameters := RestartParameters{
+		StartMode: startMode,
+	}
+	jsonPayload, _ := json.Marshal(parameters)
+	req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(jsonPayload))
+	req.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		return err
+	}
+	return handleRestartResponse(req, conInfo, httpClient, http.StatusAccepted)
+}
+
+func handleRestartResponse(req *http.Request, conInfo *connections.Connection, httpClient utils.HTTPClient, successCode int) error {
+	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
+	if httpSecError != nil {
+		return httpSecError
+	}
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != successCode {
+		return fmt.Errorf("Error code: %s - %s", http.StatusText(resp.StatusCode), string(byteArray))
+	}
+
+	return nil
+}

--- a/pkg/project/restartproject_test.go
+++ b/pkg/project/restartproject_test.go
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package project
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/stretchr/testify/assert"
+)
+
+var emptyResponseBody = ioutil.NopCloser(bytes.NewReader([]byte{}))
+var mockConnection = connections.Connection{ID: "local"}
+
+func Test_RestartProject(t *testing.T) {
+	t.Run("success case - returns nil error when PFE status code 202", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusAccepted, Body: emptyResponseBody}
+		err := RestartProject(mockClient, &mockConnection, "mockURL", "mockID", "debugNoInit")
+		assert.Nil(t, err)
+	})
+
+	t.Run("error case - returns error when PFE status code non 202", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: emptyResponseBody}
+		err := RestartProject(mockClient, &mockConnection, "mockURL", "mockID", "debugNoInit")
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Wraps the PFE rest API in a CWCTL command, with flags for connectionID, projectID and startMode.

At this stage, this is for only local projects. Further PRs will be made, to PFE and this repo, for handling remote project restart in run and debug mode.

## Which issue(s) does this PR fix ?

Part of https://github.com/eclipse/codewind/issues/1990.

## Does this PR require a documentation change ?

No
