### PR TITLE
2278 - handle local dir deletion

### DIFF
--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -119,8 +119,8 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 		return nil, &ProjectError{errOpConNotFound, conURLErr.Err, conURLErr.Desc}
 	}
 
-	// if local path doesn't exist but is equal to the locationOnDisk, the directory has likely been deleted
-	// emit this message to the UI socket by calling the PFE /localDirDeleted API
+	// if local path doesn't exist but is equal to the locOnDisk, the directory has likely been deleted
+	// emit this message to the UI socket by calling the PFE /missingLocalDir API
 	pathExists := utils.PathExists(projectPath)
 
 	if !pathExists {
@@ -134,7 +134,7 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 			return nil, &ProjectError{errBadPath, newErr, newErr.Error()}
 		}
 
-		err = handleLocalDirDeleted(&http.Client{}, conInfo, conURL, projectID)
+		err = handleMissingProjectDir(&http.Client{}, conInfo, conURL, projectID)
 		if err != nil {
 			return nil, &ProjectError{errBadPath, err, err.Error()}
 		}
@@ -442,9 +442,9 @@ func ignoreFileOrDirectory(name string, isDir bool, cwSettingsIgnoredPathsList [
 	return isFileInIgnoredList
 }
 
-// handleLocalDirDeleted : Respond to a local project dir not existing
-func handleLocalDirDeleted(httpClient utils.HTTPClient, connection *connections.Connection, url, projectID string) *ProjectError {
-	req, requestErr := http.NewRequest("POST", url+"/api/v1/projects/"+projectID+"/localDirDeleted", nil)
+// handleMissingProjectDir : Respond to a local project dir not existing
+func handleMissingProjectDir(httpClient utils.HTTPClient, connection *connections.Connection, url, projectID string) *ProjectError {
+	req, requestErr := http.NewRequest("POST", url+"/api/v1/projects/"+projectID+"/missingLocalDir", nil)
 	if requestErr != nil {
 		return &ProjectError{errOpRequest, requestErr, requestErr.Error()}
 	}

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -134,7 +134,6 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 			return nil, &ProjectError{errBadPath, newErr, newErr.Error()}
 		}
 
-
 		err = handleLocalDirDeleted(&http.Client{}, conInfo, conURL, projectID)
 		if err != nil {
 			return nil, &ProjectError{errBadPath, err, err.Error()}
@@ -457,8 +456,8 @@ func handleLocalDirDeleted(httpClient utils.HTTPClient, connection *connections.
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respErr := errors.New(errOpResponse)
-		return &ProjectError{errOpNotFound, respErr, textAPINotFound}
+		respErr := fmt.Errorf("Error: PFE responded with status code %d", resp.StatusCode)
+		return &ProjectError{errOpNotFound, respErr, respErr.Error()}
 	}
 
 	return nil

--- a/pkg/project/sync_test.go
+++ b/pkg/project/sync_test.go
@@ -322,18 +322,18 @@ func TestRetrieveIgnoredPathsList(t *testing.T) {
 	cleanupTestFolder(t, testFolder)
 }
 
-func TestHandleLocalDirDeleted(t *testing.T) {
+func TestHandleMissingProjectDir(t *testing.T) {
 	body := ioutil.NopCloser(bytes.NewReader([]byte{}))
 	mockConnection := connections.Connection{ID: "local"}
 	t.Run("success case: 200 response from PFE", func(t *testing.T) {
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
-		err := handleLocalDirDeleted(mockClient, &mockConnection, "mockURL", "mockID")
+		err := handleMissingProjectDir(mockClient, &mockConnection, "mockURL", "mockID")
 		assert.Nil(t, err)
 	})
 
 	t.Run("error case: non 200 response from PFE", func(t *testing.T) {
 		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: body}
-		err := handleLocalDirDeleted(mockClient, &mockConnection, "mockURL", "mockID")
+		err := handleMissingProjectDir(mockClient, &mockConnection, "mockURL", "mockID")
 		assert.NotNil(t, err)
 	})
 }

--- a/pkg/project/sync_test.go
+++ b/pkg/project/sync_test.go
@@ -322,6 +322,22 @@ func TestRetrieveIgnoredPathsList(t *testing.T) {
 	cleanupTestFolder(t, testFolder)
 }
 
+func TestHandleLocalDirDeleted(t *testing.T) {
+	body := ioutil.NopCloser(bytes.NewReader([]byte{}))
+	mockConnection := connections.Connection{ID: "local"}
+	t.Run("success case: 200 response from PFE", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: body}
+		err := handleLocalDirDeleted(mockClient, &mockConnection, "mockURL", "mockID")
+		assert.Nil(t, err)
+	})
+
+	t.Run("error case: non 200 response from PFE", func(t *testing.T) {
+		mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusNotFound, Body: body}
+		err := handleLocalDirDeleted(mockClient, &mockConnection, "mockURL", "mockID")
+		assert.NotNil(t, err)
+	})
+}
+
 func setupIgnoredPathsTests(t *testing.T, testFolder string, createPaths testDirPaths) {
 	t.Helper()
 	os.Mkdir(testFolder, 0777)


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

If a local path is given to `cwctl project sync` which doesn't exist but matches the `locOnDisk` of the project, call the PFE added by https://github.com/eclipse/codewind/pull/2673 to output a message to the UI socket. 

## Testing

- Create a project with local path `<path>`. Delete project route dir (i.e. `rm -rf <path>`. 

- Attempt to the sync the project: `cwctl project sync -i <project-id> -p <path> -t 0`. A `missingLocalDir` socket message should be emitted to the UI socket (through the PFE API added by the associated PR), with the project's ID in the body. 

Associated PFE change: https://github.com/eclipse/codewind/pull/2673

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2278