### PR TITLE
Move calls to req.Header.Set after error check.

### DIFF
--- a/pkg/apiroutes/logging.go
+++ b/pkg/apiroutes/logging.go
@@ -74,10 +74,10 @@ func SetLogLevel(conInfo *connections.Connection, conURL string, httpClient util
 	logLevel := &LogParameter{Level: newLogLevel}
 	jsonPayload, _ := json.Marshal(logLevel)
 	req, err := http.NewRequest("PUT", conURL+"/api/v1/logging", bytes.NewBuffer(jsonPayload))
-	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, httpSecError := sechttp.DispatchHTTPRequest(httpClient, req, conInfo)
 	if httpSecError != nil {

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -186,10 +186,10 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 	}
 
 	req, err := http.NewRequest("POST", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
-	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
@@ -231,8 +231,12 @@ func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
 		return nil, conErr.Err
 	}
 
-	req, _ := http.NewRequest("DELETE", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
+	req, err := http.NewRequest("DELETE", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("Content-Type", "application/json")
+
 	client := &http.Client{}
 	resp, httpSecError := HTTPRequestWithRetryOnLock(client, req, conInfo)
 	if httpSecError != nil {
@@ -333,7 +337,10 @@ func BatchPatchTemplateRepos(conID string, operations []RepoOperation) ([]SubRes
 		return nil, conErr.Err
 	}
 
-	req, _ := http.NewRequest("PATCH", conURL+"/api/v1/batch/templates/repositories", bytes.NewBuffer(jsonValue))
+	req, err := http.NewRequest("PATCH", conURL+"/api/v1/batch/templates/repositories", bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}

--- a/pkg/project/restartproject.go
+++ b/pkg/project/restartproject.go
@@ -38,10 +38,10 @@ func RestartProject(httpClient utils.HTTPClient, conInfo *connections.Connection
 	}
 	jsonPayload, _ := json.Marshal(parameters)
 	req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(jsonPayload))
-	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Content-Type", "application/json")
 	return handleRestartResponse(req, conInfo, httpClient, http.StatusAccepted)
 }
 


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Moves calls to `req.Header.Set()` *after* we check the error code for creating req via `req, err := http.NewRequest`.
It isn't safe to access `req` until we've checked the error. Although this has been fixed in some places it hasn't been fixed everywhere.  When writing new function the bad pattern keeps getting copied. This PR makes sure there are no bad examples left.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No