### PR TITLE
Remove secrets from Keychain when removing a connection

### DIFF
--- a/integration.bats
+++ b/integration.bats
@@ -162,9 +162,9 @@
   run go run main.go seckeyring validate --conid remoteNotKnown --username testuser
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring_secret_not_found" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }
 
 @test "invoke seckeyring validate command (using secure keyring) - key not found (incorrect username)"  {
@@ -172,9 +172,9 @@
   run go run main.go seckeyring validate --conid local --username testuser_unknown
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring_secret_not_found" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }
 
 # use our keyring (insecure)
@@ -211,9 +211,9 @@
   run go run main.go --insecureKeyring seckeyring validate --conid remoteNotKnown --username testuser
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }
 
 @test "invoke seckeyring validate command (using insecure keyring) - key not found (incorrect username)"  {
@@ -221,7 +221,7 @@
   run go run main.go --insecureKeyring seckeyring validate --conid local --username testuser_unknown
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/eclipse/codewind-installer/pkg/project"
 	"github.com/eclipse/codewind-installer/pkg/remote"
+	"github.com/eclipse/codewind-installer/pkg/security"
 	logr "github.com/sirupsen/logrus"
 )
 
@@ -50,6 +51,15 @@ func HandleConnectionError(err *connections.ConError) {
 		fmt.Println(err.Error())
 	} else {
 		logr.Error(err.Desc)
+	}
+}
+
+// HandleKeyringWarning : display keyring warning messages
+func HandleKeyringWarning(secErr *security.SecError) {
+	if printAsJSON {
+		fmt.Println(secErr.Error())
+	} else {
+		logr.Warnf("%s", secErr.Desc)
 	}
 }
 

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -156,14 +157,14 @@ func GetSecretFromKeyring(connectionID, uName string) (string, *SecError) {
 				return string(secret.Password), nil
 			}
 		}
-		err := errors.New(textSecretNotFound)
+		err := fmt.Errorf(textSecretNotFound, service+"."+uName)
 		return "", &SecError{errOpInsecureKeyring, err, err.Error()}
 	}
 	// else get from system keyring
 	secret, err := keyring.Get(service, uName)
 	if err != nil {
 		if err == keyring.ErrNotFound {
-			errNotFound := errors.New(textSecretNotFound)
+			errNotFound := fmt.Errorf(textSecretNotFound, service+"."+uName)
 			return "", &SecError{errOpKeyringSecretNotFound, errNotFound, errNotFound.Error()}
 		}
 		return "", &SecError{errOpKeyring, err, err.Error()}
@@ -189,7 +190,7 @@ func DeleteSecretFromKeyring(connectionID, uName string) *SecError {
 			}
 		}
 		if indexOfSecretToDelete == -1 {
-			err := errors.New(textSecretNotFound)
+			err := fmt.Errorf(textSecretNotFound, service+"."+uName)
 			return &SecError{errOpInsecureKeyring, err, err.Error()}
 		}
 		// remove existing secret
@@ -215,7 +216,7 @@ func DeleteSecretFromKeyring(connectionID, uName string) *SecError {
 	err := keyring.Delete(service, uName)
 	if err != nil {
 		if err == keyring.ErrNotFound {
-			errNotFound := errors.New(textSecretNotFound)
+			errNotFound := fmt.Errorf(textSecretNotFound, service+"."+uName)
 			return &SecError{errOpKeyringSecretNotFound, errNotFound, errNotFound.Error()}
 		}
 		return &SecError{errOpKeyring, err, err.Error()}
@@ -227,7 +228,7 @@ func readInsecureKeyring() ([]KeyringSecret, *SecError) {
 	file, readErr := ioutil.ReadFile(GetPathToInsecureKeyring())
 	if readErr != nil {
 		if os.IsNotExist(readErr) {
-			err := errors.New(textSecretNotFound)
+			err := errors.New(textKeyringNotFound)
 			return nil, &SecError{errOpInsecureKeyring, err, err.Error()}
 		}
 		return nil, &SecError{errOpInsecureKeyring, readErr, readErr.Error()}

--- a/pkg/security/keychain_test.go
+++ b/pkg/security/keychain_test.go
@@ -72,7 +72,7 @@ func Test_Keychain_Secure(t *testing.T) {
 		err := DeleteSecretFromKeyring(testConnection, testUsername)
 		assert.NotNil(t, err)
 		assert.Equal(t, err.Op, "sec_keyring_secret_not_found")
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Contains(t, err.Desc, "not found in keyring")
 	})
 
 	globals.SetUseInsecureKeyring(originalUseInsecureKeyring)
@@ -92,7 +92,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Secret cannot be retrieved when keychain file does not exist", func(t *testing.T) {
 		retrievedSecret, err := SecKeyGetSecret(testConnection, testUsername)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Desc, "Secret not found in keyring")
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "Keyring not found")
 		assert.Equal(t, "", retrievedSecret)
 	})
 
@@ -111,7 +112,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Secret cannot be retrieved for an unknown account", func(t *testing.T) {
 		retrievedSecret, err := SecKeyGetSecret(testConnection, "unknownaccount")
 		assert.NotNil(t, err)
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "not found in keyring")
 		assert.Equal(t, "", retrievedSecret)
 	})
 
@@ -129,7 +131,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Test keyring returns an error when trying to delete from a non-existent keyring", func(t *testing.T) {
 		err := DeleteSecretFromKeyring("mockConnectionID", "mockUsername")
 		assert.NotNil(t, err)
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "not found in keyring")
 	})
 
 	t.Run("Secret can be removed without deleting keychain", func(t *testing.T) {
@@ -141,7 +144,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 		// check this secret has been deleted
 		secretFromThisTest, err := GetSecretFromKeyring("mockConnectionID", "mockUsername")
 		assert.Equal(t, "", secretFromThisTest)
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "not found in keyring")
 
 		// check the secret created before this test has not been deleted
 		existingSecret, err2 := GetSecretFromKeyring(testConnection, testUsername)
@@ -159,7 +163,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Test keyring returns an error when trying to delete from a non-existent keyring", func(t *testing.T) {
 		err := DeleteSecretFromKeyring(testConnection, testUsername)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Desc, "Secret not found in keyring")
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "Keyring not found")
 	})
 
 	// remove insecureKeychain.json if it still exists

--- a/pkg/security/security_utils.go
+++ b/pkg/security/security_utils.go
@@ -54,12 +54,13 @@ const (
 )
 
 const (
-	textBadPassword    = "Passwords must not contains quoted characters"
-	textUserNotFound   = "Registered User not found"
-	textUnableToParse  = "Unable to parse Keycloak response"
-	textInvalidOptions = "Invalid or missing command line options"
-	textAuthIsDown     = "Authentication service unavailable"
-	textSecretNotFound = "Secret not found in keyring"
+	textBadPassword     = "Passwords must not contains quoted characters"
+	textUserNotFound    = "Registered User not found"
+	textUnableToParse   = "Unable to parse Keycloak response"
+	textInvalidOptions  = "Invalid or missing command line options"
+	textAuthIsDown      = "Authentication service unavailable"
+	textSecretNotFound  = "Secret %s not found in keyring"
+	textKeyringNotFound = "Keyring not found"
 )
 
 // SecError : Error formatted in JSON containing an errorOp and a description from
@@ -104,5 +105,5 @@ func parseKeycloakError(body string, httpCode int) *KeycloakAPIError {
 
 // IsSecretNotFoundError : Test whether a secret error is due to the secret not exisiting.
 func IsSecretNotFoundError(se *SecError) bool {
-	return se.Desc == textSecretNotFound
+	return se.Desc == textKeyringNotFound
 }


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Enhancement

## What does this PR do ?

1. Changes the behaviour of CWCTL to remove Keychain secrets (login credentials, access_token, refresh_token) when removing a connection
2. Provides a meaningful warning message including the name of the secret if something goes wrong during secret lookup and removal
3. Updates BATS and Unit tests for both secure and insecure style keyrings

## Which issue(s) does this PR fix ? 2584

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2584

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?

BATS test result PASSs:

```
 ✓ invoke seckeyring update command (using secure keyring) - create a key
 ✓ invoke seckeyring update command (using secure keyring) - update a key
 ✓ invoke seckeyring validate command (using secure keyring) - validate a key
 ✓ invoke seckeyring validate command (using secure keyring) - key not found (incorrect connection)
 ✓ invoke seckeyring validate command (using secure keyring) - key not found (incorrect username)
 ✓ invoke seckeyring update command (using insecure keyring) - create a key
 ✓ invoke seckeyring update command (using insecure keyring) - update a key
 ✓ invoke seckeyring validate command (using insecure keyring) - validate a key
 ✓ invoke seckeyring validate command (using insecure keyring) - key not found (incorrect connection)
 ✓ invoke seckeyring validate command (using insecure keyring) - key not found (incorrect username)
```


Unit test results PASS:

```
=== RUN   Test_Authenticate
=== RUN   Test_Authenticate/Expect_authentication_failure_-_invalid_credentials
=== RUN   Test_Authenticate/Expect_authentication_success_-_obtain_access_token_from_service
=== RUN   Test_Authenticate/Expect_authentication_success_-_obtain_access_token_using_refresh_token
=== RUN   Test_Authenticate/Expect_authentication_failure_-_unable_to_obtain_access_token_using_expired_refresh_token
=== RUN   Test_Authenticate/Cleanup_stored_access_token_and_refresh_token
--- PASS: Test_Authenticate (0.42s)
    --- PASS: Test_Authenticate/Expect_authentication_failure_-_invalid_credentials (0.03s)
    --- PASS: Test_Authenticate/Expect_authentication_success_-_obtain_access_token_from_service (0.27s)
    --- PASS: Test_Authenticate/Expect_authentication_success_-_obtain_access_token_using_refresh_token (0.03s)
    --- PASS: Test_Authenticate/Expect_authentication_failure_-_unable_to_obtain_access_token_using_expired_refresh_token (0.03s)
    --- PASS: Test_Authenticate/Cleanup_stored_access_token_and_refresh_token (0.07s)
=== RUN   Test_Keychain_Secure
=== RUN   Test_Keychain_Secure/Secret_cannot_be_retrieved_for_an_unknown_account
=== RUN   Test_Keychain_Secure/A_new_key_can_be_created_in_the_platform_keychain
=== RUN   Test_Keychain_Secure/The_secret_can_be_retrieved_from_the_keychain
=== RUN   Test_Keychain_Secure/An_existing_key_in_the_keychain_can_be_updated
=== RUN   Test_Keychain_Secure/Retrieved_secret_matches_the_saved_secret
=== RUN   Test_Keychain_Secure/Test_keyring_entry_can_be_removed
=== RUN   Test_Keychain_Secure/Test_keyring_returns_an_error_when_trying_to_delete_a_non-existent_secret
--- PASS: Test_Keychain_Secure (0.34s)
    --- PASS: Test_Keychain_Secure/Secret_cannot_be_retrieved_for_an_unknown_account (0.03s)
    --- PASS: Test_Keychain_Secure/A_new_key_can_be_created_in_the_platform_keychain (0.09s)
    --- PASS: Test_Keychain_Secure/The_secret_can_be_retrieved_from_the_keychain (0.02s)
    --- PASS: Test_Keychain_Secure/An_existing_key_in_the_keychain_can_be_updated (0.08s)
    --- PASS: Test_Keychain_Secure/Retrieved_secret_matches_the_saved_secret (0.02s)
    --- PASS: Test_Keychain_Secure/Test_keyring_entry_can_be_removed (0.03s)
    --- PASS: Test_Keychain_Secure/Test_keyring_returns_an_error_when_trying_to_delete_a_non-existent_secret (0.03s)
=== RUN   Test_Keychain_Insecure
=== RUN   Test_Keychain_Insecure/Secret_cannot_be_retrieved_when_keychain_file_does_not_exist
=== RUN   Test_Keychain_Insecure/A_new_secret_is_stored_in_a_new_keychain_file_when_the_keychain_file_didn't_exist
=== RUN   Test_Keychain_Insecure/The_secret_can_be_retrieved_from_the_keychain
=== RUN   Test_Keychain_Insecure/Secret_cannot_be_retrieved_for_an_unknown_account
=== RUN   Test_Keychain_Insecure/An_existing_key_in_the_keychain_can_be_updated
=== RUN   Test_Keychain_Insecure/Retrieved_secret_matches_the_saved_secret
=== RUN   Test_Keychain_Insecure/Test_keyring_returns_an_error_when_trying_to_delete_from_a_non-existent_keyring
=== RUN   Test_Keychain_Insecure/Secret_can_be_removed_without_deleting_keychain
=== RUN   Test_Keychain_Insecure/Keychain_is_deleted_when_last_secret_is_removed
=== RUN   Test_Keychain_Insecure/Test_keyring_returns_an_error_when_trying_to_delete_from_a_non-existent_keyring#01
--- PASS: Test_Keychain_Insecure (0.00s)
    --- PASS: Test_Keychain_Insecure/Secret_cannot_be_retrieved_when_keychain_file_does_not_exist (0.00s)
    --- PASS: Test_Keychain_Insecure/A_new_secret_is_stored_in_a_new_keychain_file_when_the_keychain_file_didn't_exist (0.00s)
    --- PASS: Test_Keychain_Insecure/The_secret_can_be_retrieved_from_the_keychain (0.00s)
    --- PASS: Test_Keychain_Insecure/Secret_cannot_be_retrieved_for_an_unknown_account (0.00s)
    --- PASS: Test_Keychain_Insecure/An_existing_key_in_the_keychain_can_be_updated (0.00s)
    --- PASS: Test_Keychain_Insecure/Retrieved_secret_matches_the_saved_secret (0.00s)
    --- PASS: Test_Keychain_Insecure/Test_keyring_returns_an_error_when_trying_to_delete_from_a_non-existent_keyring (0.00s)
    --- PASS: Test_Keychain_Insecure/Secret_can_be_removed_without_deleting_keychain (0.00s)
    --- PASS: Test_Keychain_Insecure/Keychain_is_deleted_when_last_secret_is_removed (0.00s)
    --- PASS: Test_Keychain_Insecure/Test_keyring_returns_an_error_when_trying_to_delete_from_a_non-existent_keyring#01 (0.00s)
PASS
ok      github.com/eclipse/codewind-installer/pkg/security      1.109s
```

Manual testing performed alongside VSCode to check error message flow.  In this example I manually removed two secrets (creds & access_token) before attempting to remove the connection noticing that the two warnings were logged but the connection still managed to be removed.

```
[INFO: 08:49:08.845 RemoveConnectionCmd.ts:39]: Removing connection https://codewind-gatekeeper-mark-1.10.98.117.7.nip.io/
Logger.ts:129
[INFO: 08:49:08.851 CLIWrapper.ts:136]: Running CLI command: cwctl --json --insecure connections remove --conid K99LWT3T
Logger.ts:129
[DBUG: 08:49:09.297 CLIWrapper.ts:214]: Successfully ran CLI command cwctl --json --insecure connections remove --conid K99LWT3T, Output was:
{"error":"sec_keyring_secret_not_found","error_description":"Secret org.eclipse.codewind.k99lwt3t.mark not found in keyring"}
{"error":"sec_keyring_secret_not_found","error_description":"Secret org.eclipse.codewind.k99lwt3t.refresh_token not found in keyring"}
{"status":"OK","status_message":"Connection removed"}
```
