### PR TITLE
Log into docker registries locally when saving credentials.

### DIFF
--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -45,22 +45,33 @@ func AddRegistrySecret(c *cli.Context) {
 	username := strings.TrimSpace(c.String("username"))
 	password := strings.TrimSpace(c.String("password"))
 
+	// If this is a local connection we need to:
+	// - Log in to local docker to support extensions such as appsody.
+	// - Persist the details in the keychain for the next time Codewind starts.
+	//   (On Kubernetes PFE persists them in a secret inside Kubernetes itself.)
+	if conInfo.ID == "local" {
+
+		// Log in with local docker. Do this first as it will validate the credentials.
+		// Otherwise we have to undo everything else if they are wrong.
+		dockerErr := docker.LoginToRegistry(address, username, password)
+		if dockerErr != nil {
+			HandleDockerError(dockerErr)
+			os.Exit(1)
+		}
+
+		// Add the credentials to the local keyring.
+		dockerErr = docker.AddDockerCredential(conInfo.ID, address, username, password)
+		if dockerErr != nil {
+			HandleDockerError(dockerErr)
+			os.Exit(1)
+		}
+	}
+
 	registrySecrets, err := apiroutes.AddRegistrySecret(conInfo, conURL, http.DefaultClient, address, username, password)
 	if err != nil {
 		registryErr := &RegistryError{errOpAddRegistry, err, err.Error()}
 		HandleRegistryError(registryErr)
 		os.Exit(1)
-	}
-
-	// If this is a local connection we need to persist the details in the keychain for
-	// the next time Codewind starts.
-	// (On Kubernetes PFE persists them in a secret inside Kubernetes itself.)
-	if conInfo.ID == "local" {
-		dockerErr := docker.AddDockerCredential(conInfo.ID, address, username, password)
-		if dockerErr != nil {
-			HandleDockerError(dockerErr)
-			os.Exit(1)
-		}
 	}
 
 	utils.PrettyPrintJSON(registrySecrets)


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
Performs a local docker login when saving docker credentials to support extensions that need access to docker registries.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/1306

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1306

## Does this PR require a documentation change ?
Yes, we should note that when a user adds a docker registry to the local connection they will be logged into that docker repository on their local machine as well. The documentation may currently assume that local codewind does not save docker registries. The work item for the whole piece of work https://github.com/eclipse/codewind/issues/1306 has been tagged with area/docs so this should be included.

## Any special notes for your reviewer ?
