### PR TITLE
Diagnostics: Make Eclipse/IntelliJ log collection status more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ Subcommands:</br>
 `collect` - Gathers logs and project files to aid diagnosis of Codewind errors
 > **Flags:**
 > --conid <value> -  Triggers diagnostics collection for the remote codewind connection ID (must have currently configured Kubectl connection)</br>
-> --eclipseWorkspaceDir/-e <value> - The location of your Eclipse workspace directory if using the Eclipse IDE (default: "")</br>
-> --intellijLogsDir/-i <value>` - The location of your IntelliJ logs directory if using the IntelliJ IDE (default: "")</br>
+> --eclipseWorkspaceDir/-e <value> - The location of your Eclipse workspace directory if using the Eclipse IDE</br>
+> --intellijLogsDir/-i <value>` - The location of your IntelliJ logs directory if not using the IntelliJ IDE default location</br>
 > --all/-a - Collects diagnostics for all defined connections, remote and local</br>
 > --projects/-p - Collect project containers information</br>
 > --nozip/-n - Does not create collection zip and leaves individual collected files in place</br>

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -345,13 +345,11 @@ func gatherCodewindEclipseLogs(codewindEclipseWSDir string) {
 		} else {
 			warnDG("Unable to collect Eclipse logs", "workspace metadata directory not found")
 		}
-	} else {
-		warnDG("Unable to collect Eclipse logs", "workspace not specified")
 	}
 }
 
 func gatherCodewindVSCodeLogs() {
-	logDG("Collecting VSCode logs ... ")
+	logDG("Attempting to collecting VSCode logs from default location ... ")
 	vsCodeDir := ""
 	switch runtime.GOOS {
 	case "darwin":
@@ -415,10 +413,9 @@ func findIntellijDirectory(inDir string) string {
 }
 
 func gatherCodewindIntellijLogs(codewindIntellijLogDir string) {
-	logDG("Collecting Intellij logs ... ")
 	intellijLogsDir := codewindIntellijLogDir
 	if intellijLogsDir == "" {
-		// attempt to use default path
+		logDG("Attempting to collect Intellij logs from default location ... ")
 		switch runtime.GOOS {
 		case "darwin":
 			libraryLogsDir := filepath.Join(homeDir, "Library", "Logs", "JetBrains")


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR addresses the `cwctl diagnostics` issues described in https://github.com/eclipse/codewind/issues/2857 by:
* Amending the README to remove confusing mentions of defaults for Eclipse and IntelliJ log dirs
* Alters the README for IntelliJ log dirs so that end-users understand they only need to specify it if they are not using the default location
* Removes any mention of collecting Eclipse log dirs if the Eclipse log directory parameter is not specified
* More explicit logging when we are using default IntelliJ log directories .

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2857
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2857
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
