### PR TITLE
2109 - handle performance container not running when finding PFE host and port

### DIFF
--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -210,7 +210,7 @@ func dgSharedCommand(c *cli.Context) {
 
 // Collect Codewind container inspection & logs
 func collectCodewindContainers() {
-	for _, cwContainerName := range docker.ContainerNames {
+	for _, cwContainerName := range docker.LocalCWContainerNames {
 		logDG("Collecting information from container " + cwContainerName)
 		containerID := getContainerID(cwContainerName)
 		writeContainerInspectToFile(containerID, cwContainerName)

--- a/pkg/actions/start.go
+++ b/pkg/actions/start.go
@@ -27,7 +27,7 @@ func StartCommand(c *cli.Context, dockerComposeFile string, healthEndpoint strin
 		os.Exit(1)
 	}
 
-	status, err := docker.CheckContainerStatus(dockerClient)
+	status, err := docker.CheckContainerStatus(dockerClient, docker.LocalCWContainerNames)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)

--- a/pkg/actions/status.go
+++ b/pkg/actions/status.go
@@ -92,7 +92,7 @@ func StatusCommandLocalConnection(c *cli.Context) {
 		os.Exit(1)
 	}
 
-	containersAreRunning, err := docker.CheckContainerStatus(dockerClient)
+	containersAreRunning, err := docker.CheckContainerStatus(dockerClient, docker.LocalCWContainerNames)
 	if err != nil {
 		HandleDockerError(err)
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,7 +29,7 @@ type ConfigError struct {
 
 const errOpConfConNotFound = "config_connection_notfound"
 const errOpConfPFEHostnamePortNotFound = "config_pfe_hostname_port_notfound"
-const textHostnameOrPortNotFound = "Hostname or port for PFE not found"
+const textHostnameOrPortNotFound = "Hostname or port for Codewind containers not found. Make sure they are running."
 
 // ConfigError : Error formatted in JSON containing an errorOp and a description from
 // either a fault condition in the CLI, or an error payload from a REST request

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -403,7 +403,7 @@ func CheckContainerStatus(dockerClient DockerClient, codewindPrefixes []string) 
 				continue
 			}
 			// The container names returned by docker are prefixed with "/"
-			if strings.HasPrefix(container.Names[0], "/"+prefix) {
+			if strings.HasPrefix(container.Names[0], "/" + prefix) {
 				containerCount++
 				break
 			}

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -96,7 +96,15 @@ func TestCheckContainerStatus(t *testing.T) {
 	t.Run("returns true when correct containers are returned by the docker client", func(t *testing.T) {
 		client := &mockDockerClientWithCw{}
 
-		containerStatus, err := CheckContainerStatus(client)
+		containerStatus, err := CheckContainerStatus(client, LocalCWContainerNames)
+		assert.Nil(t, err)
+		assert.True(t, containerStatus)
+	})
+
+	t.Run("returns true when checking for only PFE", func(t *testing.T) {
+		client := &mockDockerClientWithCw{}
+
+		containerStatus, err := CheckContainerStatus(client, []string{PfeContainerName})
 		assert.Nil(t, err)
 		assert.True(t, containerStatus)
 	})
@@ -104,14 +112,14 @@ func TestCheckContainerStatus(t *testing.T) {
 	t.Run("returns false when correct codewind containers are not returned by the docker client", func(t *testing.T) {
 		client := &mockDockerClientWithoutCw{}
 
-		containerStatus, err := CheckContainerStatus(client)
+		containerStatus, err := CheckContainerStatus(client, LocalCWContainerNames)
 		assert.Nil(t, err)
 		assert.False(t, containerStatus)
 	})
 
 	t.Run("returns DockerError when docker ContainerList errors", func(t *testing.T) {
 		client := &mockDockerErrorClient{}
-		_, err := CheckContainerStatus(client)
+		_, err := CheckContainerStatus(client, LocalCWContainerNames)
 		wantErr := &DockerError{errOpContainerList, errContainerList, errContainerList.Error()}
 		assert.Equal(t, wantErr, err)
 	})

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -109,6 +109,14 @@ func TestCheckContainerStatus(t *testing.T) {
 		assert.True(t, containerStatus)
 	})
 
+	t.Run("returns false when checking for all local codewind containers, and only PFE is running", func(t *testing.T) {
+		client := &mockDockerClientWithPFEContainerOnly{}
+
+		containerStatus, err := CheckContainerStatus(client, LocalCWContainerNames)
+		assert.Nil(t, err)
+		assert.False(t, containerStatus)
+	})
+
 	t.Run("returns false when correct codewind containers are not returned by the docker client", func(t *testing.T) {
 		client := &mockDockerClientWithoutCw{}
 
@@ -119,6 +127,7 @@ func TestCheckContainerStatus(t *testing.T) {
 
 	t.Run("returns DockerError when docker ContainerList errors", func(t *testing.T) {
 		client := &mockDockerErrorClient{}
+
 		_, err := CheckContainerStatus(client, LocalCWContainerNames)
 		wantErr := &DockerError{errOpContainerList, errContainerList, errContainerList.Error()}
 		assert.Equal(t, wantErr, err)
@@ -162,6 +171,15 @@ func TestGetContainerTags(t *testing.T) {
 func TestGetPFEHostAndPort(t *testing.T) {
 	t.Run("returns the PFE host and port set in the ContainerList mock", func(t *testing.T) {
 		client := &mockDockerClientWithCw{}
+
+		host, port, err := GetPFEHostAndPort(client)
+		assert.Nil(t, err)
+		assert.Equal(t, "pfe", host)
+		assert.Equal(t, "1000", port)
+	})
+
+	t.Run("returns the PFE host and port when only PFE is running, no performance", func(t *testing.T) {
+		client := &mockDockerClientWithPFEContainerOnly{}
 
 		host, port, err := GetPFEHostAndPort(client)
 		assert.Nil(t, err)

--- a/pkg/docker/fakeclient.go
+++ b/pkg/docker/fakeclient.go
@@ -49,6 +49,14 @@ var mockContainerListWithCwContainers = []types.Container{
 		Image: "eclipse/codewind-performance:0.0.9"},
 }
 
+var mockContainerListWithOnlyPFEContainer = []types.Container{
+	types.Container{
+		Names: []string{"/codewind-pfe"},
+		ID:    "pfe",
+		Image: "eclipse/codewind-pfe:0.0.9",
+		Ports: []types.Port{types.Port{PrivatePort: 9090, PublicPort: 1000, IP: "pfe"}}},
+}
+
 var mockImageSummaryWithoutCwImages = []types.ImageSummary{
 	types.ImageSummary{
 		ID:       "golang",
@@ -137,6 +145,75 @@ func (m *mockDockerClientWithCw) DistributionInspect(ctx context.Context, image,
 }
 
 func (m *mockDockerClientWithCw) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
+}
+
+// This mock client will return container and images lists, with only a PFE container running
+type mockDockerClientWithPFEContainerOnly struct {
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ImagePull(ctx context.Context, image string, imagePullOptions types.ImagePullOptions) (io.ReadCloser, error) {
+	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
+	return r, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ImageList(ctx context.Context, imageListOptions types.ImageListOptions) ([]types.ImageSummary, error) {
+	return mockImageSummaryWithCwImages, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ContainerList(ctx context.Context, containerListOptions types.ContainerListOptions) ([]types.Container, error) {
+	return mockContainerListWithOnlyPFEContainer, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
+	return nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
+	return nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ClientVersion() string {
+	return ""
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
+	return r, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
+	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
+	return r, types.ContainerPathStat{Name: "", Size: 0, Mode: 0, Mtime: time.Now(), LinkTarget: ""}, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ServerVersion(ctx context.Context) (types.Version, error) {
+	return types.Version{Platform: struct{ Name string }{""}, Components: []types.ComponentVersion{}, Version: "", APIVersion: "", MinAPIVersion: "", GitCommit: "", GoVersion: "", Os: "", Arch: "", KernelVersion: "", Experimental: true, BuildTime: ""}, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	return types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			HostConfig: &container.HostConfig{
+				AutoRemove: true,
+			},
+		},
+	}, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) DaemonHost() string {
+	return ""
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
+	return registry.DistributionInspect{
+		Descriptor: v1.Descriptor{
+			Digest: "sha256:7173b809",
+		},
+	}, nil
+}
+
+func (m *mockDockerClientWithPFEContainerOnly) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	return registry.AuthenticateOKBody{}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Modifies the `CheckContainerStatus` function to include an array of prefixes as a param, and then check if a container with each of these prefixes exists. 

This allows us to check for only `PFE` when determining PFE hostname and port (the cause of the associated issue), but to also check for both `PFE` and `performance` in the `start` and `status` commands. 

Adds extra unit testing for these functions with `performance` running and not running.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/2109
