### PR TITLE
Add a flag to skip performing a local docker login.

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Subcommands:</br>
 > --address value The address of the docker registry
 > --username value The username for the docker registry
 > --password value The password for the docker registry
+> --locallogin=[true|false] Whether to perform a local docker login to the registry. Defaults to true.
 
 `list/ls` - List the docker secrets (registries and usernames)
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -926,6 +926,7 @@ func Commands() {
 						cli.StringFlag{Name: "address,a", Usage: "Registry address", Required: true},
 						cli.StringFlag{Name: "username,u", Usage: "Registry username", Required: true},
 						cli.StringFlag{Name: "password,p", Usage: "Registry password", Required: true},
+						cli.BoolTFlag{Name: "locallogin", Usage: "Perform a local docker login to the registry", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						AddRegistrySecret(c)

--- a/pkg/actions/registrysecrets.go
+++ b/pkg/actions/registrysecrets.go
@@ -44,12 +44,13 @@ func AddRegistrySecret(c *cli.Context) {
 	address := strings.TrimSpace(c.String("address"))
 	username := strings.TrimSpace(c.String("username"))
 	password := strings.TrimSpace(c.String("password"))
+	localLogin := c.Bool("locallogin")
 
 	// Log in to local docker to support extensions such as appsody.
 	// Do this first as it will validate the credentials.
 	// Otherwise we have to undo everything else if they are wrong.
 	_, foundChe := os.LookupEnv("CHE_API_EXTERNAL")
-	if !foundChe {
+	if !foundChe && localLogin {
 		dockerErr := docker.LoginToRegistry(address, username, password)
 		if dockerErr != nil {
 			HandleDockerError(dockerErr)


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds a flag `--locallogin` to control whether we perform a local docker login on the users machine when adding registry credentials. The default is true but this can be overridden by setting `--locallogin=false`. Setting `--locallogin=true` has no effect as it is already true by default.

e.g:
`./cwctl --json --insecure registrysecrets add --conid KA7XYAWE --address image-registry.openshift-image-registry.svc:5000 --username pusher --password <password>  --locallogin=false`

This is required to support setting a registry that is only visible from with a Kubernetes cluster. See:
https://github.com/eclipse/codewind/issues/2961

We document the ability to do this here:
https://www.eclipse.org/codewind/openshiftregistry.html#adding-the-openshift-registry-in-codewind
(At the moment these instructions fail when adding the registry to codewind.)

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
These are currently incorrect: https://www.eclipse.org/codewind/openshiftregistry.html#adding-the-openshift-registry-in-codewind
I'm not sure whether we should change the documentation or change the UI so the user has the option of not performing the local login to the registry (especially when adding a registry to push to).

## Any special notes for your reviewer ?
