### PR TITLE
CWCTL - Mount TLS Certs in Gatekeeper

### DIFF
--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -36,7 +36,7 @@ func DeployGatekeeper(config *restclient.Config, clientset *kubernetes.Clientset
 	gatekeeperDeploy := generateGatekeeperDeploy(codewindInstance, deployOptions)
 	gatekeeperSessionSecret := generateGatekeeperSessionSecret(codewindInstance, deployOptions)
 
-	serverKey, serverCert, _ := generateCertificate(GatekeeperPrefix+codewindInstance.Ingress, "Codewind Gatekeeper")
+	serverKey, serverCert, _ := generateCertificate(GatekeeperPrefix+codewindInstance.Ingress, "Codewind Gatekeeper "+codewindInstance.WorkspaceID)
 	gatekeeperTLSSecret := generateGatekeeperTLSSecret(codewindInstance, serverKey, serverCert)
 
 	logr.Infoln("Deploying Codewind Gatekeeper Secrets")

--- a/pkg/remote/deploy_gatekeeper.go
+++ b/pkg/remote/deploy_gatekeeper.go
@@ -145,8 +145,21 @@ func generateGatekeeperDeploy(codewind Codewind, deployOptions *DeployOptions) a
 		"codewindWorkspace": codewind.WorkspaceID,
 	}
 
-	volumes := []corev1.Volume{}
-	volumeMounts := []corev1.VolumeMount{}
+	volumes := []corev1.Volume{{
+		Name: "tls-certs",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "secret-codewind-tls" + "-" + codewind.WorkspaceID,
+			},
+		},
+	}}
+
+	volumeMounts := []corev1.VolumeMount{{
+		MountPath: "/tlscerts",
+		Name:      "tls-certs",
+		ReadOnly:  true,
+	}}
+
 	envVars := setGatekeeperEnvVars(codewind, deployOptions)
 	return generateDeployment(codewind, GatekeeperPrefix, codewind.GatekeeperImage, GatekeeperContainerPort, volumes, volumeMounts, envVars, labels, codewind.ServiceAccountName, false)
 }

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -233,12 +233,12 @@ func generateService(codewind Codewind, name string, port int, labels map[string
 
 func generateCertificate(dnsName string, certTitle string) (string, string, error) {
 	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: big.NewInt(time.Now().UnixNano() / 1000000),
 		Subject: pkix.Name{
 			Organization: []string{certTitle},
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(time.Hour * 24 * 180),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 730),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,


### PR DESCRIPTION
## What type of PR is this ?

- [x] Enhancement

## Which issue(s) does this PR fix ? https://github.com/eclipse/codewind/issues/971

## What does this PR do ?

Mount the generated TLS certificate into the Codewind Gatekeeper pod. This makes it much easier for users to provide their own server certificate and keys.  It also avoids issues where Gatekeeper pod restarts will regenerate a new self-signed certificate each time which will fire the browser certificate has changed alerts. By using the same certificate each time the browser only needs to trust the self-signed certificate once. 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?

With this pr installed, cwctl will deploy the gatekeeper pod with certificates mounted into /tlscerts directory eg : 

```
bash-4.4$ cd /tlscerts
bash-4.4$ ls -al
total 8
drwxrwxrwt. 3 root root  120 May 12 23:46 .
drwxr-xr-x. 1 root root 4096 May 12 23:46 ..
drwxr-xr-x. 2 root root   80 May 12 23:46 ..2020_05_12_23_46_50.642373192
lrwxrwxrwx. 1 root root   31 May 12 23:46 ..data -> ..2020_05_12_23_46_50.642373192
lrwxrwxrwx. 1 root root   14 May 12 23:46 tls.crt -> ..data/tls.crt
lrwxrwxrwx. 1 root root   14 May 12 23:46 tls.key -> ..data/tls.key
```

Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>