### PR TITLE
feat: 2647.4 add secure template repos via PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,9 @@ Subcommands:</br>
 > --url - URL to template repository index.json
 > --name - Custom name for template repository
 > --description - Custom description for template repository
-> --username - GitHub username (required if accessing the provided URL requires GitHub authentication)
-> --password - GitHub password (required if accessing the provided URL requires GitHub authentication)
+> --username - GitHub username (required if accessing the provided URL requires GitHub authentication and you do not provide --personalAccessToken)
+> --password - GitHub password (required if accessing the provided URL requires GitHub authentication and you do not provide --personalAccessToken)
+> --personalAccessToken - GitHub personal access token (required if accessing the provided URL requires GitHub authentication and you do not provide --username and --password)
 
 ### version
 

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -152,9 +152,9 @@ func testCreateProjectFromTemplate(t *testing.T) {
 			"--username="+test.GHEUsername,
 			"--password=badpassword",
 		)
-		out, err := cmd.Output()
+		out, err := cmd.CombinedOutput()
 		assert.NotNil(t, err)
-		assert.Equal(t, "", string(out))
+		assert.Contains(t, string(out), "401 Unauthorized")
 	})
 }
 
@@ -193,7 +193,7 @@ func testSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 		assert.Nil(t, removeErr)
 		assert.NotContains(t, string(removeOut), test.PublicGHDevfileURL)
 	})
-	t.Run("cwctl templates repos add --url <GHEDevfile>"+
+	t.Run("cwctl templates repos add --url <GHEDevfile> --username --password"+
 		"\n then cwctl templates repos remove --url", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -526,6 +526,11 @@ func Commands() {
 									Usage:    "GitHub password",
 									Required: false,
 								},
+								cli.StringFlag{
+									Name:     "personalAccessToken",
+									Usage:    "GitHub personal access token",
+									Required: false,
+								},
 							},
 							Action: func(c *cli.Context) error {
 								AddTemplateRepo(c)

--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -70,11 +70,15 @@ func AddTemplateRepo(c *cli.Context) {
 	name := c.String("name")
 	username := c.String("username")
 	password := c.String("password")
+	personalAccessToken := c.String("personalAccessToken")
 
-	gitCredentials := utils.GitCredentials{
-		Username: username,
-		Password: password,
+	gitCredentials, err := utils.ExtractGitCredentials(username, password, personalAccessToken)
+	if err != nil {
+		templateErr := &TemplateError{errOpAddRepo, err, err.Error()}
+		HandleTemplateError(templateErr)
+		return
 	}
+
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	repos, err := apiroutes.AddTemplateRepo(conID, url, desc, name, gitCredentials)
 	if err != nil {

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -41,10 +41,10 @@ type (
 
 	// RepoCreationOptions is the request body for PFE's POST /templates/repositories API
 	RepoCreationOptions struct {
-		URL            string               `json:"url"`
-		Description    string               `json:"description"`
-		Name           string               `json:"name"`
-		GitCredentials utils.GitCredentials `json:"gitCredentials"`
+		URL            string                `json:"url,omitempty"`
+		Description    string                `json:"description,omitempty"`
+		Name           string                `json:"name,omitempty"`
+		GitCredentials *utils.GitCredentials `json:"gitCredentials,omitempty"`
 	}
 
 	// RepoOperation represents a requested operation on a template repository.
@@ -187,7 +187,7 @@ func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
 
 // AddTemplateRepo adds a template repo to PFE and
 // returns the new list of existing repos
-func AddTemplateRepo(conID, URL, description, name string, gitCredentials utils.GitCredentials) ([]utils.TemplateRepo, error) {
+func AddTemplateRepo(conID, URL, description, name string, gitCredentials *utils.GitCredentials) ([]utils.TemplateRepo, error) {
 	if _, err := url.ParseRequestURI(URL); err != nil {
 		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
 	}

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -168,7 +168,7 @@ func TestFailuresAddTemplateRepo(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := AddTemplateRepo("local", test.inURL, test.inDescription, "template-name", utils.GitCredentials{})
+			got, err := AddTemplateRepo("local", test.inURL, test.inDescription, "template-name", nil)
 			assert.IsType(t, test.wantedType, got, "got: %v", got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -206,18 +206,24 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 	tests := map[string]struct {
 		skip             bool
 		inURL            string
-		inGitCredentials utils.GitCredentials
+		inGitCredentials *utils.GitCredentials
 	}{
-		"PublicGHDevFileURL": {
-			inURL:            cwTest.PublicGHDevfileURL,
-			inGitCredentials: utils.GitCredentials{},
+		"public GH devfile URL": {
+			inURL: cwTest.PublicGHDevfileURL,
 		},
-		"GHEDevfileURL": {
+		"GHE devfile URL with GHE basic credentials": {
 			skip:  !cwTest.UsingOwnGHECredentials,
 			inURL: cwTest.GHEDevfileURL,
-			inGitCredentials: utils.GitCredentials{
+			inGitCredentials: &utils.GitCredentials{
 				Username: test.GHEUsername,
 				Password: test.GHEPassword,
+			},
+		},
+		"GHE devfile URL with GHE personal access token": {
+			skip:  !cwTest.UsingOwnGHECredentials,
+			inURL: cwTest.GHEDevfileURL,
+			inGitCredentials: &utils.GitCredentials{
+				PersonalAccessToken: test.GHEPersonalAccessToken,
 			},
 		},
 	}

--- a/pkg/test/globals.go
+++ b/pkg/test/globals.go
@@ -29,5 +29,8 @@ const GHEUsername = "INSERT YOUR OWN: e.g. foo.bar@foobar.com"
 // GHEPassword is a password that passes the auth required to access a GHERepoURL
 const GHEPassword = "INSERT YOUR OWN: e.g. 1234kljfdsjfaleru29348spodkfj445"
 
+// GHEPersonalAccessToken is a personal access token that passes the auth required to access a GHERepoURL
+const GHEPersonalAccessToken = "INSERT YOUR OWN"
+
 // UsingOwnGHECredentials should be set to true if you want to run tests using the credentials above
 const UsingOwnGHECredentials = false

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -28,8 +28,9 @@ import (
 type (
 	// GitCredentials : credentials to access GitHub or GitHubEnterprise
 	GitCredentials struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
+		Username            string `json:"username,omitempty"`
+		Password            string `json:"password,omitempty"`
+		PersonalAccessToken string `json:"personalAccessToken,omitempty"`
 	}
 )
 

--- a/pkg/utils/templates.go
+++ b/pkg/utils/templates.go
@@ -11,6 +11,8 @@
 
 package utils
 
+import "fmt"
+
 type (
 	// TemplateRepo represents a template repository.
 	TemplateRepo struct {
@@ -101,4 +103,29 @@ func OnDeleteTemplateRepo(extensions []Extension, url string, repos []TemplateRe
 			break
 		}
 	}
+}
+
+// ExtractGitCredentials extracts and formats git credentials from the provided arguments
+func ExtractGitCredentials(username, password, personalAccessToken string) (*GitCredentials, error) {
+	if personalAccessToken != "" && (username != "" || password != "") {
+		return nil, fmt.Errorf("received credentials for multiple authentication methods")
+	}
+	if username != "" && password == "" {
+		return nil, fmt.Errorf("received username but no password")
+	}
+	if password != "" && username == "" {
+		return nil, fmt.Errorf("received password but no username")
+	}
+	if username != "" && password != "" {
+		return &GitCredentials{
+			Username: username,
+			Password: password,
+		}, nil
+	}
+	if personalAccessToken != "" {
+		return &GitCredentials{
+			PersonalAccessToken: personalAccessToken,
+		}, nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Extends https://github.com/eclipse/codewind-installer/pull/443 so `cwctl templates repos add` can pass personal access tokens to PFE, which PFE will know how to handle when https://github.com/eclipse/codewind/pull/2762 is merged

Adds flag validation requested in https://github.com/eclipse/codewind-installer/pull/443#discussion_r416515661

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2647

## Does this PR require a documentation change ?
Included

## Any special notes for your reviewer ?
