### PR TITLE
Skip connections that are not active

### DIFF
--- a/pkg/project/projectConnection.go
+++ b/pkg/project/projectConnection.go
@@ -39,12 +39,14 @@ func GetConnectionID(projectID string) (string, *ProjectError) {
 
 		conURL, conErr := config.PFEOriginFromConnection(conInfo)
 		if conErr != nil {
-			return "", &ProjectError{errOpConNotFound, conErr, conErr.Error()}
+			// Skip the connection if it's not running (local will error here)
+			continue
 		}
 
 		projects, getAllErr := GetAll(http.DefaultClient, conInfo, conURL)
 		if getAllErr != nil {
-			return "", &ProjectError{errOpConNotFound, getAllErr, getAllErr.Error()}
+			// Skip the connection if it's not running (remote will error here)
+			continue
 		}
 
 		for _, project := range projects {
@@ -53,8 +55,8 @@ func GetConnectionID(projectID string) (string, *ProjectError) {
 			}
 		}
 	}
-	// We haven't found the project on any connection so return an error
-	projError := errors.New("Connection not found for project " + projectID)
+	// We haven't found the project on any active connection so return an error
+	projError := errors.New("Active connection not found for project " + projectID)
 	return "", &ProjectError{errOpConNotFound, projError, projError.Error()}
 }
 


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes a problem with GetConnectionID for a project when 1 or more of a users connections are not active. Errors that occur when a local/remote connection is not active are ignored when searching for the connection for a project.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2807

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
