### PR TITLE
Remove unneccessary local port mapping for the performance container.

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -86,7 +86,6 @@ services:
   secrets: [dockerconfig]
  ` + PerformanceContainerName + `:
   image: ${PERFORMANCE_IMAGE_NAME}${PLATFORM}:${TAG}
-  ports: ["127.0.0.1:9095:9095"]
   container_name: codewind-performance
   networks: [network]
 networks:
@@ -403,7 +402,7 @@ func CheckContainerStatus(dockerClient DockerClient, codewindPrefixes []string) 
 				continue
 			}
 			// The container names returned by docker are prefixed with "/"
-			if strings.HasPrefix(container.Names[0], "/" + prefix) {
+			if strings.HasPrefix(container.Names[0], "/"+prefix) {
 				containerCount++
 				break
 			}


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This port removes the unneccessary local port mapping for the performance container.
All access to the performance container is via a proxy on codewind-pfe on `/performance` so it can be removed.
If another process on the machine was already using port 9095 then the performance container could fail to start.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2830

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
This does not affect kubernetes, ports on pods are exposed separately. This PR only changes the generated docker-compose file.