### PR TITLE
[0.11.0] Check if the installer is running in Che before doing docker login.

### DIFF
--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -48,10 +48,13 @@ func AddRegistrySecret(c *cli.Context) {
 	// Log in to local docker to support extensions such as appsody.
 	// Do this first as it will validate the credentials.
 	// Otherwise we have to undo everything else if they are wrong.
-	dockerErr := docker.LoginToRegistry(address, username, password)
-	if dockerErr != nil {
-		HandleDockerError(dockerErr)
-		os.Exit(1)
+	_, foundChe := os.LookupEnv("CHE_API_EXTERNAL")
+	if !foundChe {
+		dockerErr := docker.LoginToRegistry(address, username, password)
+		if dockerErr != nil {
+			HandleDockerError(dockerErr)
+			os.Exit(1)
+		}
 	}
 
 	// If this is a local connection we need to persist the details in the
@@ -60,7 +63,7 @@ func AddRegistrySecret(c *cli.Context) {
 	if conInfo.ID == "local" {
 
 		// Add the credentials to the local keyring.
-		dockerErr = docker.AddDockerCredential(conInfo.ID, address, username, password)
+		dockerErr := docker.AddDockerCredential(conInfo.ID, address, username, password)
 		if dockerErr != nil {
 			HandleDockerError(dockerErr)
 			os.Exit(1)


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Prevents us calling docker login when running in Eclipse Che.
We detect that we are running in the by looking at whether the env var `CHE_API_EXTERNAL` is set, this check is already used elsewhere in the installer.

This backports https://github.com/eclipse/codewind-installer/pull/423 to the 0.11.0 release.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2597

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2597

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
