### PR TITLE
Project Create returns Validate status; download result trace only

### DIFF
--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -56,30 +56,13 @@ func ProjectCreate(c *cli.Context) {
 		HandleProjectError(err)
 		os.Exit(1)
 	}
-
-	if !printAsJSON {
+	if printAsJSON {
+		jsonResponse, _ := json.Marshal(result)
+		logr.Tracef(string(jsonResponse)) // won't result in multiple JSON object output unless tracing
+	} else {
 		logr.Tracef("Project downloaded to %v", destination)
 	}
-	// validate the new project
-	response, projectErr := project.ValidateProject(c)
-	if projectErr != nil {
-		fmt.Println(projectErr.Error())
-		os.Exit(1)
-	}
-
-	if printAsJSON {
-		type CreateResult struct {
-			Status           string                      `json:"status"`
-			StatusMessage    string                      `json:"status_message"`
-			ValidationResult *project.ValidationResponse `json:"validation_result"`
-		}
-		jsonResponse, _ := json.Marshal(CreateResult{Status: result.Status, StatusMessage: result.StatusMessage, ValidationResult: response})
-		logr.Tracef(string(jsonResponse))
-	} else {
-		projectInfo, _ := json.Marshal(response)
-		fmt.Println(string(projectInfo))
-	}
-	os.Exit(0)
+	ProjectValidate(c)
 }
 
 // ProjectSync : Does a project Sync


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR restores the output of the Project Create command to be the result of the Project validation, and to let the output of the download result be logged at Trace level.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2903
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2903
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
