### PR TITLE
2619 - add custom error message for invalid credentials

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	goErr "errors"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -357,7 +357,7 @@ func ValidateImageDigest(dockerClient DockerClient, image string) (string, *Dock
 					logr.Tracef("Validation for image digest ..%v succeeded\n", last10)
 				} else {
 					logr.Traceln("Local image digest did not match queried image digest from dockerhub - This could be a result of a bad download")
-					valError := goErr.New(textBadDigest)
+					valError := errors.New(textBadDigest)
 					return image.ID, &DockerError{errOpValidate, valError, valError.Error()}
 				}
 			}
@@ -623,7 +623,7 @@ func LoginToRegistry(address string, username string, password string) *DockerEr
 		return &DockerError{errDockerCredential, err, "Error executing 'docker login'"}
 	}
 
-	// Write to stdin using an asyncrhonous go routine.
+	// Write to stdin using an asynchronous go routine.
 	go func() {
 		defer stdin.Close()
 		io.WriteString(stdin, password)
@@ -631,7 +631,9 @@ func LoginToRegistry(address string, username string, password string) *DockerEr
 
 	_, err = cmd.CombinedOutput()
 	if err != nil {
-		return &DockerError{errDockerCredential, err, "Error executing 'docker login'"}
+		textDockerLoginFailed := fmt.Sprintf("Docker login to %s as %s failed. Address, username or password is incorrect", address, username)
+		loginErr := errors.New(textDockerLoginFailed)
+		return &DockerError{errDockerCredential, loginErr, textDockerLoginFailed}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Adds a custom error for if the docker login fails. Examples of this:

with `--json`:
```
cwctl --json --insecure registrysecrets add --conid local --address fakedomain0553.io --username fake-user --password *********
{"error":"DOCKER_CREDENTIAL_ERROR","error_description":"Docker login to fakedomain0553.io as fake-user failed. Address, username or password is incorrect"}
exit status 1
```

without: 
```
cwctl --insecure registrysecrets add --conid local --address fakedomain0553.io --username fake-user --password *********
ERRO[0000] Docker login to fakedomain0553.io as fake-user failed. Address, username or password is incorrect
exit status 1
```

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/2619