### PR TITLE
Determine project connection dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,24 +223,6 @@ When using a project ID the CLI will automatically detect which connection it re
 > --conid                       Connection ID
 > --startMode                   "run" | "debug" | "debugNoInit"
 
-`connection/con` - Manage the connection targets for a project
-
-`set,s` - Sets the connection for a projectID
-
-> **Flags:**
-> --id,i value Project ID
-> --conid value Connection ID
-
-`get,g` - Gets connections for a projectID
-
-> **Flags:**
-> --id,i value Project ID
-
-`remove,r` - Removes the connection from a projectID
-
-> **Flags:**
-> --id,i value Project ID
-
 ## install
 
 `--tag/-t <value>` - Dockerhub image tag (default: "latest")</br>

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -139,49 +139,6 @@ func Commands() {
 					},
 				},
 				{
-					Name:    "connection",
-					Aliases: []string{"con"},
-					Usage:   "Manage project connections",
-					Subcommands: []cli.Command{
-						{
-							Name:    "set",
-							Aliases: []string{"s"},
-							Usage:   "Set connectionID for a project",
-							Flags: []cli.Flag{
-								cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
-								cli.StringFlag{Name: "conid", Usage: "Connection ID", Required: true},
-							},
-							Action: func(c *cli.Context) error {
-								ProjectSetConnection(c)
-								return nil
-							},
-						},
-						{
-							Name:    "get",
-							Aliases: []string{"g"},
-							Usage:   "Get connectionID for a project",
-							Flags: []cli.Flag{
-								cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
-							},
-							Action: func(c *cli.Context) error {
-								ProjectGetConnection(c)
-								return nil
-							},
-						}, {
-							Name:    "remove",
-							Aliases: []string{"r"},
-							Usage:   "Remove connection from a project",
-							Flags: []cli.Flag{
-								cli.StringFlag{Name: "id,i", Usage: "Project ID", Required: true},
-							},
-							Action: func(c *cli.Context) error {
-								ProjectRemoveConnection(c)
-								return nil
-							},
-						},
-					},
-				},
-				{
 					Name:    "list",
 					Aliases: []string{"ls"},
 					Usage:   "List projects",

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -122,45 +122,6 @@ func UpgradeProjects(c *cli.Context) {
 	os.Exit(0)
 }
 
-// ProjectSetConnection : Set connection for a project
-func ProjectSetConnection(c *cli.Context) {
-	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
-	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	err := project.SetConnection(conID, projectID)
-	if err != nil {
-		HandleProjectError(err)
-		os.Exit(1)
-	}
-	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project target added successfully"})
-	fmt.Println(string(response))
-	os.Exit(0)
-}
-
-// ProjectGetConnection : List connection for a project
-func ProjectGetConnection(c *cli.Context) {
-	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
-	connectionTargets, err := project.GetConnectionID(projectID)
-	if err != nil {
-		HandleProjectError(err)
-		os.Exit(1)
-	}
-	fmt.Println(connectionTargets)
-	os.Exit(0)
-}
-
-// ProjectRemoveConnection : Remove Connection from a project
-func ProjectRemoveConnection(c *cli.Context) {
-	projectID := strings.TrimSpace(strings.ToLower(c.String("id")))
-	err := project.ResetConnectionFile(projectID)
-	if err != nil {
-		HandleProjectError(err)
-		os.Exit(1)
-	}
-	response, _ := json.Marshal(project.Result{Status: "OK", StatusMessage: "Project target removed successfully"})
-	fmt.Println(string(response))
-	os.Exit(0)
-}
-
 // ProjectList : Print the list of projects to the terminal
 func ProjectList(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))

--- a/pkg/project/bind.go
+++ b/pkg/project/bind.go
@@ -103,11 +103,7 @@ func Bind(projectPath string, name string, language string, projectType string, 
 	if projErr != nil {
 		return nil, projErr
 	}
-
 	projectID := projectInfo.ProjectID
-
-	// Generate the .codewind/connections/{projectID}.json file based on the given conID
-	SetConnection(conID, projectID)
 
 	// Sync all the project files
 	syncInfo, syncErr := syncFiles(&http.Client{}, projectPath, projectID, conURL, 0, conInfo)

--- a/pkg/project/projectConnection.go
+++ b/pkg/project/projectConnection.go
@@ -12,117 +12,49 @@
 package project
 
 import (
-	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"runtime"
-	"strings"
 
+	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
 )
 
-// ConnectionFile : Structure of the project-connections file
-type ConnectionFile struct {
-	SchemaVersion int    `json:"schemaVersion"`
-	ID            string `json:"connectionID"`
-}
-
-const connectionTargetSchemaVersion = 1
-
-// SetConnection : Add a connection target
-func SetConnection(conID string, projectID string) *ProjectError {
-
-	connection, conErr := connections.GetConnectionByID(conID)
-	if conErr != nil || connection == nil {
-		projError := errors.New("Connection unknown")
-		return &ProjectError{"con_not_found", projError, projError.Error()}
-	}
-
-	// Check if projectID is supplied in correct format
-	if !IsProjectIDValid(projectID) {
-		projError := errors.New(textInvalidProjectID)
-		return &ProjectError{errOpInvalidID, projError, projError.Error()}
-	}
-
-	connectionTargets, projError := loadConnectionFile(projectID)
-	if projError != nil && connectionTargets == nil {
-		err := CreateConnectionFile(projectID)
-		if err != nil {
-			return err
-		}
-	}
-
-	connectionTargets, _ = loadConnectionFile(projectID)
-	connectionTargets.ID = conID
-
-	// Save the project-connections file
-	projError = saveConnectionTargets(projectID, connectionTargets)
-	if projError != nil {
-		return projError
-	}
-	return nil
-}
-
-// ResetConnectionFile : Reset target file
-func ResetConnectionFile(projectID string) *ProjectError {
-	connectionTargets := ConnectionFile{
-		SchemaVersion: connectionTargetSchemaVersion,
-		ID:            "local",
-	}
-	projError := saveConnectionTargets(projectID, &connectionTargets)
-	if projError != nil {
-		return projError
-	}
-	return nil
-}
-
-// GetConnection : List the connection for a projectID
-func GetConnection(projectID string) (*ConnectionFile, *ProjectError) {
-	connectionTargets, projErr := loadConnectionFile(projectID)
-	if projErr != nil {
-		return nil, projErr
-	}
-	return connectionTargets, nil
-}
-
 // GetConnectionID : Gets the the connectionID for a given projectID
 func GetConnectionID(projectID string) (string, *ProjectError) {
-	connection, err := GetConnection(projectID)
-	if err != nil {
-		return "", err
-	}
-	var conID string
-	if connection.ID != "" {
-		conID = connection.ID
-	} else {
-		projError := errors.New("Connection not found for project " + projectID)
+	projError := errors.New("Connection not found for project " + projectID)
+	allConnections, conErr := connections.GetConnectionsConfig()
+	if conErr != nil {
 		return "", &ProjectError{errOpConNotFound, projError, projError.Error()}
 	}
-	return conID, nil
-}
 
-// ConnectionFileExists : Returns true if connection file exists for the projectID
-func ConnectionFileExists(projectID string) bool {
-	info, err := os.Stat(getConnectionFilename(projectID))
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
-}
+	for i := 0; i < len(allConnections.Connections); i++ {
+		currentConID := allConnections.Connections[i].ID
 
-// CreateConnectionFile : Creates the /connections/{project_id}.json file if one doesn't exist, with default local connection
-func CreateConnectionFile(projectID string) *ProjectError {
-	_, err := os.Stat(getConnectionFilename(projectID))
-	if os.IsNotExist(err) {
-		os.MkdirAll(getProjectConnectionConfigDir(), 0777)
-		resetFileError := ResetConnectionFile(projectID)
-		if resetFileError != nil {
-			return resetFileError
+		conInfo, conInfoErr := connections.GetConnectionByID(currentConID)
+		if conInfoErr != nil {
+			return "", &ProjectError{errOpConNotFound, projError, projError.Error()}
+		}
+
+		conURL, conErr := config.PFEOriginFromConnection(conInfo)
+		if conErr != nil {
+			return "", &ProjectError{errOpConNotFound, projError, projError.Error()}
+		}
+
+		projects, getAllErr := GetAll(http.DefaultClient, conInfo, conURL)
+		if getAllErr != nil {
+			return "", &ProjectError{errOpConNotFound, projError, projError.Error()}
+		}
+		for _, project := range projects {
+			if project.ProjectID == projectID {
+				return currentConID, nil
+			}
 		}
 	}
-	return nil
+	// We haven't found the project on any connection so return an error
+	return "", &ProjectError{errOpConNotFound, projError, projError.Error()}
 }
 
 // RemoveConnectionFile : Remove the connection file for a project
@@ -161,36 +93,4 @@ func getProjectConnectionConfigDir() string {
 // getConnectionFilename : Get full file path of connection file
 func getConnectionFilename(projectID string) string {
 	return path.Join(getProjectConnectionConfigDir(), projectID+".json")
-}
-
-// saveConnectionTargets : Write the targets file in JSON format
-func saveConnectionTargets(projectID string, connectionTargets *ConnectionFile) *ProjectError {
-	body, err := json.MarshalIndent(connectionTargets, "", "\t")
-	if err != nil {
-		return &ProjectError{errOpFileParse, err, err.Error()}
-	}
-	projError := ioutil.WriteFile(getConnectionFilename(projectID), body, 0644)
-	if projError != nil {
-		return &ProjectError{errOpFileWrite, projError, projError.Error()}
-	}
-	return nil
-}
-
-// loadConnectionFile :  Loads the connection file for a project
-func loadConnectionFile(projectID string) (*ConnectionFile, *ProjectError) {
-	projectID = strings.ToLower(projectID)
-	filePath := getConnectionFilename(projectID)
-	file, err := ioutil.ReadFile(filePath)
-
-	if err != nil {
-		return nil, &ProjectError{errOpFileLoad, err, err.Error()}
-	}
-
-	// parse the file
-	projectConnectionTargets := ConnectionFile{}
-	err = json.Unmarshal([]byte(file), &projectConnectionTargets)
-	if err != nil {
-		return nil, &ProjectError{errOpFileParse, err, err.Error()}
-	}
-	return &projectConnectionTargets, nil
 }

--- a/pkg/project/projectConnection_test.go
+++ b/pkg/project/projectConnection_test.go
@@ -12,134 +12,22 @@
 package project
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"testing"
 
-	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/stretchr/testify/assert"
 )
 
-const testProjectID = "a9384430-f177-11e9-b862-edc28aca827a"
-const testConnectionID = "testCon"
-const testHost = "http://test-host"
-const schemaVersion = 1
-
-func WriteNewConfigFile() error {
-	connectionsFile := connections.ConnectionConfig{
-		SchemaVersion: schemaVersion,
-		Connections: []connections.Connection{
-			connections.Connection{
-				ID:       "local",
-				Label:    "Codewind local connection",
-				URL:      "",
-				AuthURL:  "",
-				Realm:    "",
-				ClientID: "",
-			},
-			connections.Connection{
-				ID:       "testCon",
-				Label:    "Test remote connection",
-				URL:      testHost,
-				AuthURL:  "",
-				Realm:    "",
-				ClientID: "",
-			},
-		},
-	}
-	body, err := json.MarshalIndent(connectionsFile, "", "\t")
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(connections.GetConnectionConfigFilename(), body, 0644)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // Test_ProjectConnection :  Tests
 func Test_ProjectConnection(t *testing.T) {
-	WriteNewConfigFile()
-
 	if testing.Short() {
 		t.Skip("skipping testing in short mode")
 	}
 
-	t.Run("Asserts project connection file doesn't exist", func(t *testing.T) {
-		connectionExists := ConnectionFileExists(testProjectID)
-		assert.Equal(t, false, connectionExists)
-	})
-
-	t.Run("Asserts setting a default connection file doesn't fail", func(t *testing.T) {
-		projError := CreateConnectionFile(testProjectID)
+	t.Run("Asserts no connectionID is found for non-existant project", func(t *testing.T) {
+		connectionID, projError := GetConnectionID("1234-abcd")
 		if projError != nil {
 			t.Fail()
 		}
+		assert.Equal(t, "", connectionID)
 	})
-
-	t.Run("Asserts project connection file exists", func(t *testing.T) {
-		connectionExists := ConnectionFileExists(testProjectID)
-		assert.Equal(t, true, connectionExists)
-	})
-
-	t.Run("Asserts project defaults to local connection", func(t *testing.T) {
-		connection, projError := GetConnection(testProjectID)
-		if projError != nil {
-			t.Fail()
-		}
-		assert.Equal(t, "local", connection.ID)
-	})
-
-	t.Run("Asserts a new connectionID can be set", func(t *testing.T) {
-		projError := SetConnection(testConnectionID, testProjectID)
-		if projError != nil {
-			t.Fail()
-		}
-	})
-
-	t.Run("Asserts the correct connection has been added", func(t *testing.T) {
-		connection, projError := GetConnection(testProjectID)
-		if projError != nil {
-			t.Fail()
-		}
-		assert.Equal(t, testConnectionID, connection.ID)
-	})
-
-	t.Run("Asserts resetting the connection is successful", func(t *testing.T) {
-		projError := ResetConnectionFile(testProjectID)
-		if projError != nil {
-			t.Fail()
-		}
-	})
-
-	t.Run("Asserts connection is reset to local", func(t *testing.T) {
-		connection, projError := GetConnection(testProjectID)
-		if projError != nil {
-			t.Fail()
-		}
-		assert.Equal(t, "local", connection.ID)
-	})
-
-	t.Run("Asserts attempting to set an invalid project ID fails", func(t *testing.T) {
-		projError := SetConnection(testConnectionID, "bad-project-ID")
-		if projError == nil {
-			t.Fail()
-		}
-		assert.Equal(t, errOpInvalidID, projError.Op)
-	})
-
-	t.Run("Asserts the connection file can be removed", func(t *testing.T) {
-		projError := RemoveConnectionFile(testProjectID)
-		if projError != nil {
-			t.Fail()
-		}
-	})
-
-	t.Run("Asserts the connection file has been removed", func(t *testing.T) {
-		connectionExists := ConnectionFileExists(testProjectID)
-		assert.Equal(t, false, connectionExists)
-	})
-	connections.ResetConnectionsFile()
 }

--- a/pkg/project/remove.go
+++ b/pkg/project/remove.go
@@ -59,10 +59,8 @@ func RemoveProject(c *cli.Context) *ProjectError {
 	}
 
 	// Delete the associated connection file
-	projError = RemoveConnectionFile(projectID)
-	if projError != nil {
-		return projError
-	}
+	// We can ignore errors as we are no longer creating this file
+	RemoveConnectionFile(projectID)
 
 	// Delete the source if the flag is set
 	if deleteFiles {

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -98,11 +98,6 @@ func SyncProject(c *cli.Context) (*SyncResponse, *ProjectError) {
 	projectID := strings.TrimSpace(c.String("id"))
 	synctime := int64(c.Int("time"))
 
-	if !ConnectionFileExists(projectID) {
-		fmt.Println("Project connection file does not exist, creating default local connection")
-		CreateConnectionFile(projectID)
-	}
-
 	conID, projErr := GetConnectionID(projectID)
 
 	if projErr != nil {


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR changes the way we determine the connectionID for a project. This information is currently stored in a file but this can become out of date if the user removes and then recreates a remote connection. In this scenario, calls to project remove and project sync will fail. 

The change is to determine the connectionID for a given projectID by finding the projects for each connection and searching to find the ID. 

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/1782

## Does this PR require a documentation change ?
README has been updated to remove obsolete commands.

## Any special notes for your reviewer ?
