### PR TITLE
Don't include fake docker clients in codecov stats

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
     patch:
       default:
         enabled: no
+
+ignore:
+  - "pkg/docker/fakeclient"


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Ignores mock docker clients in code-cov report.

Complete coverage of this file requires tests for each function attached to each mock Docker client, which can lead to duplication and noise in the tests. Many of these functions are added to satisfy the DockerClient interface requirements.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2829
