### PR TITLE
2277 return better err when adding template sources

### DIFF
--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -195,15 +195,15 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 	if httpSecError != nil {
 		return nil, httpSecError
 	}
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
-	}
-
 	defer resp.Body.Close()
 
 	byteArray, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Error: %s - %s", http.StatusText(resp.StatusCode), string(byteArray))
 	}
 
 	var repos []utils.TemplateRepo

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -34,7 +34,7 @@ var numTemplatesEnabled = numCodewindTemplates + numAppsodyTemplatesEnabled
 
 var numTemplates = numTemplatesEnabled + numAppsodyTemplatesDisabled
 
-var URLOfExistingRepo = "https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json"
+var URLOfExistingRepo = "https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json"
 var URLOfNewRepo = "https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json"
 var URLOfUnknownRepo = "https://raw.githubusercontent.com/UNKNOWN"
 var URLOfUnknownRepo2 = "https://raw.githubusercontent.com/UNKNOWN_2"

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -162,7 +162,7 @@ func TestFailuresAddTemplateRepo(t *testing.T) {
 			inURL:         URLOfExistingRepo,
 			inDescription: "example repository containing links to templates",
 			wantedType:    nil,
-			wantedErr:     errors.New("Error: PFE responded with status code 400"),
+			wantedErr:     errors.New("Error: Bad Request - " + URLOfExistingRepo + " is already a template repository"),
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
improves the error message users see when adding invalid template sources/repositories:

before:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/30476587/74878608-a1bb4c00-5335-11ea-9403-f7acd4340933.png">


after:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/18170169/79331521-2c25c380-7f13-11ea-9f9c-93f5ae0d70fc.png">


## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2277

## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
