### PR TITLE
Allow PFE to start when docker is configured to use a remote docker host.

### DIFF
--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -29,15 +29,21 @@ type DockerClient interface {
 	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
 	ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error
 	ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error
+	DaemonHost() string
 	DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error)
 }
 
 // NewDockerClient creates a new client for the docker API
 func NewDockerClient() (DockerClient, *DockerError) {
-	dockerClient, err := client.NewClientWithOpts(client.WithVersion("1.30"))
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.30"))
 	if err != nil {
 		return nil, &DockerError{errOpClientCreate, err, err.Error()}
 	}
 
 	return dockerClient, nil
+}
+
+// UsingLocalDockerHost returns true if we are using the default local docker host.
+func UsingLocalDockerHost(dockerClient DockerClient) bool {
+	return dockerClient.DaemonHost() == client.DefaultDockerHost
 }

--- a/pkg/docker/fakeclient.go
+++ b/pkg/docker/fakeclient.go
@@ -106,6 +106,10 @@ func (m *mockDockerClientWithCw) ContainerInspect(ctx context.Context, container
 	}, nil
 }
 
+func (m *mockDockerClientWithCw) DaemonHost() string {
+	return ""
+}
+
 func (m *mockDockerClientWithCw) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
 	return registry.DistributionInspect{
 		Descriptor: v1.Descriptor{
@@ -151,6 +155,10 @@ func (m *mockDockerClientWithoutCw) ContainerInspect(ctx context.Context, contai
 			},
 		},
 	}, nil
+}
+
+func (m *mockDockerClientWithoutCw) DaemonHost() string {
+	return ""
 }
 
 func (m *mockDockerClientWithoutCw) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
@@ -200,6 +208,10 @@ func (m *mockDockerErrorClient) ContainerRemove(ctx context.Context, containerID
 
 func (m *mockDockerErrorClient) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
 	return types.ContainerJSON{}, errContainerInspect
+}
+
+func (m *mockDockerErrorClient) DaemonHost() string {
+	return ""
 }
 
 func (m *mockDockerErrorClient) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {

--- a/pkg/docker/filesystem.go
+++ b/pkg/docker/filesystem.go
@@ -33,9 +33,19 @@ func WriteToComposeFile(dockerComposeFile string, debug bool) *DockerError {
 		return &DockerError{errOpDockerComposeFileCreate, dockerComposeTempErr, dockerComposeTempErr.Error()}
 	}
 
-	secretFileName, secretErr := writeDockerConfigSecretFile(path.Dir(dockerComposeFile))
-	if secretErr != nil {
-		return secretErr
+	dockerClient, dockerErr := NewDockerClient()
+	if dockerErr != nil {
+		return dockerErr
+	}
+
+	// If we are using a remote docker host it won't be able to read a local secrets file.
+	secretFileName := "/dev/null"
+	if UsingLocalDockerHost(dockerClient) {
+		var secretErr *DockerError
+		secretFileName, secretErr = writeDockerConfigSecretFile(path.Dir(dockerComposeFile))
+		if secretErr != nil {
+			return secretErr
+		}
 	}
 
 	dataStruct := Compose{}


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Allows codewind to start when the docker host is on a remote machine.
It creates the docker client using the docker environment variables. This means we create our docker client more 'correctly' so is probably a good change outside of this problem. The docker config is read by the docker client library directly so the change to do this is 9 characters to tell the client to use the docker env vars to configure itself. (It should be low risk.) 

It also changes cwctl so it doesn't write a secret when we use a remote docker host as the remote host won't be able to find the local file. This does mean we lose the persisting of docker credentials when we have a remote docker host *however* in the one situation we currently use this in the environment is short lived and we wouldn't expect the user to be restarting the PFE container anyway.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2724

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2724

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No