### PR TITLE
Mustgather remote - pod description & logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Subcommands:</br>
 
 ### mustgather/mg
 
-` --connid <value>` -  Triggers mustgather collection for the remote codewind instance (must have currently configured Kubectl connection)</br>
+` --conid <value>` -  Triggers mustgather collection for the remote codewind connection ID (must have currently configured Kubectl connection)</br>
 `--eclipseWorkspaceDir/-e <value>` - The location of your Eclipse workspace directory if using the Eclipse IDE (default: "")</br>
 `--quiet/-q` - Turn off console messages</br>
 `--projects/-p` - Collect project containers information</br>

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Subcommands:</br>
 
 ### mustgather/mg
 
+` --connid <value>` -  Triggers mustgather collection for the remote codewind instance (must have currently configured Kubectl connection)</br>
 `--eclipseWorkspaceDir/-e <value>` - The location of your Eclipse workspace directory if using the Eclipse IDE (default: "")</br>
 `--quiet/-q` - Turn off console messages</br>
 `--projects/-p` - Collect project containers information</br>

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -1011,6 +1011,7 @@ func Commands() {
 			Aliases: []string{"mg"},
 			Usage:   "Gathers logs and project files to aid diagnosis of Codewind errors",
 			Flags: []cli.Flag{
+				cli.StringFlag{Name: "conid", Value: "local", Usage: "Triggers mustgather collection for the `remote` codewind instance (_must_ have currently configured Kubectl connection!)", Required: false},
 				cli.StringFlag{Name: "eclipseWorkspaceDir, e", Usage: "The location of your Eclipse workspace `directory` if using the Eclipse IDE", Required: false},
 				cli.BoolFlag{Name: "quiet, q", Usage: "Turn off console messages", Required: false},
 				cli.BoolFlag{Name: "projects, p", Usage: "Collect project containers information", Required: false},

--- a/pkg/actions/mustgather.go
+++ b/pkg/actions/mustgather.go
@@ -69,7 +69,7 @@ func MustGatherCommand(c *cli.Context) {
 		if dirErr != nil {
 			errors.CheckErr(dirErr, 205, "")
 		}
-		logMG("Mustgather files will be collected at " + mustGatherDirName)
+		logMG("Mustgather files will be written to " + mustGatherDirName)
 		if c.String("conid") != "local" {
 			mgRemoteCommand(c)
 		} else {

--- a/pkg/remote/deploy.go
+++ b/pkg/remote/deploy.go
@@ -59,7 +59,7 @@ type DeploymentResult struct {
 
 // DeployRemote : InstallRemote
 func DeployRemote(remoteDeployOptions *DeployOptions) (*DeploymentResult, *RemInstError) {
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}

--- a/pkg/remote/deploy_get.go
+++ b/pkg/remote/deploy_get.go
@@ -36,7 +36,7 @@ type K8sAPI struct {
 
 // GetExistingDeployments returns information about the remote installations of codewind, across all namespaces by default
 func GetExistingDeployments(namespace string) ([]ExistingDeployment, *RemInstError) {
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)

--- a/pkg/remote/remove.go
+++ b/pkg/remote/remove.go
@@ -85,7 +85,7 @@ type RemovalResult struct {
 // RemoveRemote : Remove remote install from Kube
 func RemoveRemote(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
 	namespace := remoteRemovalOptions.Namespace
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}
@@ -199,7 +199,7 @@ func RemoveRemote(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult
 // RemoveRemoteKeycloak : Remove remote keycloak install from Kube
 func RemoveRemoteKeycloak(remoteRemovalOptions *RemoveDeploymentOptions) (*RemovalResult, *RemInstError) {
 	namespace := remoteRemovalOptions.Namespace
-	config, err := getKubeConfig()
+	config, err := GetKubeConfig()
 	if err != nil {
 		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
 		return nil, &RemInstError{errOpNotFound, err, err.Error()}

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -69,7 +69,7 @@ func GetImages() (string, string, string, string) {
 }
 
 // Get kubeconfig
-func getKubeConfig() (*rest.Config, error) {
+func GetKubeConfig() (*rest.Config, error) {
 	var config *rest.Config
 	var err error
 


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
This PR allows the mustgather script to collect information (pod description and logs) from the codewind and project Pods of a remote connection.

## Which issue(s) does this PR fix ?

Part of https://github.com/eclipse/codewind/issues/1579

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: 
https://github.com/eclipse/codewind/issues/1579

## Does this PR require a documentation change ?
Yes - in order to use this a Kubectl connection to the remote service must be established (mustgather takes it's kubeconfig from this connection).
Extra flag has been put into the options - `conid`. Full help text:
```
./cwctl.exe help mg
NAME:
   cwctl.exe mustgather - Gathers logs and project files to aid diagnosis of Codewind errors

USAGE:
   cwctl.exe mustgather [command options] [arguments...]

OPTIONS:
   --conid remote                                 Triggers mustgather collection for the remote codewind instance (_must_ have currently configured Kubectl connection!) (default: "local")
   --eclipseWorkspaceDir directory, -e directory  The location of your Eclipse workspace directory if using the Eclipse IDE
   --quiet, -q                                    Turn off console messages
   --projects, -p                                 Collect project containers information
   --nozip, -n                                    Does not create collection zip and leaves individual collected files in place
   --clean                                        Removes the mustgather directory and all its contents from the Codewind home directory

```

## Any special notes for your reviewer ?
