### PR TITLE
point to correct version for 0.12.0

### DIFF
--- a/pkg/appconstants/version.go
+++ b/pkg/appconstants/version.go
@@ -12,4 +12,4 @@
 package appconstants
 
 // VersionNum : CLI Version number
-const VersionNum = "x.x.dev"
+const VersionNum = "0.12.0"

--- a/pkg/remote/defaults.go
+++ b/pkg/remote/defaults.go
@@ -42,16 +42,16 @@ const (
 	GatekeeperImage = "eclipse/codewind-gatekeeper-amd64"
 
 	// PFEImageTag is the image tag associated with the docker image that's used for Codewind-PFE
-	PFEImageTag = "latest"
+	PFEImageTag = "0.12.0"
 
 	// PerformanceTag is the image tag associated with the docker image that's used for the Performance dashboard
-	PerformanceTag = "latest"
+	PerformanceTag = "0.12.0"
 
 	// KeycloakImageTag is the image tag associated with the docker image that's used for Codewind-Keycloak
-	KeycloakImageTag = "latest"
+	KeycloakImageTag = "0.12.0"
 
 	// GatekeeperImageTag is the image tag associated with the docker image that's used for Codewind-Gatekeeper
-	GatekeeperImageTag = "latest"
+	GatekeeperImageTag = "0.12.0"
 
 	// ImagePullPolicy is the pull policy used for all containers in Codewind, defaults to Always
 	ImagePullPolicy = corev1.PullAlways


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

## What type of PR is this ? 

- [x ] Bug fix
- [ ] Enhancement

## What does this PR do ?
Changes the image versions to be pulled from latest (dev) to 0.12.0 for release

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2831


## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No
