### PR TITLE
Remove installer .zips in favour of just .tar.gz

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,10 +272,6 @@ spec:
 
                     mkdir ${ZIPS_DIR}
                     for f in $(ls ${CWCTL_BASENAME}*); do
-                        export ZIP_NAME="${f}.zip"
-                        zip -r $ZIP_NAME $f
-                        mv $ZIP_NAME ${ZIPS_DIR}
-
                         export TARGZ_NAME="${f}.tar.gz"
                         tar -czvf $TARGZ_NAME $f
                         mv $TARGZ_NAME ${ZIPS_DIR}


### PR DESCRIPTION
Signed-off-by: Tim Etchells <timetchells@ibm.com>

As per https://github.com/eclipse/codewind-installer/pull/411 and https://github.com/eclipse/codewind-vscode/pull/517 the zips are no longer used.

## What type of PR is this ? 

- [ ] Bug fix
- [ ] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
