### PR TITLE
2647.1 download template from secure repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Subcommands:</br>
 > --url,-u value URL of project to download
 > --path,-p value Path at which to create the new project
 > --conid value Connection ID of PFE that will be used to validate the project (optional)
+> --username value Username for GitHub account authorized to download the provided GitHub repo
+> --password value Password for GitHub account authorized to download the provided GitHub repo
 
 `validate` - Returns the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist
 

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,7 +43,7 @@ func TestCwctl(t *testing.T) {
 func testBasicUsage(t *testing.T) {
 	t.Run("cwctl", func(t *testing.T) {
 		out, err := exec.Command(cwctl).Output()
-		require.Nil(t, err)
+		assert.Nil(t, err)
 		require.NotNil(t, out)
 	})
 }
@@ -57,20 +58,20 @@ func testUseInsecureKeyring(t *testing.T) {
 			"--password=seCretphrase",
 		)
 		out, err := cmd.Output()
-		require.Nil(t, err)
+		assert.Nil(t, err)
 		require.Equal(t, "{\"status\":\"OK\"}\n", string(out))
 
 		file, readErr := ioutil.ReadFile(security.GetPathToInsecureKeyring())
-		require.Nil(t, readErr)
+		assert.Nil(t, readErr)
 		require.NotNil(t, file)
 
 		secrets := []security.KeyringSecret{}
 		unmarshalErr := json.Unmarshal([]byte(file), &secrets)
-		require.Nil(t, unmarshalErr)
+		assert.Nil(t, unmarshalErr)
 		require.Len(t, secrets, 1)
 
 		secret := secrets[0]
-		require.Equal(t, "testuser", string(secret.Username))
+		assert.Equal(t, "testuser", string(secret.Username))
 		require.Equal(t, "seCretphrase", string(secret.Password))
 
 		os.Remove(security.GetPathToInsecureKeyring())
@@ -86,20 +87,20 @@ func testUseInsecureKeyring(t *testing.T) {
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "INSECURE_KEYRING=true")
 		out, err := cmd.Output()
-		require.Nil(t, err)
+		assert.Nil(t, err)
 		require.Equal(t, "{\"status\":\"OK\"}\n", string(out))
 
 		file, readErr := ioutil.ReadFile(security.GetPathToInsecureKeyring())
-		require.Nil(t, readErr)
+		assert.Nil(t, readErr)
 		require.NotNil(t, file)
 
 		secrets := []security.KeyringSecret{}
 		unmarshalErr := json.Unmarshal([]byte(file), &secrets)
-		require.Nil(t, unmarshalErr)
+		assert.Nil(t, unmarshalErr)
 		require.Len(t, secrets, 1)
 
 		secret := secrets[0]
-		require.Equal(t, "testuser", string(secret.Username))
+		assert.Equal(t, "testuser", string(secret.Username))
 		require.Equal(t, "seCretphrase", string(secret.Password))
 
 		os.Remove(security.GetPathToInsecureKeyring())

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -75,6 +75,8 @@ func Commands() {
 						cli.StringFlag{Name: "url, u", Usage: "URL of project to download", Required: true},
 						cli.StringFlag{Name: "path, p", Usage: "The path at which to create the new project", Required: true},
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id of PFE which will be used to validate the project", Required: false},
+						cli.StringFlag{Name: "username", Usage: "Username for GitHub account authorized to download the provided GitHub repo", Required: false},
+						cli.StringFlag{Name: "password", Usage: "Password for GitHub account authorized to download the provided GitHub repo", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						ProjectCreate(c)

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -43,7 +43,15 @@ func ProjectValidate(c *cli.Context) {
 func ProjectCreate(c *cli.Context) {
 	destination := c.String("path")
 	url := c.String("url")
-	result, err := project.DownloadTemplate(destination, url)
+	username := c.String("username")
+	password := c.String("password")
+	var gitCredentials utils.GitCredentials
+	if username != "" && password != "" {
+		gitCredentials.Username = username
+		gitCredentials.Password = password
+	}
+
+	result, err := project.DownloadTemplate(destination, url, gitCredentials)
 	if err != nil {
 		HandleProjectError(err)
 		os.Exit(1)

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -54,8 +54,7 @@ type (
 )
 
 // DownloadTemplate using the url/link provided
-func DownloadTemplate(destination string, url string) (*Result, *ProjectError) {
-
+func DownloadTemplate(destination, url string, gitCredentials utils.GitCredentials) (*Result, *ProjectError) {
 	projErr := checkProjectDirIsEmpty(destination)
 	if projErr != nil {
 		return nil, projErr
@@ -71,7 +70,7 @@ func DownloadTemplate(destination string, url string) (*Result, *ProjectError) {
 		projectName = "PROJ_NAME_PLACEHOLDER"
 	}
 
-	err := utils.DownloadFromURLThenExtract(url, destination)
+	err := utils.DownloadFromURLThenExtract(url, destination, gitCredentials)
 	if err != nil {
 		return nil, &ProjectError{errOpCreateProject, err, err.Error()}
 	}

--- a/pkg/test/globals.go
+++ b/pkg/test/globals.go
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package test
+
+// PublicGHRepoURL is a URL to a GitHub repo not requiring auth to access
+const PublicGHRepoURL = "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
+
+// GHERepoURL is a URL to a GitHub Enterprise repo (requiring auth to access)
+const GHERepoURL = "https://github.ibm.com/DevCamp2018/git-basics"
+
+// GHEUsername is a username that passes the auth required to access a GHERepoURL
+const GHEUsername = "INSERT YOUR OWN: e.g. foo.bar@foobar.com"
+
+// GHEPassword is a password that passes the auth required to access a GHERepoURL
+const GHEPassword = "INSERT YOUR OWN: e.g. 1234kljfdsjfaleru29348spodkfj445"
+
+// UsingOwnGHECredentials should be set to true if you want to run tests using the credentials above
+const UsingOwnGHECredentials = false

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -12,34 +12,60 @@
 package utils
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/google/go-github/github"
+)
+
+type (
+	// GitCredentials : credentials to access GitHub or GitHubEnterprise
+	GitCredentials struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
 )
 
 // DownloadFromURLThenExtract downloads files from a URL
 // to a destination, extracting them if necessary
-func DownloadFromURLThenExtract(URL string, destination string) error {
-	if _, err := url.ParseRequestURI(URL); err != nil {
+func DownloadFromURLThenExtract(URL, destination string, gitCredentials GitCredentials) error {
+	_url, err := url.ParseRequestURI(URL)
+	if err != nil {
 		return err
+	}
+	if !_url.IsAbs() {
+		return fmt.Errorf("URL must be absolute, but received relative URL %s", _url)
 	}
 
 	if IsTarGzURL(URL) {
-		return DownloadFromTarGzURL(URL, destination)
+		return DownloadFromTarGzURL(URL, destination, gitCredentials)
 	}
-	return DownloadFromRepoURL(URL, destination)
+	return DownloadFromRepoURL(URL, destination, gitCredentials)
 }
 
 // DownloadFromTarGzURL downloads a tar.gz file from a URL
 // and extracts it to a destination
-func DownloadFromTarGzURL(URL string, destination string) error {
+func DownloadFromTarGzURL(URL, destination string, gitCredentials GitCredentials) error {
 	time := time.Now().Format(time.RFC3339)
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
 	pathToTempFile := path.Join(os.TempDir(), "_"+time+"temp.tar.gz")
 
-	err := DownloadFile(URL, pathToTempFile)
+	if gitCredentials != (GitCredentials{}) {
+		downloadURL, err := getURLToDownloadReleaseAsset(URL, gitCredentials)
+		if err != nil {
+			return err
+		}
+		URL = downloadURL
+	}
+
+	err := DownloadFile(URL, pathToTempFile, gitCredentials)
 	if err != nil {
 		return err
 	}
@@ -48,23 +74,109 @@ func DownloadFromTarGzURL(URL string, destination string) error {
 	return err
 }
 
-// DownloadFromRepoURL downloads a repo from a URL to a destination
-func DownloadFromRepoURL(repoURL string, destination string) error {
-	// expecting string in format 'https://github.com/<owner>/<repo>'
-	if strings.HasPrefix(repoURL, "https://") {
-		repoURL = strings.TrimPrefix(repoURL, "https://")
-	}
-	repoArray := strings.Split(repoURL, "/")
-	owner := repoArray[1]
-	repo := repoArray[2]
-	branch := "master"
+func getURLToDownloadReleaseAsset(URL string, gitCredentials GitCredentials) (string, error) {
+	URLSlice := strings.Split(URL, "/")
 
-	zipURL, err := GetZipURL(owner, repo, branch)
+	domain := URLSlice[2]
+	client, err := getGitHubClient(domain, gitCredentials)
+	if err != nil {
+		return "", err
+	}
+
+	ctx := context.Background()
+
+	owner := URLSlice[3]
+	repo := URLSlice[4]
+	releases, gitHubResponse, err := client.Repositories.ListReleases(
+		ctx,
+		owner,
+		repo,
+		nil,
+	)
+	resp := gitHubResponse.Response
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("[client.Repositories.ListReleases] GitHub responded with status code %d", resp.StatusCode)
+	}
+
+	release := URLSlice[7]
+	assetID, err := findAssetID(releases, release, URL)
+	if err != nil {
+		return "", err
+	}
+
+	_, redirectURL, err := client.Repositories.DownloadReleaseAsset(
+		ctx,
+		owner,
+		repo,
+		assetID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)
+	}
+	return redirectURL, nil
+}
+
+func findAssetID(releases []*github.RepositoryRelease, releaseName, URL string) (int64, error) {
+	for _, v := range releases {
+		if *v.TagName == releaseName {
+			for _, val := range v.Assets {
+				if *val.BrowserDownloadURL == URL {
+					return *val.ID, nil
+				}
+			}
+			return 0, fmt.Errorf("Cannot find matching assets for release %s", releaseName)
+		}
+	}
+	return 0, fmt.Errorf("Cannot find release %s", releaseName)
+}
+
+// DownloadFromRepoURL downloads a repo from a URL to a destination
+func DownloadFromRepoURL(repoURL, destination string, gitCredentials GitCredentials) error {
+	// expecting string in format 'https://<github.com>/<owner>/<repo>'
+	URLSlice := strings.Split(repoURL, "/")
+
+	domain := URLSlice[2]
+	client, err := getGitHubClient(domain, gitCredentials)
+	if err != nil {
+		return err
+	}
+
+	owner := URLSlice[3]
+	repo := URLSlice[4]
+	zipURL, err := GetZipURL(owner, repo, "master", client)
 	if err != nil {
 		return err
 	}
 
 	return DownloadAndExtractZip(zipURL, destination)
+}
+
+func getGitHubClient(domain string, gitCredentials GitCredentials) (*github.Client, error) {
+	if gitCredentials == (GitCredentials{}) {
+		return github.NewClient(nil), nil
+	}
+
+	tp := github.BasicAuthTransport{
+		Username: gitCredentials.Username,
+		Password: gitCredentials.Password,
+	}
+	if domain == "github.com" {
+		return github.NewClient(tp.Client()), nil
+	}
+	baseURL := "https://" + domain
+	return github.NewEnterpriseClient(baseURL, baseURL, tp.Client())
+}
+
+// GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
+func GetZipURL(owner, repo, branch string, client *github.Client) (string, error) {
+	ctx := context.Background()
+	opt := &github.RepositoryContentGetOptions{Ref: branch}
+	URL, _, err := client.Repositories.GetArchiveLink(ctx, owner, repo, "zipball", opt, true)
+	if err != nil {
+		return "", err
+	}
+	url := URL.String()
+	return url, nil
 }
 
 // DownloadAndExtractZip downloads a zip file from a URL
@@ -74,7 +186,7 @@ func DownloadAndExtractZip(zipURL string, destination string) error {
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
 	pathToTempZipFile := path.Join(os.TempDir(), "_"+time+".zip")
 
-	err := DownloadFile(zipURL, pathToTempZipFile)
+	err := DownloadFile(zipURL, pathToTempZipFile, GitCredentials{})
 	if err != nil {
 		return err
 	}
@@ -86,6 +198,29 @@ func DownloadAndExtractZip(zipURL string, destination string) error {
 
 	os.Remove(pathToTempZipFile)
 	return nil
+}
+
+// DownloadFile from URL to file destination
+func DownloadFile(URL, destination string, gitCredentials GitCredentials) error {
+	resp, err := http.Get(URL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("File download failed for %s, status code %d", URL, resp.StatusCode)
+	}
+
+	// Create the file
+	file, err := os.Create(destination)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Write body to file
+	_, err = io.Copy(file, resp.Body)
+	return err
 }
 
 // IsTarGzURL returns whether the provided URL is a tar.gz file

--- a/pkg/utils/download_test.go
+++ b/pkg/utils/download_test.go
@@ -20,64 +20,156 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/eclipse/codewind-installer/pkg/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-var exampleGitURL = "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
-var exampleZipURL = "https://codeload.github.com/microclimate-dev2ops/nodeExpressTemplate/legacy.zip/master"
-var exampleTarGzURL = "https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz"
-var testDir = "./testDir"
+const testDir = "./testDir"
+const publicGHZipURL = "https://codeload.github.com/microclimate-dev2ops/nodeExpressTemplate/legacy.zip/master"
+const publicGHTarGzURL = "https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz"
+
+const privateGHRepoURL = "https://github.com/rwalle61/samplePrivateRepo"
+const privateGHTarGzURL = "https://github.com/rwalle61/samplePrivateRepo/releases/download/v0.1.0/incubator.java-spring-boot2.v0.3.29.templates.default.tar.gz"
+const privateGHUsername = "INSERT YOUR OWN: e.g. foo.bar@foobar.com"
+const privateGHPassword = "INSERT YOUR OWN: e.g. 1234kljfdsjfaleru29348spodkfj445"
+const usingOwnPrivateGHCredentials = false
+
+const GHETarGzURL = "https://github.ibm.com/Richard-Waller/sampleGHERepo/releases/download/v0.1.0/incubator.nodejs.templates.simple.tar.gz"
+const GHETarGzURLToNonExistentRepo = "https://github.ibm.com/Richard-Waller/nonExistentRepo/releases/download/v0.1.0/incubator.nodejs.templates.simple.tar.gz"
+const GHETarGzURLToNonExistentRelease = "https://github.ibm.com/Richard-Waller/sampleGHERepo/releases/download/v0.nonExistentRelease.0/incubator.nodejs.templates.simple.tar.gz"
+const GHETarGzURLToNonExistentReleaseAsset = "https://github.ibm.com/Richard-Waller/sampleGHERepo/releases/download/v0.1.0/nonExistentReleaseAsset.tar.gz"
 
 func TestDownloadFromURLThenExtract(t *testing.T) {
 	tests := map[string]struct {
-		inURL          string
-		inDestination  string
-		wantedType     error
-		wantedNumFiles int
+		skip             bool
+		inURL            string
+		inDestination    string
+		inGitCredentials GitCredentials
+		wantedType       error
+		wantedErrMsg     string
+		wantedNumFiles   int
 	}{
-		"success case: input good Git URL": {
-			inURL:          exampleGitURL,
+		"success case: input good insecure Git URL": {
+			inURL:          test.PublicGHRepoURL,
 			inDestination:  filepath.Join(testDir, "git"),
 			wantedType:     nil,
 			wantedNumFiles: 17,
 		},
+		"success case: input good secure Git URL and credentials": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            test.GHERepoURL,
+			inDestination:    filepath.Join(testDir, "git"),
+			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			wantedType:       nil,
+			wantedNumFiles:   7,
+		},
+		"success case: input good private Git URL and credentials": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            privateGHRepoURL,
+			inDestination:    filepath.Join(testDir, "git"),
+			inGitCredentials: GitCredentials{Username: privateGHUsername, Password: privateGHPassword},
+			wantedType:       nil,
+			wantedNumFiles:   15,
+		},
 		"success case: input good zip URL": {
-			inURL:          exampleZipURL,
+			inURL:          publicGHZipURL,
 			inDestination:  filepath.Join(testDir, "zip"),
 			wantedType:     nil,
 			wantedNumFiles: 17,
 		},
 		"success case: input good tar.gz URL": {
-			inURL:          exampleTarGzURL,
+			inURL:          publicGHTarGzURL,
 			inDestination:  filepath.Join(testDir, "targz"),
 			wantedType:     nil,
 			wantedNumFiles: 6,
+		},
+		"success case: input good private tar.gz URL and credentials": {
+			skip:             !usingOwnPrivateGHCredentials,
+			inURL:            privateGHTarGzURL,
+			inDestination:    filepath.Join(testDir, "privateTarGz"),
+			inGitCredentials: GitCredentials{Username: privateGHUsername, Password: privateGHPassword},
+			wantedType:       nil,
+			wantedNumFiles:   5,
+		},
+		"success case: input good GHE tar.gz URL and credentials": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            GHETarGzURL,
+			inDestination:    filepath.Join(testDir, "privateTarGz"),
+			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			wantedType:       nil,
+			wantedNumFiles:   6,
 		},
 		"fail case: input bad URL": {
 			inURL:          "bad URL",
 			inDestination:  filepath.Join(testDir, "badURL"),
 			wantedType:     new(url.Error),
+			wantedErrMsg:   "invalid URI",
 			wantedNumFiles: 0,
 		},
-		"fail case: input URL that doesn't return 200": {
-			inURL:          "/bad/URL",
-			inDestination:  filepath.Join(testDir, "badURL"),
+		"fail case: input relative URL": {
+			inURL:          "/relative/URL",
+			inDestination:  filepath.Join(testDir, "relativeURL"),
 			wantedType:     errors.New(""),
+			wantedErrMsg:   "URL must be absolute, but received relative URL /relative/URL",
 			wantedNumFiles: 0,
+		},
+		"fail case: input good GHE repo URL but bad password": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            test.GHERepoURL,
+			inDestination:    filepath.Join(testDir, "failCase"),
+			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: "bad password"},
+			wantedType:       errors.New(""),
+			wantedErrMsg:     "401 Unauthorized",
+			wantedNumFiles:   0,
+		},
+		"fail case: input good GHE tar.gz URL and credentials but no matching repo found": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            GHETarGzURLToNonExistentRepo,
+			inDestination:    filepath.Join(testDir, "failCase"),
+			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			wantedType:       errors.New(""),
+			wantedErrMsg:     "GitHub responded with status code 404",
+			wantedNumFiles:   0,
+		},
+		"fail case: input good GHE tar.gz URL and credentials but no matching releases found": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            GHETarGzURLToNonExistentRelease,
+			inDestination:    filepath.Join(testDir, "failCase"),
+			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			wantedType:       errors.New(""),
+			wantedErrMsg:     "Cannot find release ",
+			wantedNumFiles:   0,
+		},
+		"fail case: input good GHE tar.gz URL and credentials but no matching assets found for release": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            GHETarGzURLToNonExistentReleaseAsset,
+			inDestination:    filepath.Join(testDir, "failCase"),
+			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			wantedType:       errors.New(""),
+			wantedErrMsg:     "Cannot find matching assets for release ",
+			wantedNumFiles:   0,
 		},
 	}
 	for name, test := range tests {
-		os.RemoveAll(testDir)
 		t.Run(name, func(t *testing.T) {
-			got := DownloadFromURLThenExtract(test.inURL, test.inDestination)
-			assert.IsType(t, test.wantedType, got, "Got: %s", got)
+			if test.skip {
+				t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
+			}
+
+			os.RemoveAll(testDir)
+			defer os.RemoveAll(testDir)
+			defer fmt.Println()
+
+			got := DownloadFromURLThenExtract(test.inURL, test.inDestination, test.inGitCredentials)
+			require.IsType(t, test.wantedType, got, "Got: %s", got)
+			if test.wantedErrMsg != "" {
+				assert.Contains(t, got.Error(), test.wantedErrMsg)
+			}
 
 			createdFiles, _ := ioutil.ReadDir(test.inDestination)
 			assert.Truef(t, len(createdFiles) == test.wantedNumFiles, "len(createdFiles) was %d but should have been %d. createdFiles: %s", len(createdFiles), test.wantedNumFiles, getFilenames(createdFiles))
-
 		})
-		os.RemoveAll(testDir)
-		fmt.Println()
 	}
 }
 
@@ -91,28 +183,23 @@ func getFilenames(files []os.FileInfo) []string {
 
 func TestDownloadFromRepoURL(t *testing.T) {
 	tests := map[string]struct {
-		inURL          string
-		inDestination  string
-		wantedType     error
-		wantedNumFiles int
+		inURL            string
+		inDestination    string
+		inGitCredentials GitCredentials
+		wantedType       error
+		wantedNumFiles   int
 	}{
 		"success case: input good path": {
-			inURL:          exampleGitURL,
+			inURL:          test.PublicGHRepoURL,
 			inDestination:  filepath.Join(testDir, "git"),
 			wantedType:     nil,
 			wantedNumFiles: 17,
-		},
-		"fail case: input URL that doesn't return 200": {
-			inURL:          "/bad/URL",
-			inDestination:  filepath.Join(testDir, "badURL"),
-			wantedType:     errors.New(""),
-			wantedNumFiles: 0,
 		},
 	}
 	for name, test := range tests {
 		os.RemoveAll(testDir)
 		t.Run(name, func(t *testing.T) {
-			got := DownloadFromRepoURL(test.inURL, test.inDestination)
+			got := DownloadFromRepoURL(test.inURL, test.inDestination, test.inGitCredentials)
 
 			assert.IsType(t, test.wantedType, got, "Got: %s", got)
 
@@ -133,7 +220,7 @@ func TestDownloadAndExtractZip(t *testing.T) {
 		wantedNumFiles int
 	}{
 		"success case: input good path": {
-			inURL:          exampleZipURL,
+			inURL:          publicGHZipURL,
 			inDestination:  filepath.Join(testDir, "zip"),
 			wantedType:     nil,
 			wantedNumFiles: 17,
@@ -169,13 +256,14 @@ func TestDownloadAndExtractZip(t *testing.T) {
 
 func TestDownloadFromTarGzURL(t *testing.T) {
 	tests := map[string]struct {
-		inURL          string
-		inDestination  string
-		wantedType     error
-		wantedNumFiles int
+		inURL            string
+		inDestination    string
+		inGitCredentials GitCredentials
+		wantedType       error
+		wantedNumFiles   int
 	}{
 		"success case: input good path": {
-			inURL:          exampleTarGzURL,
+			inURL:          publicGHTarGzURL,
 			inDestination:  "./testDir",
 			wantedType:     nil,
 			wantedNumFiles: 6,
@@ -197,7 +285,7 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 		os.RemoveAll(testDir)
 		t.Run(name, func(t *testing.T) {
 
-			got := DownloadFromTarGzURL(test.inURL, test.inDestination)
+			got := DownloadFromTarGzURL(test.inURL, test.inDestination, test.inGitCredentials)
 
 			assert.IsType(t, test.wantedType, got, "Got: %s", got)
 
@@ -210,21 +298,30 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 	}
 }
 
+func TestDownloadFile(t *testing.T) {
+	t.Run("fail case - response status code is not 200", func(t *testing.T) {
+		testURL := "https://github.com/nonexistentrepo"
+		err := DownloadFile(testURL, testDir, GitCredentials{})
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "File download failed for "+testURL+", status code ")
+	})
+}
+
 func TestIsTarGzURL(t *testing.T) {
 	tests := map[string]struct {
 		in   string
 		want bool
 	}{
 		"success case": {
-			in:   exampleTarGzURL,
+			in:   publicGHTarGzURL,
 			want: true,
 		},
 		"fail case: git repo URL": {
-			in:   exampleGitURL,
+			in:   test.PublicGHRepoURL,
 			want: false,
 		},
 		"fail case: zip URL": {
-			in:   exampleZipURL,
+			in:   publicGHZipURL,
 			want: false,
 		},
 		"fail case: other string": {

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -16,20 +16,16 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	"context"
-	goErr "errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/errors"
-	"github.com/google/go-github/github"
 	logr "github.com/sirupsen/logrus"
 )
 
@@ -46,48 +42,6 @@ func CreateTempFile(filePath string) error {
 		defer file.Close()
 	}
 	return nil
-}
-
-// GetZipURL from github api /repos/:owner/:repo/:archive_format/:ref
-func GetZipURL(owner, repo, branch string) (string, error) {
-	client := github.NewClient(nil)
-
-	opt := &github.RepositoryContentGetOptions{Ref: branch}
-
-	URL, _, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt, true)
-	if err != nil {
-		return "", err
-	}
-	url := URL.String()
-	return url, nil
-}
-
-// DownloadFile from URL to file destination
-func DownloadFile(URL, destination string) error {
-	// Get the data
-	resp, err := http.Get(URL)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return goErr.New(fmt.Sprintf("File download failed for %s, status code %d", URL, resp.StatusCode))
-	}
-
-	// Create the file
-	file, err := os.Create(destination)
-	if err != nil {
-		log.Println(err)
-		return err
-	}
-	defer file.Close()
-
-	// Write body to file
-	_, err = io.Copy(file, resp.Body)
-	logr.Tracef("Downloaded file from '%s' to '%s'\n", URL, destination)
-
-	return err
 }
 
 // UnZip unzips a file to a destination


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
`cwctl` can now download templates from GHE repos via `cwctl project create --url <url> --path <path> --username <username> --password <password>`.

Used the `go-github` client to use GitHub's API:
- https://github.com/google/go-github/blob/259aa56b9e3f43b924520fb5b5bc0784a901f90d/github/repos_releases.go
- https://pkg.go.dev/github.com/google/go-github/github?tab=doc#RepositoriesService
- https://developer.github.com/v3/repos/releases/#list-assets-for-a-release

## Which issue(s) does this PR fix ?
first step of https://github.com/eclipse/codewind/issues/2647

## Does this PR require a documentation change ?
yes, included here

## Any special notes for your reviewer ?
To run the tests that need to pass GitHub auth, you will have to manually input your credentials, because I have not found a way to safely include credentials