### PR TITLE
Keycloak - Apply Codewind theme to accounts

### DIFF
--- a/pkg/security/realm.go
+++ b/pkg/security/realm.go
@@ -37,7 +37,7 @@ func SecRealmCreate(c *cli.Context) *SecError {
 	newRealm := strings.TrimSpace(c.String("newrealm"))
 	accesstoken := strings.TrimSpace(c.String("accesstoken"))
 
-	themeToUse, secErr := GetSuggestedTheme(hostname, accesstoken)
+	themeLoginName, themeAccountName, secErr := GetSuggestedThemes(hostname, accesstoken)
 	if secErr != nil {
 		return secErr
 	}
@@ -51,6 +51,7 @@ func SecRealmCreate(c *cli.Context) *SecError {
 		DisplayName           string `json:"displayName"`
 		Enabled               bool   `json:"enabled"`
 		LoginTheme            string `json:"loginTheme"`
+		AccountTheme          string `json:"accountTheme"`
 		AccessTokenLifespan   int    `json:"accessTokenLifespan"`
 		SSOSessionIdleTimeout int    `json:"ssoSessionIdleTimeout"`
 		SSOSessionMaxLifespan int    `json:"ssoSessionMaxLifespan"`
@@ -59,7 +60,8 @@ func SecRealmCreate(c *cli.Context) *SecError {
 		Realm:                 newRealm,
 		DisplayName:           newRealm,
 		Enabled:               true,
-		LoginTheme:            themeToUse,
+		LoginTheme:            themeLoginName,
+		AccountTheme:          themeAccountName,
 		AccessTokenLifespan:   (1 * 24 * 60 * 60), // access tokens last 1 day
 		SSOSessionIdleTimeout: (5 * 24 * 60 * 60), // refresh tokens last 5 days
 		SSOSessionMaxLifespan: (5 * 24 * 60 * 60), // refresh tokens last 5 days

--- a/pkg/security/serverinfo.go
+++ b/pkg/security/serverinfo.go
@@ -85,23 +85,25 @@ func GetServerInfo(keycloakHostname string, accesstoken string) (*ServerInfo, *S
 	return &serverInfo, nil
 }
 
-// GetSuggestedTheme - Recommends the Codewind theme, else Che, else keycloak default
-func GetSuggestedTheme(keycloakHostname string, accesstoken string) (string, *SecError) {
+// GetSuggestedThemes - Recommends the Codewind theme, else Che, else keycloak default
+// Returns the loginTheme, accountTheme, optionalError
+func GetSuggestedThemes(keycloakHostname string, accesstoken string) (string, string, *SecError) {
 	serverInfo, secErr := GetServerInfo(keycloakHostname, accesstoken)
 	if secErr != nil {
-		return "", secErr
+		return "", "", secErr
 	}
 
 	loginThemes := serverInfo.Themes.Login
 	if len(loginThemes) == 0 {
-		return "", nil
+		return "", "", nil
 	}
 
 	themeCodewind := ""
 	themeChe := ""
 	themeKeycloak := ""
+	themeCodewindAccount := ""
 
-	for _, theme := range loginThemes {
+	for _, theme := range serverInfo.Themes.Login {
 		switch strings.ToLower(theme.Name) {
 		case "codewind":
 			{
@@ -121,15 +123,25 @@ func GetSuggestedTheme(keycloakHostname string, accesstoken string) (string, *Se
 		}
 	}
 
+	for _, theme := range serverInfo.Themes.Account {
+		switch strings.ToLower(theme.Name) {
+		case "codewind":
+			{
+				themeCodewindAccount = theme.Name
+				break
+			}
+		}
+	}
+
 	if themeCodewind != "" {
-		return themeCodewind, nil
+		return themeCodewind, themeCodewindAccount, nil
 	}
 	if themeChe != "" {
-		return themeChe, nil
+		return themeChe, themeCodewindAccount, nil
 	}
 	if themeKeycloak != "" {
-		return themeKeycloak, nil
+		return themeKeycloak, themeCodewindAccount, nil
 	}
-	return "", nil
+	return "", "", nil
 
 }


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ?

- [x] Bug fix

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2957

## What does this PR do ?

When deploying a new Keycloak Pod, checks that the pod supports the Codewind theme, if so for the Codewind realm only sets the Account theme to Codewind.

eg : 
![Screenshot 2020-05-18 at 11 55 49](https://user-images.githubusercontent.com/28102564/82205530-a4124f80-98fe-11ea-91d6-6c12dd1bc1fe.png)


#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2957

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
To try this PR out,  you will need this cwctl build and Keycloak UI pod fixes (see Codewind PR: 2964) 
