### PR TITLE
[WIP] add k8s port forward

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -142,6 +142,17 @@
   version = "v0.4.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:ecdc8e0fe3bc7d549af1c9c36acf3820523b707d6c071b6d0c3860882c6f7b42"
+  name = "github.com/docker/spdystream"
+  packages = [
+    ".",
+    "spdy",
+  ]
+  pruneopts = "UT"
+  revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
+
+[[projects]]
   digest = "1:2b5f431fa18891a2ac0e02353c83fb3bf458fced6ccecd664b429054e0c4ce3b"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
@@ -540,14 +551,6 @@
   version = "v2.2.4"
 
 [[projects]]
-  branch = "v3"
-  digest = "1:46754188622566b86271d7526cb643b88c2b9589ee224c2d55e282f0f35a0df8"
-  name = "gopkg.in/yaml.v3"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "674ba3eaed223079f9377fbb0c98c0951bf6ec10"
-
-[[projects]]
   branch = "master"
   digest = "1:bd776e2c0357331ee88cbe8989a7424ddc1e20b49066739fc9a86dbe704df284"
   name = "k8s.io/api"
@@ -594,7 +597,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7d0f2423733b8bc7379bb6aeef64e6ead6e374060d7c9d405cf7aa43c0e70466"
+  digest = "1:4b43985392bba7fc757d7b4d36f48c7e69432c764dfe54d02f4d9b07467fe3f5"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -619,6 +622,8 @@
     "pkg/util/clock",
     "pkg/util/errors",
     "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/httpstream/spdy",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
@@ -634,13 +639,14 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
+    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
   revision = "31cb258e7ad9e746e7f46dbd0844c992ed56d179"
 
 [[projects]]
-  digest = "1:055f27bf0f54eaa99f4bbe9d52275a4bd755f99ad9c88dd4790bd46c27fdca38"
+  digest = "1:677dea746504d89c8f33e130dbed92e65e7fe3e02c3d19f3f2d2673d79b1b032"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -740,8 +746,10 @@
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
     "tools/metrics",
+    "tools/portforward",
     "tools/reference",
     "transport",
+    "transport/spdy",
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
@@ -804,7 +812,7 @@
     "github.com/stretchr/testify/require",
     "github.com/urfave/cli",
     "github.com/zalando/go-keyring",
-    "gopkg.in/yaml.v3",
+    "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
@@ -822,6 +830,8 @@
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/portforward",
+    "k8s.io/client-go/transport/spdy",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This is the same as `go test ./...`, but outputs test coverage scores for each f
 ### CLI Commands
 
 | Command         | Alias | Usage                                                               |
-| ----------------| ----- | ------------------------------------------------------------------- |
+| --------------- | ----- | ------------------------------------------------------------------- |
 | project         |       | 'Manage Codewind projects'                                          |
 | install         | `in`  | 'Pull pfe & performance images from dockerhub'                      |
 | start           |       | 'Start the Codewind containers'                                     |
@@ -203,21 +203,29 @@ Subcommands:</br>
 > --time,-t value Time of last project sync
 
 `list` - List projects bound to a Codewind deployment
+
 > **Flags**
-> --conid value                 Connection ID
+> --conid value Connection ID
 
 `get` - Get a single project, requires either the project ID or name
 When using a project ID the CLI will automatically detect which connection it relates to
+
 > **Flags**
-> --id value                    Project ID
-> --name                        Project name
-> --conid                       Connection ID
+> --id value Project ID
+> --name Project name
+> --conid Connection ID
 
 `restart` - Restart a project
+
 > **Flags**
-> --id, i                       Project ID
-> --conid                       Connection ID
-> --startMode                   "run" | "debug" | "debugNoInit"
+> --id, i Project ID
+> --conid Connection ID
+> --startMode "run" | "debug" | "debugNoInit"
+
+`port-forward` - Forward a remote project port, to local
+
+> --id, i Project ID
+> --port, p The remote port to port to local
 
 `connection/con` - Manage the connection targets for a project
 
@@ -280,20 +288,24 @@ Subcommands:</br>
 ### remove
 
 `--tag/-t <value>` - Dockerhub image tag.</br>
+
 > **Note:** Failing to specify a `--tag`, will result in an attempt to remove the default `latest` tagged Codewind images on the host machine.
 
 Subcommands:</br>
 
 `local/l` - Removes and deletes a Codewind local deployment
+
 > **Flags:**
 > --tag - Docker hub image tag
 
 `remote/r` - Removes and deletes a Codewind remote deployment from Kubernetes
+
 > **Flags:**
 > --namespace - Kubernetes namespace
 > --workspace - Codewind workspace ID
 
 `keycloak/k` - Removes and deletes a Keycloak deployment from Kubernetes
+
 > **Flags:**
 > --namespace - Kubernetes namespace
 > --workspace - Keycloak workspace ID

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -219,7 +219,7 @@ func Commands() {
 				},
 				{
 					Name:  "port-forward",
-					Usage: "Forward a port from a remote project to local'",
+					Usage: "Forward a port from a remote project to an available local port'",
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
 						cli.StringFlag{Name: "port, p", Usage: "Remote port to forward", Required: true},

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -217,9 +217,20 @@ func Commands() {
 						return nil
 					},
 				},
+				{
+					Name:  "port-forward",
+					Usage: "Forward a port from a remote project to local'",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
+						cli.StringFlag{Name: "port, p", Usage: "Remote port to forward", Required: true},
+					},
+					Action: func(c *cli.Context) error {
+						ProjectPortForward(c)
+						return nil
+					},
+				},
 			},
 		},
-
 		{
 			Name:    "install",
 			Aliases: []string{"in"},

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -287,7 +287,7 @@ func ProjectRestart(c *cli.Context) {
 	os.Exit(0)
 }
 
-// ProjectPortForward : Forward a remote project port to local
+// ProjectPortForward : Forward a remote project port to an available local port
 func ProjectPortForward(c *cli.Context) {
 	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
 	port := strings.TrimSpace(strings.ToLower(c.String("port")))

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -288,20 +288,22 @@ func ProjectRestart(c *cli.Context) {
 }
 
 // ProjectPortForward : Forward a remote project port to local
-func ProjectPortForward(c *cli.Context) error {
+func ProjectPortForward(c *cli.Context) {
 	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
 	port := strings.TrimSpace(strings.ToLower(c.String("port")))
 
 	// convert port string to int
 	intPort, err := strconv.Atoi(port)
 	if err != nil {
-		return err
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 
-	err = remote.HandlePortForward(projectID, intPort)
-	if err != nil {
-		return err
+	RemErr := remote.HandlePortForward(projectID, intPort)
+	if RemErr != nil {
+		HandleRemInstError(RemErr)
+		os.Exit(1)
 	}
 
-	return nil
+	os.Exit(0)
 }

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -16,12 +16,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/project"
+	"github.com/eclipse/codewind-installer/pkg/remote"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -283,4 +285,23 @@ func ProjectRestart(c *cli.Context) {
 	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project restart request accepted"})
 	fmt.Println(string(response))
 	os.Exit(0)
+}
+
+// ProjectPortForward : Forward a remote project port to local
+func ProjectPortForward(c *cli.Context) error {
+	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
+	port := strings.TrimSpace(strings.ToLower(c.String("port")))
+
+	// convert port string to int
+	intPort, err := strconv.Atoi(port)
+	if err != nil {
+		return err
+	}
+
+	err = remote.HandlePortForward(projectID, intPort)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/project/restartproject.go
+++ b/pkg/project/restartproject.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
+	"github.com/eclipse/codewind-installer/pkg/remote"
 	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
@@ -32,6 +33,15 @@ type (
 
 // RestartProject calls the restart API on the connected PFE, for the given projectID and startMode
 func RestartProject(httpClient utils.HTTPClient, conInfo *connections.Connection, conURL string, projectID string, startMode string) error {
+	// this will come after the call requesting restart on turbine, however currently an error is returned
+	// when a request to restart a k8s project is sent
+	if conInfo.ID != "local" {
+		err := remote.HandlePortForward(projectID, "")
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	requestURL := conURL + "/api/v1/projects/" + projectID + "/restart"
 	parameters := RestartParameters{
 		StartMode: startMode,

--- a/pkg/project/restartproject.go
+++ b/pkg/project/restartproject.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
-	"github.com/eclipse/codewind-installer/pkg/remote"
 	"github.com/eclipse/codewind-installer/pkg/sechttp"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 )
@@ -33,15 +32,6 @@ type (
 
 // RestartProject calls the restart API on the connected PFE, for the given projectID and startMode
 func RestartProject(httpClient utils.HTTPClient, conInfo *connections.Connection, conURL string, projectID string, startMode string) error {
-	// this will come after the call requesting restart on turbine, however currently an error is returned
-	// when a request to restart a k8s project is sent
-	if conInfo.ID != "local" {
-		err := remote.HandlePortForward(projectID, "")
-		if err != nil {
-			return err
-		}
-		return nil
-	}
 	requestURL := conURL + "/api/v1/projects/" + projectID + "/restart"
 	parameters := RestartParameters{
 		StartMode: startMode,

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -59,7 +59,7 @@ type DeploymentResult struct {
 
 // DeployRemote : InstallRemote
 func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemInstError) {
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}

--- a/pkg/remote/deploy_get.go
+++ b/pkg/remote/deploy_get.go
@@ -36,7 +36,7 @@ type K8sAPI struct {
 
 // GetExistingDeployments returns information about the remote installations of codewind, across all namespaces by default
 func GetExistingDeployments(namespace string) ([]ExistingDeployment, *RemInstError) {
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)

--- a/pkg/remote/install_utils.go
+++ b/pkg/remote/install_utils.go
@@ -26,6 +26,8 @@ const (
 	errOpNotFound        = "rem_not_found"
 	errOpNoIngress       = "rem_no_ingress"
 	errOpCreateNamespace = "rem_create_namespace"
+	errOpGetPods         = "rem_get_pods"
+	errOpPortForward     = "rem_port_forward"
 )
 
 const (

--- a/pkg/remote/portforward.go
+++ b/pkg/remote/portforward.go
@@ -14,6 +14,7 @@ package remote
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
@@ -44,7 +44,7 @@ type (
 		Pod        v1.Pod
 		LocalPort  int
 		PodPort    int
-		Streams    genericclioptions.IOStreams
+		Streams    IOStreams
 		StopCh     <-chan struct{}
 		ReadyCh    chan struct{}
 	}
@@ -55,6 +55,13 @@ type (
 		ReadyChannel chan struct{}
 	}
 )
+
+// IOStreams provides the standard names for IOstreams, which are passed to kubernetes port-forward
+type IOStreams struct {
+	In     io.Reader
+	Out    io.Writer
+	ErrOut io.Writer
+}
 
 // HandlePortForward : Forwards port from remote pod to local
 func HandlePortForward(projectID string, port int) error {
@@ -79,7 +86,7 @@ func HandlePortForward(projectID string, port int) error {
 		ReadyChannel: make(chan struct{}),
 	}
 
-	stream := genericclioptions.IOStreams{
+	stream := IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,

--- a/pkg/remote/portforward.go
+++ b/pkg/remote/portforward.go
@@ -57,14 +57,14 @@ type (
 	}
 )
 
-// IOStreams provides the standard names for IOstreams, which are passed to kubernetes port-forward
+// IOStreams provides the standard names for IOstreams, which are passed to k8s port-forward
 type IOStreams struct {
 	In     io.Reader
 	Out    io.Writer
 	ErrOut io.Writer
 }
 
-// HandlePortForward : Forwards port from remote pod to local
+// HandlePortForward : Forwards port from remote pod to an available local port
 func HandlePortForward(projectID string, port int) *RemInstError {
 	kubeConfig, err := GetKubeConfig()
 	if err != nil {
@@ -111,7 +111,8 @@ func HandlePortForward(projectID string, port int) *RemInstError {
 				Namespace: podInfo.Namespace,
 			},
 		},
-		LocalPort: 9229,
+		// k8s port-forwarder will select an available local port, as local port is set to 0
+		LocalPort: 0,
 		PodPort:   port,
 		Streams:   stream,
 		StopCh:    portForwarder.StopChannel,
@@ -123,11 +124,11 @@ func HandlePortForward(projectID string, port int) *RemInstError {
 	return nil
 }
 
-// PortForwardPod : Requests PortForward from remote pod to local
+// PortForwardPod : Requests PortForward from remote port to local
 func PortForwardPod(req PortForwardPodRequest) error {
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward",
 		req.Pod.Namespace, req.Pod.Name)
-	hostIP := strings.TrimLeft(req.RestConfig.Host, "htps:/")
+	hostIP := strings.TrimLeft(req.RestConfig.Host, "https://")
 
 	transport, upgrader, err := spdy.RoundTripperFor(req.RestConfig)
 	if err != nil {

--- a/pkg/remote/portforward.go
+++ b/pkg/remote/portforward.go
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package remote
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// ProjectPod : Relevant properities of a remote deploted project pod
+type ProjectPod struct {
+	Namespace   string
+	ProjectID   string
+	ProjectName string
+}
+
+// PortForwardPodRequest : The request made to forward the port from a remote pod to local
+type PortForwardPodRequest struct {
+	RestConfig *rest.Config
+	Pod        v1.Pod
+	LocalPort  int
+	PodPort    int
+	Streams    genericclioptions.IOStreams
+	StopCh     <-chan struct{}
+	ReadyCh    chan struct{}
+}
+
+// HandlePortForward : Forwards port from remote pod to local
+func HandlePortForward(projectID string, namespace string) error {
+	// wg will wait for goroutines to finish
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	config, err := GetKubeConfig()
+	if err != nil {
+		return err
+	}
+
+	client := K8sAPI{}
+	client.clientset, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	podInfo, err := client.GetProjectPodFromID(projectID)
+	if err != nil {
+		return err
+	}
+
+	stopCh := make(chan struct{}, 1)
+	readyCh := make(chan struct{})
+
+	// stream controls where portforward sends its output,
+	// and where to expect its input from
+	stream := genericclioptions.IOStreams{
+		In:     os.Stdin,
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigs
+		close(stopCh)
+		fmt.Println(sig)
+		wg.Done()
+	}()
+
+	go func() error {
+		err := PortForwardPod(PortForwardPodRequest{
+			RestConfig: config,
+			Pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podInfo.ProjectName,
+					Namespace: podInfo.Namespace,
+				},
+			},
+			LocalPort: 9229,
+			PodPort:   9229,
+			Streams:   stream,
+			StopCh:    stopCh,
+			ReadyCh:   readyCh,
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	}()
+
+	select {
+	case <-readyCh:
+		break
+	case <-stopCh:
+		println("stopped!")
+		break
+	}
+	wg.Wait()
+	return nil
+}
+
+// PortForwardPod : Requests PortForward from remote pod to local
+func PortForwardPod(req PortForwardPodRequest) error {
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward",
+		req.Pod.Namespace, req.Pod.Name)
+	hostIP := strings.TrimLeft(req.RestConfig.Host, "htps:/")
+
+	transport, upgrader, err := spdy.RoundTripperFor(req.RestConfig)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, &url.URL{Scheme: "https", Path: path, Host: hostIP})
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", req.LocalPort, req.PodPort)}, req.StopCh, req.ReadyCh, req.Streams.Out, req.Streams.ErrOut)
+	if err != nil {
+		return err
+	}
+	return fw.ForwardPorts()
+}
+
+// GetProjectPodFromID : Gets a project pod from its id
+func (client K8sAPI) GetProjectPodFromID(projectID string) (*ProjectPod, error) {
+	// projectIDs are unique, so this should only return one deployment
+	podList, err := client.clientset.CoreV1().Pods("").List(metav1.ListOptions{
+		LabelSelector: "projectID=" + projectID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(podList.Items) == 0 {
+		return nil, err
+	}
+
+	pod := podList.Items[0]
+	return &ProjectPod{
+		ProjectName: pod.GetName(),
+		Namespace:   pod.GetNamespace(),
+		ProjectID:   projectID,
+	}, nil
+}

--- a/pkg/remote/portforward.go
+++ b/pkg/remote/portforward.go
@@ -57,7 +57,7 @@ type (
 )
 
 // HandlePortForward : Forwards port from remote pod to local
-func HandlePortForward(projectID string, namespace string) error {
+func HandlePortForward(projectID string, port int) error {
 	kubeConfig, err := GetKubeConfig()
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func HandlePortForward(projectID string, namespace string) error {
 			},
 		},
 		LocalPort: 9229,
-		PodPort:   9229,
+		PodPort:   port,
 		Streams:   stream,
 		StopCh:    portForwarder.StopChannel,
 		ReadyCh:   portForwarder.ReadyChannel,

--- a/pkg/remote/portforward_test.go
+++ b/pkg/remote/portforward_test.go
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package remote
+
+import (
+	"testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetProjectPodFromID(t *testing.T) {
+	k8s := newTestSimpleK8s()
+	k8s.clientset = fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"projectID": "test",
+			},
+		},
+	})
+	want := &ProjectPod{
+		ProjectName: "test",
+		Namespace: "test-ns",
+		ProjectID: "test",
+
+	}
+	got, err := k8s.GetProjectPodFromID("test")
+	assert.Nil(t, err)
+	assert.Equal(t, want, got)
+}

--- a/pkg/remote/remove.go
+++ b/pkg/remote/remove.go
@@ -85,7 +85,7 @@ type RemovalResult struct {
 // RemoveRemote : Remove remote install from Kube
 func RemoveRemote(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
 	namespace := remoteRemovalOptions.Namespace
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}
@@ -199,7 +199,7 @@ func RemoveRemote(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult
 // RemoveRemoteKeycloak : Remove remote keycloak install from Kube
 func RemoveRemoteKeycloak(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
 	namespace := remoteRemovalOptions.Namespace
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -68,8 +68,8 @@ func GetImages() (string, string, string, string) {
 	return pfeImage + ":" + pfeTag, performanceImage + ":" + performanceTag, keycloakImage + ":" + keycloakTag, gatekeeperImage + ":" + gatekeeperTag
 }
 
-// Get kubeconfig
-func getKubeConfig() (*rest.Config, error) {
+// GetKubeConfig : Gets kube config
+func GetKubeConfig() (*rest.Config, error) {
 	var config *rest.Config
 	var err error
 


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Allows `kubectl portforward` to be invoked by `cwctl` as part of Codewind's remote-debug story. The functionality, and its implementation, is relatively similar to the [kubectl](https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/portforward/portforward.go) and [oc](https://github.com/openshift/oc/blob/master/pkg/cli/admin/inspect/port_forward.go) equivalents (links to the relevant files in those codebases).

If a user runs `cwctl --insecure project port-forward --id <projectID> --port <port-to-forward>` on a remote project, the following output should be seen, and the port (in the this example 922) should be forwarded from the remote pod to localhost for as long as the process runs: 

```shell
Forwarding from 127.0.0.1:9229 -> 9229
Forwarding from [::1]:9229 -> 9229
```
## Testing

- Forwarding ports from Node, Liberty and Spring apps, deployed by Codewind into an Openshift 4 cluster. I can connect the vscode debuggers to these, with a configuration documented in the linked issue.

- Handles when `26299 portforward.go:233] lost connection to pod` error is seen and forwarding drops. This is an example of (https://stackoverflow.com/questions/47484312/kubectl-port-forwarding-timeout-issue) - the line number is from the k8s go-client portforwarder struct we wrap. This will exit the process if it occurs.

- Passing non existent projectID, non-numeric ports, ports without correct permissions returns relevant errors.

> Note: forwarding to a local port that's already in use will return error logs the same as k port-forward, however it won't exit the process. This may be something we want to work further on handling. 

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/1990
 
## Does this PR require a documentation change ?

The epic itself will do, for the overall debugging of remote projects.

