### PR TITLE
Split "diagnostics" into "collect" and "remove"

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,13 +261,21 @@ Subcommands:</br>
 
 ### diagnostics/dg
 
-` --conid <value>` -  Triggers diagnostics collection for the remote codewind connection ID (must have currently configured Kubectl connection)</br>
-`--eclipseWorkspaceDir/-e <value>` - The location of your Eclipse workspace directory if using the Eclipse IDE (default: "")</br>
-`--intellijLogsDir/-i <value>` - The location of your IntelliJ logs directory if using the IntelliJ IDE (default: "")</br>
-`--all/-a` - Collects diagnostics for all defined connections, remote and local</br>
-`--projects/-p` - Collect project containers information</br>
-`--nozip/-n` - Does not create collection zip and leaves individual collected files in place</br>
-`--clean` - Removes the diagnostics directory and all its contents from the Codewind home directory
+> **Note:** No additional flags
+
+Subcommands:</br>
+
+`collect` - Gathers logs and project files to aid diagnosis of Codewind errors
+> **Flags:**
+> --conid <value> -  Triggers diagnostics collection for the remote codewind connection ID (must have currently configured Kubectl connection)</br>
+> --eclipseWorkspaceDir/-e <value> - The location of your Eclipse workspace directory if using the Eclipse IDE (default: "")</br>
+> --intellijLogsDir/-i <value>` - The location of your IntelliJ logs directory if using the IntelliJ IDE (default: "")</br>
+> --all/-a - Collects diagnostics for all defined connections, remote and local</br>
+> --projects/-p - Collect project containers information</br>
+> --nozip/-n - Does not create collection zip and leaves individual collected files in place</br>
+
+`remove` - Removes the diagnostics directory and all its contents from the Codewind home directory
+> **Note:** No additional flags
 
 ### stop-all
 

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -981,19 +981,32 @@ func Commands() {
 		{
 			Name:    "diagnostics",
 			Aliases: []string{"dg"},
-			Usage:   "Gathers logs and project files to aid diagnosis of Codewind errors",
-			Flags: []cli.Flag{
-				cli.StringFlag{Name: "conid", Value: "local", Usage: "Triggers diagnostics collection for the `remote` codewind instance (_must_ have currently configured Kubectl connection!)", Required: false},
-				cli.StringFlag{Name: "eclipseWorkspaceDir, e", Usage: "The location of your Eclipse workspace `directory` if using the Eclipse IDE", Required: false},
-				cli.StringFlag{Name: "intellijLogsDir, i", Usage: "The location of your IntelliJ logs `directory` if using the IntelliJ IDE", Required: false},
-				cli.BoolFlag{Name: "all, a", Usage: "Collects diagnostics for all defined connections, remote and local", Required: false},
-				cli.BoolFlag{Name: "projects, p", Usage: "Collect project containers information", Required: false},
-				cli.BoolFlag{Name: "nozip, n", Usage: "Does not create collection zip and leaves individual collected files in place", Required: false},
-				cli.BoolFlag{Name: "clean", Usage: "Removes the diagnostics directory and all its contents from the Codewind home directory", Required: false},
-			},
-			Action: func(c *cli.Context) error {
-				DiagnosticsCommand(c)
-				return nil
+			Usage:   "Collect and remove diagnostic reports on Codewind errors",
+			Subcommands: []cli.Command{
+				{
+					Name:  "collect",
+					Usage: "Gathers logs and project files to aid diagnosis of Codewind errors",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "conid", Value: "local", Usage: "Triggers diagnostics collection for the `remote` codewind instance (_must_ have currently configured Kubectl connection!)", Required: false},
+						cli.StringFlag{Name: "eclipseWorkspaceDir, e", Usage: "The location of your Eclipse workspace `directory` if using the Eclipse IDE", Required: false},
+						cli.StringFlag{Name: "intellijLogsDir, i", Usage: "The location of your IntelliJ logs `directory` if using the IntelliJ IDE", Required: false},
+						cli.BoolFlag{Name: "all, a", Usage: "Collects diagnostics for all defined connections, remote and local", Required: false},
+						cli.BoolFlag{Name: "projects, p", Usage: "Collect project containers information", Required: false},
+						cli.BoolFlag{Name: "nozip, n", Usage: "Does not create collection zip and leaves individual collected files in place", Required: false},
+					},
+					Action: func(c *cli.Context) error {
+						DiagnosticsCollect(c)
+						return nil
+					},
+				},
+				{
+					Name:  "remove",
+					Usage: "Removes the diagnostics directory and all its contents from the Codewind home directory",
+					Action: func(c *cli.Context) error {
+						DiagnosticsRemove(c)
+						return nil
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
### Summary
Splits `cwctl diagnostics` into:
1. `cwctl diagnostics collect` - Run the collection
2. `cwctl diagnostics remove` - Remove the `.codewind/diagnostics` directory

### Testing
* Manual test to check that diagnostics can still be collected and removed.

### Other information

Help for `cwctl diagnostics`
```
NAME:
   cwctl diagnostics - Collect and remove diagnostic reports on Codewind errors

USAGE:
   cwctl diagnostics command [command options] [arguments...]

COMMANDS:
   collect  Gathers logs and project files to aid diagnosis of Codewind errors
   remove   Removes the diagnostics directory and all its contents from the Codewind home directory

OPTIONS:
   --help, -h  show help
```

Help for `cwctl diagnostics collect`
```
NAME:
   cwctl diagnostics collect - Gathers logs and project files to aid diagnosis of Codewind errors

USAGE:
   cwctl diagnostics collect [command options] [arguments...]

OPTIONS:
   --conid remote                                 Triggers diagnostics collection for the remote codewind instance (_must_ have currently configured Kubectl connection!) (default: "local")
   --eclipseWorkspaceDir directory, -e directory  The location of your Eclipse workspace directory if using the Eclipse IDE
   --intellijLogsDir directory, -i directory      The location of your IntelliJ logs directory if using the IntelliJ IDE
   --all, -a                                      Collects diagnostics for all defined connections, remote and local
   --projects, -p                                 Collect project containers information
   --nozip, -n                                    Does not create collection zip and leaves individual collected files in place
```

Help for `cwctl diagnostics remove`
```
NAME:
   cwctl diagnostics remove - Removes the diagnostics directory and all its contents from the Codewind home directory

USAGE:
   cwctl diagnostics remove [arguments...]
```

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2930

## Does this PR require a documentation change ? Yes 
will need to change this page: https://www.eclipse.org/codewind/troubleshooting.html#collecting-log-files-and-environment-data 

## Any special notes for your reviewer ?
