### PR TITLE
Fix stored docker credentials when docker.io credentials are saved.

### DIFF
--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -62,8 +62,13 @@ func AddRegistrySecret(c *cli.Context) {
 	// (On Kubernetes PFE persists them in a secret inside Kubernetes itself.)
 	if conInfo.ID == "local" {
 
+		localAddress := address
+		if strings.HasPrefix(localAddress, "docker.io") {
+			strings.Replace(localAddress, "docker.io", "https://index.docker.io/v1", 1)
+		}
+
 		// Add the credentials to the local keyring.
-		dockerErr := docker.AddDockerCredential(conInfo.ID, address, username, password)
+		dockerErr := docker.AddDockerCredential(conInfo.ID, localAddress, username, password)
 		if dockerErr != nil {
 			HandleDockerError(dockerErr)
 			os.Exit(1)
@@ -94,10 +99,18 @@ func RemoveRegistrySecret(c *cli.Context) {
 	}
 	// Remove secret from our keychain entry.
 	// (But don't logout of docker locally.)
-	dockerErr := docker.RemoveDockerCredential(conInfo.ID, address)
-	if dockerErr != nil {
-		HandleDockerError(dockerErr)
-		os.Exit(1)
+	if conInfo.ID == "local" {
+
+		localAddress := address
+		if strings.HasPrefix(localAddress, "docker.io") {
+			strings.Replace(localAddress, "docker.io", "https://index.docker.io/v1", 1)
+		}
+
+		dockerErr := docker.RemoveDockerCredential(conInfo.ID, localAddress)
+		if dockerErr != nil {
+			HandleDockerError(dockerErr)
+			os.Exit(1)
+		}
 	}
 	utils.PrettyPrintJSON(registrySecrets)
 }

--- a/pkg/security/keychain_test.go
+++ b/pkg/security/keychain_test.go
@@ -90,7 +90,7 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Secret cannot be retrieved when keychain file does not exist", func(t *testing.T) {
 		retrievedSecret, err := SecKeyGetSecret(testConnection, testUsername)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Desc, "insecureKeychain.json: no such file or directory")
+		assert.Contains(t, err.Desc, "Secret not found in keyring")
 		assert.Equal(t, "", retrievedSecret)
 	})
 
@@ -109,7 +109,7 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Secret cannot be retrieved for an unknown account", func(t *testing.T) {
 		retrievedSecret, err := SecKeyGetSecret(testConnection, "unknownaccount")
 		assert.NotNil(t, err)
-		assert.Equal(t, "secret not found in keyring", err.Desc)
+		assert.Equal(t, "Secret not found in keyring", err.Desc)
 		assert.Equal(t, "", retrievedSecret)
 	})
 
@@ -139,7 +139,7 @@ func Test_Keychain_Insecure(t *testing.T) {
 		// check this secret has been deleted
 		secretFromThisTest, err := GetSecretFromKeyring("mockConnectionID", "mockUsername")
 		assert.Equal(t, "", secretFromThisTest)
-		assert.Equal(t, "secret not found in keyring", err.Desc)
+		assert.Equal(t, "Secret not found in keyring", err.Desc)
 
 		// check the secret created before this test has not been deleted
 		existingSecret, err2 := GetSecretFromKeyring(testConnection, testUsername)
@@ -157,7 +157,7 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Test keyring returns an error when trying to delete from a non-existent keyring", func(t *testing.T) {
 		err := DeleteSecretFromKeyring(testConnection, testUsername)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Desc, "insecureKeychain.json: no such file or directory")
+		assert.Contains(t, err.Desc, "Secret not found in keyring")
 	})
 
 	// remove insecureKeychain.json if it still exists


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adjusts the docker repository url stored when docker.io is passed as a repository to match the way `docker login` stores the url.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2588

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2588

## Does this PR require a documentation change ?
No.

## Any special notes for your reviewer ?
