### PR TITLE
Collect Docker Client/Server versions for local diagnostics

### DIFF
--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -532,14 +532,14 @@ func gatherCodewindVersions(connectionID string) {
 func getDockerVersions() (clientVersion, serverVersion string) {
 	dockerClient, dockerErr := docker.NewDockerClient()
 	if dockerErr != nil {
-		HandleDockerError(dockerErr)
-		os.Exit(1)
+		warnDG("Problems getting docker client", dockerErr.Error())
+		return "Unknown", "Unknown"
 	}
 	dockerClientVersion := docker.GetClientVersion(dockerClient)
 	dockerServerVersion, gsvErr := docker.GetServerVersion(dockerClient)
 	if gsvErr != nil {
-		HandleDockerError(gsvErr)
-		os.Exit(1)
+		warnDG("Problems getting docker server version", gsvErr.Error())
+		return dockerClientVersion, "Unknown"
 	}
 	return dockerClientVersion, dockerServerVersion.Version
 }

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -495,7 +495,11 @@ func createZipAndRemoveCollectedFiles() {
 
 func gatherCodewindVersions(connectionID string) {
 	logDG("Collecting version information ... ")
-	dockerClientVersion, dockerServerVersion := getDockerVersions()
+	dockerClientVersion := ""
+	dockerServerVersion := ""
+	if connectionID == "local" {
+		dockerClientVersion, dockerServerVersion = getDockerVersions()
+	}
 	containerVersions, cvErr := GetContainerVersions(connectionID)
 	errorString := ""
 	if cvErr != nil {
@@ -533,13 +537,13 @@ func getDockerVersions() (clientVersion, serverVersion string) {
 	dockerClient, dockerErr := docker.NewDockerClient()
 	if dockerErr != nil {
 		warnDG("Problems getting docker client", dockerErr.Error())
-		return "Unknown", "Unknown"
+		return "Unable to determine version - " + dockerErr.Error(), "Unable to determine version - " + dockerErr.Error()
 	}
 	dockerClientVersion := docker.GetClientVersion(dockerClient)
 	dockerServerVersion, gsvErr := docker.GetServerVersion(dockerClient)
 	if gsvErr != nil {
 		warnDG("Problems getting docker server version", gsvErr.Error())
-		return dockerClientVersion, "Unknown"
+		return dockerClientVersion, "Unable to determine version - " + gsvErr.Error()
 	}
 	return dockerClientVersion, dockerServerVersion.Version
 }


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
This PR enables the Docker Client & Server version strings to be written to the codewind.versions file created by running `cwctl diagnostics` for a local connection. The version strings are obtained using the docker client's getClientVersion() and getServerVersion() methods.

## Which issue(s) does this PR fix ?
Part fix for https://github.com/eclipse/codewind/issues/2793
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2793
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
