### PR TITLE
cwctl use identical index.docker.io url to PFE.

### DIFF
--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -64,7 +64,7 @@ func AddRegistrySecret(c *cli.Context) {
 
 		localAddress := address
 		if strings.HasPrefix(localAddress, "docker.io") {
-			strings.Replace(localAddress, "docker.io", "https://index.docker.io/v1", 1)
+			localAddress = "https://index.docker.io/v1/"
 		}
 
 		// Add the credentials to the local keyring.
@@ -103,7 +103,7 @@ func RemoveRegistrySecret(c *cli.Context) {
 
 		localAddress := address
 		if strings.HasPrefix(localAddress, "docker.io") {
-			strings.Replace(localAddress, "docker.io", "https://index.docker.io/v1", 1)
+			localAddress = "https://index.docker.io/v1/"
 		}
 
 		dockerErr := docker.RemoveDockerCredential(conInfo.ID, localAddress)


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This is one half of ensuring that cwctl and PFE convert "docker.io" and "docker.io/" to exactly the same URL, "https://index.docker.io/v1/" (including trailing '/')/

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2588

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
This will not work without the matching PR: https://github.com/eclipse/codewind/pull/2618