### PR TITLE
Diagnostics: remove --quiet flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,6 @@ Subcommands:</br>
 ` --conid <value>` -  Triggers diagnostics collection for the remote codewind connection ID (must have currently configured Kubectl connection)</br>
 `--eclipseWorkspaceDir/-e <value>` - The location of your Eclipse workspace directory if using the Eclipse IDE (default: "")</br>
 `--intellijLogsDir/-i <value>` - The location of your IntelliJ logs directory if using the IntelliJ IDE (default: "")</br>
-`--quiet/-q` - Turn off console messages</br>
 `--all/-a` - Collects diagnostics for all defined connections, remote and local</br>
 `--projects/-p` - Collect project containers information</br>
 `--nozip/-n` - Does not create collection zip and leaves individual collected files in place</br>

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -986,7 +986,6 @@ func Commands() {
 				cli.StringFlag{Name: "conid", Value: "local", Usage: "Triggers diagnostics collection for the `remote` codewind instance (_must_ have currently configured Kubectl connection!)", Required: false},
 				cli.StringFlag{Name: "eclipseWorkspaceDir, e", Usage: "The location of your Eclipse workspace `directory` if using the Eclipse IDE", Required: false},
 				cli.StringFlag{Name: "intellijLogsDir, i", Usage: "The location of your IntelliJ logs `directory` if using the IntelliJ IDE", Required: false},
-				cli.BoolFlag{Name: "quiet, q", Usage: "Turn off console messages", Required: false},
 				cli.BoolFlag{Name: "all, a", Usage: "Collects diagnostics for all defined connections, remote and local", Required: false},
 				cli.BoolFlag{Name: "projects, p", Usage: "Collect project containers information", Required: false},
 				cli.BoolFlag{Name: "nozip, n", Usage: "Does not create collection zip and leaves individual collected files in place", Required: false},

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -47,11 +47,10 @@ const codewindPrefix = "codewind-"
 const codewindProjectPrefix = "cw-"
 const dgProjectDirName = "projects"
 
-var isLoud = true
 var collectingAll = false
 
 func logDG(input string) {
-	if isLoud {
+	if !printAsJSON {
 		fmt.Print(input)
 	}
 }
@@ -81,9 +80,6 @@ func warnDG(warning, description string) {
 func DiagnosticsCommand(c *cli.Context) {
 	collectingAll = c.Bool("all")
 	connectionID := c.String("conid")
-	if c.Bool("quiet") || printAsJSON {
-		isLoud = false
-	}
 	if c.Bool("clean") {
 		logDG("Deleting all collected diagnostics files ... ")
 		err := os.RemoveAll(diagnosticsMasterDirName)


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR removes the `--quiet` flag from the `diagnostics` command. All checking on whether to display output is done via the global `printAsJSON`.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2959
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2959
## Does this PR require a documentation change ?
Yes

## Any special notes for your reviewer ?
