### PR TITLE
diagnostics: output correct versions for remote connection

### DIFF
--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -464,6 +464,7 @@ func createZipAndRemoveCollectedFiles() {
 func gatherCodewindVersions(connectionID string) {
 	logDG("Collecting version information ... ")
 	containerVersions, cvErr := GetContainerVersions(connectionID)
+	errorString := ""
 	if cvErr != nil {
 		if strings.Contains(cvErr.Error(), "certificate signed by unknown authority") {
 			warnDG("Problems getting Codewind container versions - please run command again specifying global option '--insecure'", cvErr.Error())
@@ -471,17 +472,18 @@ func gatherCodewindVersions(connectionID string) {
 			//just log and continue; version file will have "Unknown" values
 			warnDG("Problems getting Codewind container versions", cvErr.Error())
 		}
+		errorString = cvErr.Error()
 	}
 	versionsByteArray := []byte(
-		"CWCTL VERSION: " + containerVersions.CwctlVersion + "\n" +
-			"PFE VERSION: " + containerVersions.PFEVersion + "\n" +
-			"PERFORMANCE VERSION: " + containerVersions.PerformanceVersion)
+		"CWCTL VERSION: " + containerVersions.CwctlVersion + errorString + "\n" +
+			"PFE VERSION: " + containerVersions.PFEVersion + errorString + "\n" +
+			"PERFORMANCE VERSION: " + containerVersions.PerformanceVersion + errorString)
 	if connectionID != "local" {
 		versionsByteArray = []byte(
-			"CWCTL VERSION: " + containerVersions.CwctlVersion + "\n" +
-				"PFE VERSION: " + containerVersions.PFEVersion + "\n" +
-				"PERFORMANCE VERSION: " + containerVersions.PerformanceVersion + "\n" +
-				"GATEKEEPER VERSION: " + containerVersions.GatekeeperVersion)
+			"CWCTL VERSION: " + containerVersions.CwctlVersion + errorString + "\n" +
+				"PFE VERSION: " + containerVersions.PFEVersion + errorString + "\n" +
+				"PERFORMANCE VERSION: " + containerVersions.PerformanceVersion + errorString + "\n" +
+				"GATEKEEPER VERSION: " + containerVersions.GatekeeperVersion + errorString)
 	}
 	versionsErr := ioutil.WriteFile(filepath.Join(diagnosticsDirName, "codewind.versions"), versionsByteArray, 0644)
 	if versionsErr != nil {

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -183,6 +183,9 @@ func dgRemoteCommand(c *cli.Context) {
 		}
 		collectPodInfo(clientset, cwProjPods.Items)
 	}
+
+	// Collect codewind versions
+	gatherCodewindVersions(connectionID)
 }
 
 func collectPodInfo(clientset *kubernetes.Clientset, podArray []corev1.Pod) {
@@ -194,9 +197,6 @@ func collectPodInfo(clientset *kubernetes.Clientset, podArray []corev1.Pod) {
 		writePodLogToFile(clientset, pod, podName)
 		logDG("done\n")
 	}
-
-	// Collect codewind versions
-	gatherCodewindVersions(connectionID)
 }
 
 func writePodLogToFile(clientset *kubernetes.Clientset, pod corev1.Pod, podName string) error {

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -66,7 +66,7 @@ func GetSingleConnectionVersion(c *cli.Context) {
 // GetContainerVersions : Gets the cwctl and container versions for a single connection
 func GetContainerVersions(connectionID string) (apiroutes.ContainerVersions, error) {
 	// dummy ContainerVersions to send back if there is an error
-	errorVersions := apiroutes.ContainerVersions{CwctlVersion: "Unknown", PerformanceVersion: "Unknown", GatekeeperVersion: "Unknown", PFEVersion: "Unknown"}
+	errorVersions := apiroutes.ContainerVersions{CwctlVersion: "Unable to determine version - ", PerformanceVersion: "Unable to determine version - ", GatekeeperVersion: "Unable to determine version - ", PFEVersion: "Unable to determine version - "}
 	conInfo, conInfoErr := connections.GetConnectionByID(connectionID)
 	if conInfoErr != nil {
 		return errorVersions, conInfoErr


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
This PR allows the `diagnostics` tool to get the correct versions for remote containers. The gatherCodewindVersions() function now takes a connectionID so that it can be passed to the existing GetContainerVersions() method to allow version retrieval for both remote and local connections. The additional GATEKEEPER version has been added to codewind.versions file for remote connections, and extra error handling has been put in so that end users will be able to clearly see why version information is not present if there has been a problem obtaining it.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2798
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2798
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
