### PR TITLE
Add checks to all uses of json.Unmarshal()

### DIFF
--- a/pkg/apiroutes/extensions.go
+++ b/pkg/apiroutes/extensions.go
@@ -51,7 +51,10 @@ func GetExtensions(conID string) ([]utils.Extension, error) {
 	}
 
 	var extensions []utils.Extension
-	json.Unmarshal(byteArray, &extensions)
+	err = json.Unmarshal(byteArray, &extensions)
+	if err != nil {
+		return nil, err
+	}
 
 	return extensions, nil
 }

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -93,7 +93,11 @@ func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template,
 	}
 
 	var templates []Template
-	json.Unmarshal(byteArray, &templates)
+	err = json.Unmarshal(byteArray, &templates)
+	if err != nil {
+		return nil, err
+	}
+
 	return templates, nil
 }
 
@@ -124,7 +128,10 @@ func GetTemplateStyles(conID string) ([]string, error) {
 	}
 
 	var styles []string
-	json.Unmarshal(byteArray, &styles)
+	err = json.Unmarshal(byteArray, &styles)
+	if err != nil {
+		return nil, err
+	}
 
 	return styles, nil
 }
@@ -157,7 +164,10 @@ func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
 	}
 
 	var repos []utils.TemplateRepo
-	json.Unmarshal(byteArray, &repos)
+	err = json.Unmarshal(byteArray, &repos)
+	if err != nil {
+		return nil, err
+	}
 
 	return repos, nil
 }
@@ -207,7 +217,10 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 	}
 
 	var repos []utils.TemplateRepo
-	json.Unmarshal(byteArray, &repos)
+	err = json.Unmarshal(byteArray, &repos)
+	if err != nil {
+		return nil, err
+	}
 
 	return repos, nil
 }
@@ -250,7 +263,10 @@ func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
 	}
 
 	var repos []utils.TemplateRepo
-	json.Unmarshal(byteArray, &repos)
+	err = json.Unmarshal(byteArray, &repos)
+	if err != nil {
+		return nil, err
+	}
 
 	return repos, nil
 }
@@ -353,7 +369,10 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 	}
 
 	var subResponsesFromBatchOperation []SubResponseFromBatchOperation
-	json.Unmarshal(byteArray, &subResponsesFromBatchOperation)
+	err = json.Unmarshal(byteArray, &subResponsesFromBatchOperation)
+	if err != nil {
+		return nil, err
+	}
 
 	return subResponsesFromBatchOperation, nil
 }

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -87,6 +87,11 @@ func GetTemplates(conID, projectStyle string, showEnabledOnly bool) ([]Template,
 
 	defer resp.Body.Close()
 
+	// May return 204, no content, which means no resp.Body to parse.
+	if resp.StatusCode == 204 {
+		return []Template{}, nil
+	}
+
 	byteArray, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -372,11 +372,13 @@ func applySchemaUpdates() *ConError {
 				originalConnection := originalConnectionsV0[i]
 				connectionJSON, _ := json.Marshal(originalConnection)
 				var upgradedConnection ConnectionV1
-				_ = json.Unmarshal(connectionJSON, &upgradedConnection)
+				err = json.Unmarshal(connectionJSON, &upgradedConnection)
 
-				// rename 'name' field to 'id'
-				upgradedConnection.ID = originalConnection.Name
-				newConnectionConfig.Connections = append(newConnectionConfig.Connections, upgradedConnection)
+				if err == nil {
+					// rename 'name' field to 'id'
+					upgradedConnection.ID = originalConnection.Name
+					newConnectionConfig.Connections = append(newConnectionConfig.Connections, upgradedConnection)
+				}
 			}
 
 			// schema has been updated

--- a/pkg/connections/connection.go
+++ b/pkg/connections/connection.go
@@ -372,7 +372,7 @@ func applySchemaUpdates() *ConError {
 				originalConnection := originalConnectionsV0[i]
 				connectionJSON, _ := json.Marshal(originalConnection)
 				var upgradedConnection ConnectionV1
-				json.Unmarshal(connectionJSON, &upgradedConnection)
+				_ = json.Unmarshal(connectionJSON, &upgradedConnection)
 
 				// rename 'name' field to 'id'
 				upgradedConnection.ID = originalConnection.Name

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -334,9 +334,10 @@ func retrieveIgnoredPathsList(projectPath string) []string {
 	if _, err := os.Stat(cwSettingsPath); !os.IsNotExist(err) {
 		plan, _ := ioutil.ReadFile(cwSettingsPath)
 		var cwSettingsJSON CWSettings
-		// Don't need to handle an invalid JSON file as we should just return []
-		json.Unmarshal(plan, &cwSettingsJSON)
-		cwSettingsIgnoredPathsList = cwSettingsJSON.IgnoredPaths
+		err = json.Unmarshal(plan, &cwSettingsJSON)
+		if err == nil {
+			cwSettingsIgnoredPathsList = cwSettingsJSON.IgnoredPaths
+		}
 	}
 	return cwSettingsIgnoredPathsList
 }
@@ -348,9 +349,10 @@ func retrieveRefPathsList(projectPath string) []refPath {
 	if _, err := os.Stat(cwRefPathsPath); !os.IsNotExist(err) {
 		plan, _ := ioutil.ReadFile(cwRefPathsPath)
 		var cwRefPathsJSON refPaths
-		// Don't need to handle an invalid JSON file as we should just return []
-		json.Unmarshal(plan, &cwRefPathsJSON)
-		cwRefPathsList = cwRefPathsJSON.RefPaths
+		err = json.Unmarshal(plan, &cwRefPathsJSON)
+		if err == nil {
+			cwRefPathsList = cwRefPathsJSON.RefPaths
+		}
 	}
 	return cwRefPathsList
 }

--- a/pkg/project/upgrade.go
+++ b/pkg/project/upgrade.go
@@ -56,7 +56,10 @@ func UpgradeProjects(oldDir string) (*map[string]interface{}, *ProjectError) {
 			}
 
 			var result map[string]string
-			json.Unmarshal([]byte(file), &result)
+			err = json.Unmarshal([]byte(file), &result)
+			if err != nil {
+				return nil
+			}
 
 			language := result["language"]
 			projectType := result["projectType"]

--- a/pkg/security/security_utils.go
+++ b/pkg/security/security_utils.go
@@ -89,7 +89,10 @@ type Result struct {
 func parseKeycloakError(body string, httpCode int) *KeycloakAPIError {
 	keycloakAPIError := KeycloakAPIError{}
 	keycloakAPIError.HTTPStatus = httpCode
-	json.Unmarshal([]byte(body), &keycloakAPIError)
+	err := json.Unmarshal([]byte(body), &keycloakAPIError)
+	if err != nil {
+		keycloakAPIError.ErrorDescription = "Bad JSON in error response from keycloak"
+	}
 	// copy message into description if one is not set
 	if keycloakAPIError.ErrorMessage != "" && keycloakAPIError.ErrorDescription == "" {
 		keycloakAPIError.ErrorDescription = keycloakAPIError.ErrorMessage


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Makes sure we check whether an error is returned from json.Unmarshal. We were missing these checks in a lot of cases, notably this caused https://github.com/eclipse/codewind/issues/2319
We fixed that specific issue but didn't fix all cases in the codewind-install code.

This also fixes an error where we didn't check for a possible status code from api/v1/templates, 204, which indicates no body and no JSON to parse in that case.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2364
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2364

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No