### PR TITLE
add details of the time units in sync params

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Subcommands:</br>
 > **Flags:**
 > --path,-p value Project Path
 > --id,-i value Project ID
-> --time,-t value Time of last project sync
+> --time,-t value UNIX timestamp of the last sync for the given project, in milliseconds
 
 `list` - List projects bound to a Codewind deployment
 > **Flags**

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -131,7 +131,7 @@ func Commands() {
 					Flags: []cli.Flag{
 						cli.StringFlag{Name: "path, p", Usage: "the path to the project", Required: true},
 						cli.StringFlag{Name: "id, i", Usage: "the project id", Required: true},
-						cli.StringFlag{Name: "time, t", Usage: "time of the last sync for the given project", Required: true},
+						cli.StringFlag{Name: "time, t", Usage: "UNIX timestamp of the last sync for the given project, in milliseconds", Required: true},
 					},
 					Action: func(c *cli.Context) error {
 						ProjectSync(c)


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What does this PR do ?

Gives details of the units of time for the `sync` command. 

I found myself having to look up in the code what these were and thought it would make sense to document in the README and command instructions.