### PR TITLE
Remove secrets from Keychain when removing a connection 

### DIFF
--- a/integration.bats
+++ b/integration.bats
@@ -162,9 +162,9 @@
   run go run main.go seckeyring validate --conid remoteNotKnown --username testuser
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring_secret_not_found" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }
 
 @test "invoke seckeyring validate command (using secure keyring) - key not found (incorrect username)"  {
@@ -172,9 +172,9 @@
   run go run main.go seckeyring validate --conid local --username testuser_unknown
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring_secret_not_found" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }
 
 # use our keyring (insecure)
@@ -211,9 +211,9 @@
   run go run main.go --insecureKeyring seckeyring validate --conid remoteNotKnown --username testuser
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }
 
 @test "invoke seckeyring validate command (using insecure keyring) - key not found (incorrect username)"  {
@@ -221,7 +221,7 @@
   run go run main.go --insecureKeyring seckeyring validate --conid local --username testuser_unknown
   echo "status = ${status}"
   echo "output trace = ${output}"
-  [ "${lines[0]}" = '{"error":"sec_keyring","error_description":"secret not found in keyring"}' ]
-  [ "${lines[1]}" = "exit status 1" ]
   [ "$status" -eq 1 ]
+  [[ ${lines[0]} =~ "sec_keyring" && ${lines[0]} =~ "not found in keyring" ]]
+  [[ ${lines[1]} = "exit status 1" ]]
 }

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/eclipse/codewind-installer/pkg/project"
 	"github.com/eclipse/codewind-installer/pkg/remote"
+	"github.com/eclipse/codewind-installer/pkg/security"
 	logr "github.com/sirupsen/logrus"
 )
 
@@ -50,6 +51,15 @@ func HandleConnectionError(err *connections.ConError) {
 		fmt.Println(err.Error())
 	} else {
 		logr.Error(err.Desc)
+	}
+}
+
+// HandleKeyringWarning : display keyring warning messages
+func HandleKeyringWarning(secErr *security.SecError) {
+	if printAsJSON {
+		fmt.Println(secErr.Error())
+	} else {
+		logr.Warnf("%s", secErr.Desc)
 	}
 }
 

--- a/pkg/security/keychain.go
+++ b/pkg/security/keychain.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -156,14 +157,14 @@ func GetSecretFromKeyring(connectionID, uName string) (string, *SecError) {
 				return string(secret.Password), nil
 			}
 		}
-		err := errors.New(textSecretNotFound)
+		err := fmt.Errorf(textSecretNotFound, service+"."+uName)
 		return "", &SecError{errOpInsecureKeyring, err, err.Error()}
 	}
 	// else get from system keyring
 	secret, err := keyring.Get(service, uName)
 	if err != nil {
 		if err == keyring.ErrNotFound {
-			errNotFound := errors.New(textSecretNotFound)
+			errNotFound := fmt.Errorf(textSecretNotFound, service+"."+uName)
 			return "", &SecError{errOpKeyringSecretNotFound, errNotFound, errNotFound.Error()}
 		}
 		return "", &SecError{errOpKeyring, err, err.Error()}
@@ -189,7 +190,7 @@ func DeleteSecretFromKeyring(connectionID, uName string) *SecError {
 			}
 		}
 		if indexOfSecretToDelete == -1 {
-			err := errors.New(textSecretNotFound)
+			err := fmt.Errorf(textSecretNotFound, service+"."+uName)
 			return &SecError{errOpInsecureKeyring, err, err.Error()}
 		}
 		// remove existing secret
@@ -215,7 +216,7 @@ func DeleteSecretFromKeyring(connectionID, uName string) *SecError {
 	err := keyring.Delete(service, uName)
 	if err != nil {
 		if err == keyring.ErrNotFound {
-			errNotFound := errors.New(textSecretNotFound)
+			errNotFound := fmt.Errorf(textSecretNotFound, service+"."+uName)
 			return &SecError{errOpKeyringSecretNotFound, errNotFound, errNotFound.Error()}
 		}
 		return &SecError{errOpKeyring, err, err.Error()}
@@ -227,7 +228,7 @@ func readInsecureKeyring() ([]KeyringSecret, *SecError) {
 	file, readErr := ioutil.ReadFile(GetPathToInsecureKeyring())
 	if readErr != nil {
 		if os.IsNotExist(readErr) {
-			err := errors.New(textSecretNotFound)
+			err := errors.New(textKeyringNotFound)
 			return nil, &SecError{errOpInsecureKeyring, err, err.Error()}
 		}
 		return nil, &SecError{errOpInsecureKeyring, readErr, readErr.Error()}

--- a/pkg/security/keychain_test.go
+++ b/pkg/security/keychain_test.go
@@ -72,7 +72,7 @@ func Test_Keychain_Secure(t *testing.T) {
 		err := DeleteSecretFromKeyring(testConnection, testUsername)
 		assert.NotNil(t, err)
 		assert.Equal(t, err.Op, "sec_keyring_secret_not_found")
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Contains(t, err.Desc, "not found in keyring")
 	})
 
 	globals.SetUseInsecureKeyring(originalUseInsecureKeyring)
@@ -92,7 +92,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Secret cannot be retrieved when keychain file does not exist", func(t *testing.T) {
 		retrievedSecret, err := SecKeyGetSecret(testConnection, testUsername)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Desc, "Secret not found in keyring")
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "Keyring not found")
 		assert.Equal(t, "", retrievedSecret)
 	})
 
@@ -111,7 +112,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Secret cannot be retrieved for an unknown account", func(t *testing.T) {
 		retrievedSecret, err := SecKeyGetSecret(testConnection, "unknownaccount")
 		assert.NotNil(t, err)
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "not found in keyring")
 		assert.Equal(t, "", retrievedSecret)
 	})
 
@@ -129,7 +131,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Test keyring returns an error when trying to delete from a non-existent keyring", func(t *testing.T) {
 		err := DeleteSecretFromKeyring("mockConnectionID", "mockUsername")
 		assert.NotNil(t, err)
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "not found in keyring")
 	})
 
 	t.Run("Secret can be removed without deleting keychain", func(t *testing.T) {
@@ -141,7 +144,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 		// check this secret has been deleted
 		secretFromThisTest, err := GetSecretFromKeyring("mockConnectionID", "mockUsername")
 		assert.Equal(t, "", secretFromThisTest)
-		assert.Equal(t, "Secret not found in keyring", err.Desc)
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "not found in keyring")
 
 		// check the secret created before this test has not been deleted
 		existingSecret, err2 := GetSecretFromKeyring(testConnection, testUsername)
@@ -159,7 +163,8 @@ func Test_Keychain_Insecure(t *testing.T) {
 	t.Run("Test keyring returns an error when trying to delete from a non-existent keyring", func(t *testing.T) {
 		err := DeleteSecretFromKeyring(testConnection, testUsername)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Desc, "Secret not found in keyring")
+		assert.Equal(t, "sec_insecure_keyring", err.Op)
+		assert.Contains(t, err.Desc, "Keyring not found")
 	})
 
 	// remove insecureKeychain.json if it still exists

--- a/pkg/security/security_utils.go
+++ b/pkg/security/security_utils.go
@@ -13,6 +13,7 @@ package security
 
 import (
 	"encoding/json"
+	"strings"
 )
 
 // KeycloakMasterRealm : master realm name
@@ -59,7 +60,8 @@ const (
 	textUnableToParse   = "Unable to parse Keycloak response"
 	textInvalidOptions  = "Invalid or missing command line options"
 	textAuthIsDown      = "Authentication service unavailable"
-	textSecretNotFound  = "Secret %s not found in keyring"
+	textNotFoundSuffix  = "not found in keyring"
+	textSecretNotFound  = "Secret %s " + textNotFoundSuffix
 	textKeyringNotFound = "Keyring not found"
 )
 
@@ -103,7 +105,7 @@ func parseKeycloakError(body string, httpCode int) *KeycloakAPIError {
 	return &keycloakAPIError
 }
 
-// IsSecretNotFoundError : Test whether a secret error is due to the secret not exisiting.
+// IsSecretNotFoundError : Test whether a secret error is due to the secret not existing.
 func IsSecretNotFoundError(se *SecError) bool {
-	return se.Desc == textKeyringNotFound
+	return strings.Contains(se.Desc, textNotFoundSuffix) || strings.Contains(se.Desc, textKeyringNotFound)
 }

--- a/pkg/security/security_utils.go
+++ b/pkg/security/security_utils.go
@@ -54,12 +54,13 @@ const (
 )
 
 const (
-	textBadPassword    = "Passwords must not contains quoted characters"
-	textUserNotFound   = "Registered User not found"
-	textUnableToParse  = "Unable to parse Keycloak response"
-	textInvalidOptions = "Invalid or missing command line options"
-	textAuthIsDown     = "Authentication service unavailable"
-	textSecretNotFound = "Secret not found in keyring"
+	textBadPassword     = "Passwords must not contains quoted characters"
+	textUserNotFound    = "Registered User not found"
+	textUnableToParse   = "Unable to parse Keycloak response"
+	textInvalidOptions  = "Invalid or missing command line options"
+	textAuthIsDown      = "Authentication service unavailable"
+	textSecretNotFound  = "Secret %s not found in keyring"
+	textKeyringNotFound = "Keyring not found"
 )
 
 // SecError : Error formatted in JSON containing an errorOp and a description from
@@ -104,5 +105,5 @@ func parseKeycloakError(body string, httpCode int) *KeycloakAPIError {
 
 // IsSecretNotFoundError : Test whether a secret error is due to the secret not exisiting.
 func IsSecretNotFoundError(se *SecError) bool {
-	return se.Desc == textSecretNotFound
+	return se.Desc == textKeyringNotFound
 }


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Enhancement

## What does this PR do ?

1. Same code as PR 437 but with an extra check for a missing keyring rather than just a missing secret 

commit :  https://github.com/eclipse/codewind-installer/commit/723bc4a5e728f68b9523b2aff45c106767f9758f

## Which issue(s) does this PR fix ? 2584

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2584

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?

Re ran BATS and UNIT test:

```
 ✓ invoke seckeyring update command (using secure keyring) - create a key
 ✓ invoke seckeyring update command (using secure keyring) - update a key
 ✓ invoke seckeyring validate command (using secure keyring) - validate a key
 ✓ invoke seckeyring validate command (using secure keyring) - key not found (incorrect connection)
 ✓ invoke seckeyring validate command (using secure keyring) - key not found (incorrect username)
 ✓ invoke seckeyring update command (using insecure keyring) - create a key
 ✓ invoke seckeyring update command (using insecure keyring) - update a key
 ✓ invoke seckeyring validate command (using insecure keyring) - validate a key
 ✓ invoke seckeyring validate command (using insecure keyring) - key not found (incorrect connection)
 ✓ invoke seckeyring validate command (using insecure keyring) - key not found (incorrect username)

10 tests, 0 failures
```


Unit test results PASS:

```
ok      github.com/eclipse/codewind-installer/cmd/cli   (cached)
?       github.com/eclipse/codewind-installer/resources/test/go-project [no test files]
?       github.com/eclipse/codewind-installer/pkg/globals       [no test files]
?       github.com/eclipse/codewind-installer/pkg/appconstants  [no test files]
ok      github.com/eclipse/codewind-installer/pkg/docker        0.324s
ok      github.com/eclipse/codewind-installer/pkg/config        (cached)
ok      github.com/eclipse/codewind-installer/pkg/security      (cached)
ok      github.com/eclipse/codewind-installer/pkg/apiroutes     (cached)
ok      github.com/eclipse/codewind-installer/pkg/gatekeeper    (cached)
ok      github.com/eclipse/codewind-installer/pkg/utils 2.485s
ok      github.com/eclipse/codewind-installer/pkg/sechttp       (cached)
ok      github.com/eclipse/codewind-installer/pkg/project       1.344s
ok      github.com/eclipse/codewind-installer/pkg/connections   (cached)
?       github.com/eclipse/codewind-installer/pkg/actions       [no test files]
?       github.com/eclipse/codewind-installer/pkg/errors        [no test files]
ok      github.com/eclipse/codewind-installer/pkg/desktop_utils (cached)
ok      github.com/eclipse/codewind-installer/pkg/remote        (cached)
?       github.com/eclipse/codewind-installer/pkg/remote/kube   [no test files]
```
