### PR TITLE
refer to authentication in error message

### DIFF
--- a/pkg/sechttp/httpclient.go
+++ b/pkg/sechttp/httpclient.go
@@ -118,7 +118,7 @@ func DispatchHTTPRequest(httpClient utils.HTTPClient, originalRequest *http.Requ
 
 	// No other methods of authentication left to try, tell the user and give up
 	logr.Tracef("No other methods of authentication left to try, tell the user and give up")
-	failedError := errors.New("No other methods left to try")
+	failedError := errors.New("No other methods of authentication left to try")
 	return nil, &HTTPSecError{errOpFailed, failedError, failedError.Error()}
 }
 


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Adds reference to authentication in the error that's returned when all methods have tried (see https://github.com/eclipse/codewind/issues/2536#issuecomment-603080334).

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2536

## Does this PR require a documentation change ?
 
No