### PR TITLE
feat: 2647.3 `cwctl template repos add` secure repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,17 @@ Subcommands:</br>
 Subcommands:</br>
 
 `list/ls` - List available templates
+`repos` - Manage template repositories
+
+Subcommands:</br>
+`list/ls` - List available template repositories
+`add` - Add a new template repository
+> **Flags:**
+> --url - URL to template repository index.json
+> --name - Custom name for template repository
+> --description - Custom description for template repository
+> --username - GitHub username (required if accessing the provided URL requires GitHub authentication)
+> --password - GitHub password (required if accessing the provided URL requires GitHub authentication)
 
 ### version
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -516,6 +516,16 @@ func Commands() {
 									Usage:    "Connection ID",
 									Required: false,
 								},
+								cli.StringFlag{
+									Name:     "username",
+									Usage:    "GitHub username",
+									Required: false,
+								},
+								cli.StringFlag{
+									Name:     "password",
+									Usage:    "GitHub password",
+									Required: false,
+								},
 							},
 							Action: func(c *cli.Context) error {
 								AddTemplateRepo(c)

--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -68,8 +68,15 @@ func AddTemplateRepo(c *cli.Context) {
 	url := c.String("url")
 	desc := c.String("description")
 	name := c.String("name")
+	username := c.String("username")
+	password := c.String("password")
+
+	gitCredentials := utils.GitCredentials{
+		Username: username,
+		Password: password,
+	}
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	repos, err := apiroutes.AddTemplateRepo(conID, url, desc, name)
+	repos, err := apiroutes.AddTemplateRepo(conID, url, desc, name, gitCredentials)
 	if err != nil {
 		templateErr := &TemplateError{errOpAddRepo, err, err.Error()}
 		HandleTemplateError(templateErr)

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -44,6 +44,7 @@ type (
 		URL            string               `json:"url"`
 		Description    string               `json:"description"`
 		Name           string               `json:"name"`
+		GitCredentials utils.GitCredentials `json:"gitCredentials"`
 	}
 
 	// RepoOperation represents a requested operation on a template repository.
@@ -186,7 +187,7 @@ func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
 
 // AddTemplateRepo adds a template repo to PFE and
 // returns the new list of existing repos
-func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo, error) {
+func AddTemplateRepo(conID, URL, description, name string, gitCredentials utils.GitCredentials) ([]utils.TemplateRepo, error) {
 	if _, err := url.ParseRequestURI(URL); err != nil {
 		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
 	}
@@ -204,6 +205,7 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 		URL:            URL,
 		Description:    description,
 		Name:           name,
+		GitCredentials: gitCredentials,
 	}
 	buf := new(bytes.Buffer)
 	json.NewEncoder(buf).Encode(requestBody)

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -39,6 +39,13 @@ type (
 		SourceID     string `json:"sourceId,omitempty"`
 	}
 
+	// RepoCreationOptions is the request body for PFE's POST /templates/repositories API
+	RepoCreationOptions struct {
+		URL            string               `json:"url"`
+		Description    string               `json:"description"`
+		Name           string               `json:"name"`
+	}
+
 	// RepoOperation represents a requested operation on a template repository.
 	RepoOperation struct {
 		Operation string `json:"op"`
@@ -184,13 +191,6 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
 	}
 
-	values := map[string]string{
-		"url":         URL,
-		"description": description,
-		"name":        name,
-	}
-	jsonValue, _ := json.Marshal(values)
-
 	conInfo, conInfoErr := connections.GetConnectionByID(conID)
 	if conInfoErr != nil {
 		return nil, conInfoErr.Err
@@ -200,7 +200,15 @@ func AddTemplateRepo(conID, URL, description, name string) ([]utils.TemplateRepo
 		return nil, conErr.Err
 	}
 
-	req, err := http.NewRequest("POST", conURL+"/api/v1/templates/repositories", bytes.NewBuffer(jsonValue))
+	requestBody := RepoCreationOptions{
+		URL:            URL,
+		Description:    description,
+		Name:           name,
+	}
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(requestBody)
+
+	req, err := http.NewRequest("POST", conURL+"/api/v1/templates/repositories", buf)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -22,22 +22,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var numCodewindTemplates = 8
+const numCodewindTemplates = 8
 
-var numAppsodyTemplatesEnabled = 11
+const numAppsodyTemplatesEnabled = 11
 
-var numAppsodyTemplatesDisabled = 7
+const numAppsodyTemplatesDisabled = 7
 
-var numAppsodyTemplates = numAppsodyTemplatesEnabled + numAppsodyTemplatesDisabled
+const numAppsodyTemplates = numAppsodyTemplatesEnabled + numAppsodyTemplatesDisabled
 
-var numTemplatesEnabled = numCodewindTemplates + numAppsodyTemplatesEnabled
+const numTemplatesEnabled = numCodewindTemplates + numAppsodyTemplatesEnabled
 
-var numTemplates = numTemplatesEnabled + numAppsodyTemplatesDisabled
+const numTemplates = numTemplatesEnabled + numAppsodyTemplatesDisabled
 
-var URLOfExistingRepo = "https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json"
-var URLOfNewRepo = "https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json"
-var URLOfUnknownRepo = "https://raw.githubusercontent.com/UNKNOWN"
-var URLOfUnknownRepo2 = "https://raw.githubusercontent.com/UNKNOWN_2"
+const URLOfExistingRepo = "https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json"
+const URLOfUnknownRepo = "https://raw.githubusercontent.com/UNKNOWN"
+const URLOfUnknownRepo2 = "https://raw.githubusercontent.com/UNKNOWN_2"
 
 func TestGetTemplates(t *testing.T) {
 	if testing.Short() {
@@ -89,7 +88,7 @@ func TestGetTemplates(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := GetTemplates("local", test.inProjectStyle, test.inShowEnabledOnly)
 			assert.IsType(t, test.wantedType, got)
-			assert.True(t, len(got) >= test.wantedLength)
+			assert.True(t, len(got) >= test.wantedLength, "wanted len(got) >= %d but len(got) was %d", test.wantedLength, len(got))
 			assert.Nil(t, err)
 		})
 	}
@@ -136,7 +135,7 @@ func TestGetTemplateRepos(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := GetTemplateRepos("local")
 			assert.IsType(t, test.wantedType, got)
-			assert.True(t, len(got) >= test.wantedLength)
+			assert.True(t, len(got) >= test.wantedLength, "wanted len(got) >= %d but len(got) was %d", test.wantedLength, len(got))
 			assert.Equal(t, test.wantedErr, err)
 		})
 	}
@@ -202,7 +201,7 @@ func TestSuccessfulAddAndDeleteTemplateRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping testing in short mode")
 	}
-	testRepoURL := URLOfNewRepo
+	testRepoURL := test.PublicGHDevfileURL
 
 	originalRepos, err := GetTemplateRepos("local")
 	if err != nil {
@@ -230,7 +229,7 @@ func TestSuccessfulAddAndDeleteTemplateRepo(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	// This test block cleans up after itself, assuming that the template repo tested was initially enabled. (This test block resets it to 'enabled')
+	// This test block cleans up after itself
 }
 
 func TestFailuresEnableTemplateRepos(t *testing.T) {

--- a/pkg/test/globals.go
+++ b/pkg/test/globals.go
@@ -20,6 +20,9 @@ const PublicGHDevfileURL = "https://raw.githubusercontent.com/kabanero-io/codewi
 // GHERepoURL is a URL to a GitHub Enterprise repo (requiring auth to access)
 const GHERepoURL = "https://github.ibm.com/DevCamp2018/git-basics"
 
+// GHEDevfileURL is a URL to a devfiles/index.json in a GitHub Enterprise repo
+const GHEDevfileURL = "https://raw.github.ibm.com/Richard-Waller/sampleGHETemplateRepo/415ece47958250175f182c095af7da6cfe40e58a/devfiles/index.json"
+
 // GHEUsername is a username that passes the auth required to access a GHERepoURL
 const GHEUsername = "INSERT YOUR OWN: e.g. foo.bar@foobar.com"
 

--- a/pkg/test/globals.go
+++ b/pkg/test/globals.go
@@ -11,8 +11,11 @@
 
 package test
 
-// PublicGHRepoURL is a URL to a GitHub repo not requiring auth to access
+// PublicGHRepoURL is a URL to a public GitHub repo (not requiring auth to access)
 const PublicGHRepoURL = "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
+
+// PublicGHDevfileURL is a URL to a devfiles/index.json in a public GitHub repo (not requiring auth to access)
+const PublicGHDevfileURL = "https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json"
 
 // GHERepoURL is a URL to a GitHub Enterprise repo (requiring auth to access)
 const GHERepoURL = "https://github.ibm.com/DevCamp2018/git-basics"


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Extends `cwctl templates repos add` so that it can pass GitHub credentials to PFE, which PFE can handle when https://github.com/eclipse/codewind/pull/2747 is merged

The credentials are sent to PFE in the request body. I haven't encrypted the credentials because I assume we'll be using HTTPS when we care about security. Happy to improve security though if there are any suggestions

See commit messages for more details

## Which issue(s) does this PR fix ?
Part of https://github.com/eclipse/codewind/issues/2647

## Does this PR require a documentation change ?
included in this PR (see README)

## Any special notes for your reviewer ?
Codecov is failing only because the tests that cover my new code are skipped in Jenkins because they need Git credentials