### PR TITLE
Support gathering for all connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Subcommands:</br>
 `--eclipseWorkspaceDir/-e <value>` - The location of your Eclipse workspace directory if using the Eclipse IDE (default: "")</br>
 `--intellijLogsDir/-i <value>` - The location of your IntelliJ logs directory if using the IntelliJ IDE (default: "")</br>
 `--quiet/-q` - Turn off console messages</br>
+`--all/-a` - Collects diagnostics for all defined connections, remote and local</br>
 `--projects/-p` - Collect project containers information</br>
 `--nozip/-n` - Does not create collection zip and leaves individual collected files in place</br>
 `--clean` - Removes the diagnostics directory and all its contents from the Codewind home directory

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -982,6 +982,7 @@ func Commands() {
 				cli.StringFlag{Name: "eclipseWorkspaceDir, e", Usage: "The location of your Eclipse workspace `directory` if using the Eclipse IDE", Required: false},
 				cli.StringFlag{Name: "intellijLogsDir, i", Usage: "The location of your IntelliJ logs `directory` if using the IntelliJ IDE", Required: false},
 				cli.BoolFlag{Name: "quiet, q", Usage: "Turn off console messages", Required: false},
+				cli.BoolFlag{Name: "all, a", Usage: "Collects diagnostics for all defined connections, remote and local", Required: false},
 				cli.BoolFlag{Name: "projects, p", Usage: "Collect project containers information", Required: false},
 				cli.BoolFlag{Name: "nozip, n", Usage: "Does not create collection zip and leaves individual collected files in place", Required: false},
 				cli.BoolFlag{Name: "clean", Usage: "Removes the diagnostics directory and all its contents from the Codewind home directory", Required: false},

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -109,12 +109,6 @@ func DiagnosticsCommand(c *cli.Context) {
 		}
 		logDG("done\n")
 	} else {
-		if c.GlobalBool("json") {
-			jsonOutput = true
-		}
-		if c.Bool("quiet") || jsonOutput {
-			isLoud = false
-		}
 		dirErr := os.MkdirAll(diagnosticsDirName, 0755)
 		if dirErr != nil {
 			errors.CheckErr(dirErr, 205, "")
@@ -149,19 +143,19 @@ func dgRemoteCommand(c *cli.Context) {
 	}
 	existingDeployments, edErr := remote.GetExistingDeployments("")
 	if edErr != nil {
-		errDG("existing_deployment_error", edErr.Error())
+		errDG("existing_deployment_error", "Unable to get existing deployments "+edErr.Error())
 		mkWorkspaceDir = false
 		exitDGUnlessAll()
 	}
 	config, err := remote.GetKubeConfig()
 	if err != nil {
-		errDG("kube_config_error", err.Error())
+		errDG("kube_config_error", "Unable to retrieve Kubernetes Config: "+err.Error())
 		mkWorkspaceDir = false
 		exitDGUnlessAll()
 	}
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		errDG("kube_client_error", err.Error())
+		errDG("kube_client_error", "Unable to retrieve Kubernetes clientset: "+err.Error())
 		mkWorkspaceDir = false
 		exitDGUnlessAll()
 	}


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
This PR supports the gathering of diagnostics for all defined connections in one go. It modifies the errDG() function to store errors in an array rather than just outputting JSON, to avoid multiple JSON objects being emitted. The exitDGUnlessAll() function allows diagnostics collecting to continue with another connection rather than letting an erroring connection to exit. The dgRemote command has been altered to deal with an array of connections rather than a single one, and now separates out collected files into separate folders named after the workspaceID. The dgLocal command also now stores its gathered files into a "local" folder. Finally, all handling of Docker and Kube errors has been changed to use local errDG and exitDGUnlessAll functions, as the existing ones output JSON objects and needed to exit straightaway.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2767
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2767
## Does this PR require a documentation change ?
Yes, addition of `--all/-a` parameter (see README)

## Any special notes for your reviewer ?
Please test on mac