### PR TITLE
2647.5 store secure template repo creds for use in project create

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ Subcommands:</br>
 > --url,-u value URL of project to download
 > --path,-p value Path at which to create the new project
 > --conid value Connection ID of PFE that will be used to validate the project (optional)
-> --username value Username for GitHub account authorized to download the provided GitHub repo. If provided, overrides GitHub credentials stored in keychain (optional)
-> --password value Password for GitHub account authorized to download the provided GitHub repo. If provided, overrides GitHub credentials stored in keychain (optional)
+> --username value Username for GitHub account authorized to download the provided URL. Takes precedence over git credentials stored in keychain (optional)
+> --password value Password for GitHub account authorized to download the provided URL. Takes precedence over git credentials stored in keychain (optional)
+> --personalAccessToken value PersonalAccessToken authorized to download the provided URL. Takes precedence over git credentials stored in keychain (optional)
 
 `validate` - Returns the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ Subcommands:</br>
 > --url,-u value URL of project to download
 > --path,-p value Path at which to create the new project
 > --conid value Connection ID of PFE that will be used to validate the project (optional)
-> --username value Username for GitHub account authorized to download the provided GitHub repo
-> --password value Password for GitHub account authorized to download the provided GitHub repo
+> --username value Username for GitHub account authorized to download the provided GitHub repo. If provided, overrides GitHub credentials stored in keychain (optional)
+> --password value Password for GitHub account authorized to download the provided GitHub repo. If provided, overrides GitHub credentials stored in keychain (optional)
 
 `validate` - Returns the predicted language and build type for a project, and writes a default .cw-settings to it if one does not already exist
 

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -138,7 +138,7 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"javascript\",\"projectType\":\"nodejs\"}}\n", string(out))
 	})
-	t.Run("success case: create GHE project with good username and password"+
+	t.Run("success case: create GHE project using good username and password"+
 		"\ncwctl project create --url <secureTemplateRepo> --path <testDir> --username <test.GHEUsername> --password <test.GHEPassword>", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
@@ -157,7 +157,7 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"unknown\",\"projectType\":\"docker\"}}\n", string(out))
 	})
-	t.Run("success case: create GHE project with good personalAccessToken"+
+	t.Run("success case: create GHE project using good personalAccessToken"+
 		"\ncwctl project create --url <secureTemplateRepo> --path <testDir> --personalAccessToken <test.GHEPersonalAccessToken>", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
@@ -175,7 +175,7 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"unknown\",\"projectType\":\"docker\"}}\n", string(out))
 	})
-	t.Run("fail case: create GHE project with good username but bad password"+
+	t.Run("fail case: create GHE project using good username but bad password"+
 		"\ncwctl project create --url <secureTemplateRepo> --path <testDir> --username <goodUsername> --password <badPassword>", func(t *testing.T) {
 		os.RemoveAll(testDir)
 		defer os.RemoveAll(testDir)
@@ -310,7 +310,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		assert.Nil(t, removeErr)
 		assert.NotContains(t, string(removeOut), test.GHEDevfileURL)
 	})
-	t.Run("success case: create GHE template project using stored GHE personalAccessToken"+
+	t.Run("success case: add GHE template repo and create one of its projects using stored GHE personalAccessToken"+
 		"\ncwctl templates repos add --url <GHEDevfile> --personalAccessToken <goodToken>"+
 		"\ncwctl project create --url <GHETemplateRepo>"+
 		"\ncwctl templates repos remove --url", func(t *testing.T) {
@@ -345,7 +345,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		assert.Nil(t, removeErr)
 		assert.NotContains(t, string(removeOut), test.GHEDevfileURL)
 	})
-	t.Run("fail case: create GHE template project with bad password, overriding good stored GHE creds"+
+	t.Run("fail case: add GHE template repo and create one of its projects using bad password, overriding good stored GHE creds"+
 		"\ncwctl templates repos add --url <GHEDevfile> --username --password"+
 		"\ncwctl project create --url <GHETemplateRepo> --username <goodUsername> --password <badPassword>"+
 		"\ncwctl templates repos remove --url", func(t *testing.T) {
@@ -382,7 +382,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		assert.Nil(t, removeErr)
 		assert.NotContains(t, string(removeOut), test.GHEDevfileURL)
 	})
-	t.Run("fail case: create GHE template project with bad personalAccessToken, overriding good stored GHE creds"+
+	t.Run("fail case: add GHE template repo and create one of its projects using bad personalAccessToken, overriding good stored GHE creds"+
 		"\ncwctl templates repos add --url <GHEDevfile> --personalAccessToken <goodToken>"+
 		"\ncwctl project create --url <GHETemplateRepo> --personalAccessToken <badToken>"+
 		"\ncwctl templates repos remove --url", func(t *testing.T) {
@@ -420,7 +420,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 }
 
 func testFailToAddTemplateRepo(t *testing.T) {
-	t.Run("cwctl templates repos add --url <badURL>", func(t *testing.T) {
+	t.Run("fail case: cwctl templates repos add --url <badURL>", func(t *testing.T) {
 		cmd := exec.Command(cwctl, "templates", "repos", "add",
 			"--url=https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/NOT_INDEX_JSON",
 		)
@@ -428,7 +428,7 @@ func testFailToAddTemplateRepo(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Contains(t, string(out), "does not point to a JSON file of the correct form")
 	})
-	t.Run("cwctl templates repos add --url <GHEDevfile> --personalAccessToken --username", func(t *testing.T) {
+	t.Run("fail case: cwctl templates repos add --url <GHEDevfile> --personalAccessToken --username", func(t *testing.T) {
 		cmd := exec.Command(cwctl, "templates", "repos", "add",
 			"--url="+test.GHEDevfileURL,
 			"--personalAccessToken=validPersonalAccessToken",
@@ -438,7 +438,7 @@ func testFailToAddTemplateRepo(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Contains(t, string(out), "received credentials for multiple authentication methods")
 	})
-	t.Run("cwctl templates repos add --url <GHEDevfile> --username", func(t *testing.T) {
+	t.Run("fail case: cwctl templates repos add --url <GHEDevfile> --username", func(t *testing.T) {
 		cmd := exec.Command(cwctl, "templates", "repos", "add",
 			"--url="+test.GHEDevfileURL,
 			"--username=validUsername",
@@ -447,7 +447,7 @@ func testFailToAddTemplateRepo(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Contains(t, string(out), "received username but no password")
 	})
-	t.Run("cwctl templates repos add --url <GHEDevfile> --password", func(t *testing.T) {
+	t.Run("fail case: cwctl templates repos add --url <GHEDevfile> --password", func(t *testing.T) {
 		cmd := exec.Command(cwctl, "templates", "repos", "add",
 			"--url="+test.GHEDevfileURL,
 			"--password=validPassword",

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -287,7 +287,37 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		assert.Nil(t, removeErr)
 		assert.NotContains(t, string(removeOut), test.GHEDevfileURL)
 	})
-	t.Run("success case: create GHE template project using stored GHE username-password"+
+	t.Run("success case: add public GH template repo and create one of its projects"+
+		"\ncwctl templates repos add --url <PublicGHDevfileURL>"+
+		"\ncwctl project create --url <PublicGHRepoURL>"+
+		"\ncwctl templates repos remove --url", func(t *testing.T) {
+		os.RemoveAll(testDir)
+		defer os.RemoveAll(testDir)
+
+		cmd := exec.Command(cwctl, "templates", "repos", "add",
+			"--url="+test.PublicGHDevfileURL,
+		)
+		out, err := cmd.Output()
+		assert.Nil(t, err)
+		assert.Contains(t, string(out), test.PublicGHDevfileURL)
+
+		createCmd := exec.Command(cwctl, "project", "create",
+			"--url="+test.PublicGHRepoURL,
+			"--path="+testDir,
+		)
+		createOut, createErr := createCmd.Output()
+		assert.Nil(t, createErr)
+		assert.Contains(t, string(createOut), "success")
+		assert.Contains(t, string(createOut), testDir)
+
+		removeCmd := exec.Command(cwctl, "templates", "repos", "remove",
+			"--url="+test.PublicGHDevfileURL,
+		)
+		removeOut, removeErr := removeCmd.Output()
+		assert.Nil(t, removeErr)
+		assert.NotContains(t, string(removeOut), test.PublicGHDevfileURL)
+	})
+	t.Run("success case: add GHE template repo and create one of its projects using stored GHE username-password"+
 		"\ncwctl templates repos add --url <GHEDevfile> --username <goodUsername> --password <goodPassword>"+
 		"\ncwctl project create --url <GHETemplateRepo>"+
 		"\ncwctl templates repos remove --url", func(t *testing.T) {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -426,7 +426,7 @@ func testFailToAddTemplateRepo(t *testing.T) {
 		)
 		out, err := cmd.CombinedOutput()
 		assert.Nil(t, err)
-		assert.Contains(t, string(out), "does not point to a JSON file of the correct form")
+		assert.Contains(t, string(out), "Unexpected HTTP status")
 	})
 	t.Run("fail case: cwctl templates repos add --url <GHEDevfile> --personalAccessToken --username", func(t *testing.T) {
 		cmd := exec.Command(cwctl, "templates", "repos", "add",

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -112,7 +112,8 @@ func testUseInsecureKeyring(t *testing.T) {
 }
 
 func testCreateProjectFromTemplate(t *testing.T) {
-	t.Run("cwctl project create --url <insecureTemplateRepo> --path <testDir>", func(t *testing.T) {
+	t.Run("success case: create project"+
+		"\ncwctl project create --url <insecureTemplateRepo> --path <testDir>", func(t *testing.T) {
 		os.RemoveAll(testDir)
 		defer os.RemoveAll(testDir)
 
@@ -124,7 +125,8 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"javascript\",\"projectType\":\"nodejs\"}}\n", string(out))
 	})
-	t.Run("cwctl --json project create --url <insecureTemplateRepo> --path <testDir>", func(t *testing.T) {
+	t.Run("success case: create project and output JSON"+
+		"\ncwctl --json project create --url <insecureTemplateRepo> --path <testDir>", func(t *testing.T) {
 		os.RemoveAll(testDir)
 		defer os.RemoveAll(testDir)
 
@@ -136,7 +138,8 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"javascript\",\"projectType\":\"nodejs\"}}\n", string(out))
 	})
-	t.Run("cwctl project create --url <secureTemplateRepo> --path <testDir> --username <test.GHEUsername> --password <test.GHEPassword>", func(t *testing.T) {
+	t.Run("success case: create GHE project with good username and password"+
+		"\ncwctl project create --url <secureTemplateRepo> --path <testDir> --username <test.GHEUsername> --password <test.GHEPassword>", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
 		}
@@ -154,7 +157,8 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"unknown\",\"projectType\":\"docker\"}}\n", string(out))
 	})
-	t.Run("cwctl project create --url <secureTemplateRepo> --path <testDir> --username <goodUsername> --password <badPassword>", func(t *testing.T) {
+	t.Run("fail case: create GHE project with good username but bad password"+
+		"\ncwctl project create --url <secureTemplateRepo> --path <testDir> --username <goodUsername> --password <badPassword>", func(t *testing.T) {
 		os.RemoveAll(testDir)
 		defer os.RemoveAll(testDir)
 

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -256,8 +256,8 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		assert.Nil(t, removeErr)
 		assert.NotContains(t, string(removeOut), test.GHEDevfileURL)
 	})
-	t.Run("success case: create GHE template project using stored GHE creds"+
-		"\ncwctl templates repos add --url <GHEDevfile> --username --password"+
+	t.Run("success case: create GHE template project using stored GHE username-password"+
+		"\ncwctl templates repos add --url <GHEDevfile> --username <goodUsername> --password <goodPassword>"+
 		"\ncwctl project create --url <GHETemplateRepo>"+
 		"\ncwctl templates repos remove --url", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -125,6 +125,19 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"javascript\",\"projectType\":\"nodejs\"}}\n", string(out))
 	})
+	t.Run("success case: create default template project"+
+		"\ncwctl project create --url <insecureTemplateRepo> --path <testDir>", func(t *testing.T) {
+		os.RemoveAll(testDir)
+		defer os.RemoveAll(testDir)
+
+		cmd := exec.Command(cwctl, "project", "create",
+			"--url="+test.DefaultPublicGHRepoURL,
+			"--path="+testDir,
+		)
+		out, err := cmd.Output()
+		assert.Nil(t, err)
+		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"javascript\",\"projectType\":\"nodejs\"}}\n", string(out))
+	})
 	t.Run("success case: create project and output JSON"+
 		"\ncwctl --json project create --url <insecureTemplateRepo> --path <testDir>", func(t *testing.T) {
 		os.RemoveAll(testDir)

--- a/pkg/actions/commands.go
+++ b/pkg/actions/commands.go
@@ -75,8 +75,9 @@ func Commands() {
 						cli.StringFlag{Name: "url, u", Usage: "URL of project to download", Required: true},
 						cli.StringFlag{Name: "path, p", Usage: "The path at which to create the new project", Required: true},
 						cli.StringFlag{Name: "conid", Value: "local", Usage: "The connection id of PFE which will be used to validate the project", Required: false},
-						cli.StringFlag{Name: "username", Usage: "Username for GitHub account authorized to download the provided GitHub repo", Required: false},
-						cli.StringFlag{Name: "password", Usage: "Password for GitHub account authorized to download the provided GitHub repo", Required: false},
+						cli.StringFlag{Name: "username", Usage: "Username for GitHub account authorized to download the provided URL. Takes precedence over git credentials stored in keychain", Required: false},
+						cli.StringFlag{Name: "password", Usage: "Password for GitHub account authorized to download the provided URL. Takes precedence over git credentials stored in keychain", Required: false},
+						cli.StringFlag{Name: "personalAccessToken", Usage: "PersonalAccessToken authorized to download the provided URL. Takes precedence over git credentials stored in keychain", Required: false},
 					},
 					Action: func(c *cli.Context) error {
 						ProjectCreate(c)

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -47,12 +47,17 @@ func ProjectCreate(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	username := c.String("username")
 	password := c.String("password")
+	personalAccessToken := c.String("personalAccessToken")
+
 	var gitCredentials *utils.GitCredentials
-	if username != "" && password != "" {
-		gitCredentials = &utils.GitCredentials{
-			Username: username,
-			Password: password,
+	if username != "" || password != "" || personalAccessToken != "" {
+		inputGitCredentials, err := utils.ExtractGitCredentials(username, password, personalAccessToken)
+		if err != nil {
+			templateErr := &TemplateError{errOpAddRepo, err, err.Error()}
+			HandleTemplateError(templateErr)
+			os.Exit(1)
 		}
+		gitCredentials = inputGitCredentials
 	} else {
 		savedGitCredentials, templateErr := templates.GetGitCredentialsFromKeychain(conID, url)
 		if templateErr != nil {

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -47,10 +47,12 @@ func ProjectCreate(c *cli.Context) {
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	username := c.String("username")
 	password := c.String("password")
-	var gitCredentials utils.GitCredentials
+	var gitCredentials *utils.GitCredentials
 	if username != "" && password != "" {
-		gitCredentials.Username = username
-		gitCredentials.Password = password
+		gitCredentials = &utils.GitCredentials{
+			Username: username,
+			Password: password,
+		}
 	} else {
 		savedGitCredentials, templateErr := templates.GetGitCredentialsFromKeychain(conID, url)
 		if templateErr != nil {

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -22,6 +22,7 @@ import (
 	"github.com/eclipse/codewind-installer/pkg/config"
 	"github.com/eclipse/codewind-installer/pkg/connections"
 	"github.com/eclipse/codewind-installer/pkg/project"
+	"github.com/eclipse/codewind-installer/pkg/templates"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	logr "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -43,12 +44,21 @@ func ProjectValidate(c *cli.Context) {
 func ProjectCreate(c *cli.Context) {
 	destination := c.String("path")
 	url := c.String("url")
+	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
 	username := c.String("username")
 	password := c.String("password")
 	var gitCredentials utils.GitCredentials
 	if username != "" && password != "" {
 		gitCredentials.Username = username
 		gitCredentials.Password = password
+	} else {
+		savedGitCredentials, templateErr := templates.GetGitCredentialsFromKeychain(conID, url)
+		if templateErr != nil {
+			err := &TemplateError{errOpGetGitCredsFromKeychain, templateErr, templateErr.Error()}
+			HandleTemplateError(err)
+			os.Exit(1)
+		}
+		gitCredentials = savedGitCredentials
 	}
 
 	result, err := project.DownloadTemplate(destination, url, gitCredentials)

--- a/pkg/actions/templates.go
+++ b/pkg/actions/templates.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/templates"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/urfave/cli"
 )
@@ -80,7 +81,7 @@ func AddTemplateRepo(c *cli.Context) {
 	}
 
 	conID := strings.TrimSpace(strings.ToLower(c.String("conid")))
-	repos, err := apiroutes.AddTemplateRepo(conID, url, desc, name, gitCredentials)
+	repos, err := templates.AddTemplateRepo(conID, url, desc, name, gitCredentials)
 	if err != nil {
 		templateErr := &TemplateError{errOpAddRepo, err, err.Error()}
 		HandleTemplateError(templateErr)
@@ -104,7 +105,7 @@ func DeleteTemplateRepo(c *cli.Context) {
 			utils.OnDeleteTemplateRepo(extensions, url, repos)
 		}
 	}
-	repos, err := apiroutes.DeleteTemplateRepo(conID, url)
+	repos, err := templates.DeleteTemplateRepo(conID, url)
 	if err != nil {
 		templateErr := &TemplateError{errOpDeleteRepo, err, err.Error()}
 		HandleTemplateError(templateErr)

--- a/pkg/actions/templates_error.go
+++ b/pkg/actions/templates_error.go
@@ -21,13 +21,14 @@ type TemplateError struct {
 }
 
 const (
-	errOpListTemplates = "LIST_TEMPLATES_ERROR"
-	errOpListStyles    = "LIST_STYLES_ERROR"
-	errOpListRepos     = "LIST_REPOS_ERROR"
-	errOpAddRepo       = "ADD_REPO_ERROR"
-	errOpDeleteRepo    = "DELETE_REPO_ERROR"
-	errOpEnableRepo    = "ENABLE_REPO_ERROR"
-	errOpDisableRepo   = "DISABLE_REPO_ERROR"
+	errOpListTemplates           = "LIST_TEMPLATES_ERROR"
+	errOpListStyles              = "LIST_STYLES_ERROR"
+	errOpListRepos               = "LIST_REPOS_ERROR"
+	errOpAddRepo                 = "ADD_REPO_ERROR"
+	errOpDeleteRepo              = "DELETE_REPO_ERROR"
+	errOpEnableRepo              = "ENABLE_REPO_ERROR"
+	errOpDisableRepo             = "DISABLE_REPO_ERROR"
+	errOpGetGitCredsFromKeychain = "GET_CREDS_KEYCHAIN_ERROR"
 )
 
 // TemplateError : Error formatted in JSON containing an errorOp and a description

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -222,9 +222,9 @@ func AddTemplateRepo(conID, URL, description, name string, gitCredentials *utils
 	}
 	defer resp.Body.Close()
 
-	byteArray, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	byteArray, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, readErr
 	}
 
 	if resp.StatusCode != 200 {
@@ -232,9 +232,9 @@ func AddTemplateRepo(conID, URL, description, name string, gitCredentials *utils
 	}
 
 	var repos []utils.TemplateRepo
-	err = json.Unmarshal(byteArray, &repos)
-	if err != nil {
-		return nil, err
+	unmarshalErr := json.Unmarshal(byteArray, &repos)
+	if unmarshalErr != nil {
+		return nil, unmarshalErr
 	}
 
 	return repos, nil

--- a/pkg/apiroutes/templates.go
+++ b/pkg/apiroutes/templates.go
@@ -185,9 +185,9 @@ func GetTemplateRepos(conID string) ([]utils.TemplateRepo, error) {
 	return repos, nil
 }
 
-// AddTemplateRepo adds a template repo to PFE and
+// AddTemplateRepoToPFE adds a template repo to PFE and
 // returns the new list of existing repos
-func AddTemplateRepo(conID, URL, description, name string, gitCredentials *utils.GitCredentials) ([]utils.TemplateRepo, error) {
+func AddTemplateRepoToPFE(conID, URL, description, name string, gitCredentials *utils.GitCredentials) ([]utils.TemplateRepo, error) {
 	if _, err := url.ParseRequestURI(URL); err != nil {
 		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
 	}
@@ -240,9 +240,9 @@ func AddTemplateRepo(conID, URL, description, name string, gitCredentials *utils
 	return repos, nil
 }
 
-// DeleteTemplateRepo deletes a template repo from PFE and
+// DeleteTemplateRepoFromPFE deletes a template repo from PFE and
 // returns the new list of existing repos
-func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
+func DeleteTemplateRepoFromPFE(conID, URL string) ([]utils.TemplateRepo, error) {
 	if _, err := url.ParseRequestURI(URL); err != nil {
 		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
 	}

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -167,7 +167,7 @@ func TestFailuresAddTemplateRepo(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := AddTemplateRepo(cwTest.ConID, test.inURL, test.inDescription, "template-name", nil)
+			got, err := AddTemplateRepoToPFE(cwTest.ConID, test.inURL, test.inDescription, "template-name", nil)
 			assert.IsType(t, test.wantedType, got, "got: %v", got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -191,7 +191,7 @@ func TestFailuresDeleteTemplateRepo(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := DeleteTemplateRepo(cwTest.ConID, test.inURL)
+			got, err := DeleteTemplateRepoFromPFE(cwTest.ConID, test.inURL)
 			assert.IsType(t, test.wantedType, got, "got: %v", got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -239,7 +239,7 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 			t.Run("Add template repo", func(t *testing.T) {
 				wantedNumRepos := originalNumRepos + 1
 
-				got, err := AddTemplateRepo(cwTest.ConID, test.inURL, "description", "name", test.inGitCredentials)
+				got, err := AddTemplateRepoToPFE(cwTest.ConID, test.inURL, "description", "name", test.inGitCredentials)
 
 				assert.IsType(t, []utils.TemplateRepo{}, got)
 				assert.Equal(t, wantedNumRepos, len(got), "got: %v", got)
@@ -249,7 +249,7 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 			t.Run("Delete template repo", func(t *testing.T) {
 				wantedNumRepos := originalNumRepos
 
-				got, err := DeleteTemplateRepo(cwTest.ConID, test.inURL)
+				got, err := DeleteTemplateRepoFromPFE(cwTest.ConID, test.inURL)
 
 				assert.IsType(t, []utils.TemplateRepo{}, got)
 				assert.Equal(t, wantedNumRepos, len(got), "got: %v", got)

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -162,7 +162,7 @@ func TestFailuresAddTemplateRepo(t *testing.T) {
 			inURL:         URLOfExistingRepo,
 			inDescription: "example repository containing links to templates",
 			wantedType:    nil,
-			wantedErr:     errors.New("Error: Bad Request - " + URLOfExistingRepo + " is already a template repository"),
+			wantedErr:     errors.New("Error: Bad Request - URL " + URLOfExistingRepo + " is already a template repository"),
 		},
 	}
 	for name, test := range tests {

--- a/pkg/apiroutes/templates_test.go
+++ b/pkg/apiroutes/templates_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/eclipse/codewind-installer/pkg/connections"
-	"github.com/eclipse/codewind-installer/pkg/test"
 	cwTest "github.com/eclipse/codewind-installer/pkg/test"
 	"github.com/eclipse/codewind-installer/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -88,7 +87,7 @@ func TestGetTemplates(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := GetTemplates("local", test.inProjectStyle, test.inShowEnabledOnly)
+			got, err := GetTemplates(cwTest.ConID, test.inProjectStyle, test.inShowEnabledOnly)
 			assert.IsType(t, test.wantedType, got)
 			assert.True(t, len(got) >= test.wantedLength, "wanted len(got) >= %d but len(got) was %d", test.wantedLength, len(got))
 			assert.Nil(t, err)
@@ -111,7 +110,7 @@ func TestGetTemplateStyles(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := GetTemplateStyles("local")
+			got, err := GetTemplateStyles(cwTest.ConID)
 			assert.Equal(t, test.want, got)
 			assert.IsType(t, test.wantedErr, err)
 		})
@@ -135,7 +134,7 @@ func TestGetTemplateRepos(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := GetTemplateRepos("local")
+			got, err := GetTemplateRepos(cwTest.ConID)
 			assert.IsType(t, test.wantedType, got)
 			assert.True(t, len(got) >= test.wantedLength, "wanted len(got) >= %d but len(got) was %d", test.wantedLength, len(got))
 			assert.Equal(t, test.wantedErr, err)
@@ -168,7 +167,7 @@ func TestFailuresAddTemplateRepo(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := AddTemplateRepo("local", test.inURL, test.inDescription, "template-name", nil)
+			got, err := AddTemplateRepo(cwTest.ConID, test.inURL, test.inDescription, "template-name", nil)
 			assert.IsType(t, test.wantedType, got, "got: %v", got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -192,7 +191,7 @@ func TestFailuresDeleteTemplateRepo(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := DeleteTemplateRepo("local", test.inURL)
+			got, err := DeleteTemplateRepo(cwTest.ConID, test.inURL)
 			assert.IsType(t, test.wantedType, got, "got: %v", got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -215,15 +214,15 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 			skip:  !cwTest.UsingOwnGHECredentials,
 			inURL: cwTest.GHEDevfileURL,
 			inGitCredentials: &utils.GitCredentials{
-				Username: test.GHEUsername,
-				Password: test.GHEPassword,
+				Username: cwTest.GHEUsername,
+				Password: cwTest.GHEPassword,
 			},
 		},
 		"GHE devfile URL with GHE personal access token": {
 			skip:  !cwTest.UsingOwnGHECredentials,
 			inURL: cwTest.GHEDevfileURL,
 			inGitCredentials: &utils.GitCredentials{
-				PersonalAccessToken: test.GHEPersonalAccessToken,
+				PersonalAccessToken: cwTest.GHEPersonalAccessToken,
 			},
 		},
 	}
@@ -232,7 +231,7 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 			t.Skip()
 		}
 
-		originalRepos, err := GetTemplateRepos("local")
+		originalRepos, err := GetTemplateRepos(cwTest.ConID)
 		require.Nilf(t, err, "Error getting template repos: %s", err)
 		originalNumRepos := len(originalRepos)
 
@@ -240,7 +239,7 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 			t.Run("Add template repo", func(t *testing.T) {
 				wantedNumRepos := originalNumRepos + 1
 
-				got, err := AddTemplateRepo("local", test.inURL, "description", "name", test.inGitCredentials)
+				got, err := AddTemplateRepo(cwTest.ConID, test.inURL, "description", "name", test.inGitCredentials)
 
 				assert.IsType(t, []utils.TemplateRepo{}, got)
 				assert.Equal(t, wantedNumRepos, len(got), "got: %v", got)
@@ -250,14 +249,13 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 			t.Run("Delete template repo", func(t *testing.T) {
 				wantedNumRepos := originalNumRepos
 
-				got, err := DeleteTemplateRepo("local", test.inURL)
+				got, err := DeleteTemplateRepo(cwTest.ConID, test.inURL)
 
 				assert.IsType(t, []utils.TemplateRepo{}, got)
 				assert.Equal(t, wantedNumRepos, len(got), "got: %v", got)
 				assert.Nil(t, err)
 			})
 		})
-		// This test block cleans up after itself
 	}
 }
 
@@ -293,7 +291,7 @@ func TestFailuresEnableTemplateRepos(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := EnableTemplateRepos("local", test.in)
+			got, err := EnableTemplateRepos(cwTest.ConID, test.in)
 			assert.IsType(t, test.wantedType, got, "got: %v", got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -332,7 +330,7 @@ func TestFailuresDisableTemplateRepos(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := DisableTemplateRepos("local", test.in)
+			got, err := DisableTemplateRepos(cwTest.ConID, test.in)
 			assert.IsType(t, test.wantedType, got, "got: %v", got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -346,7 +344,7 @@ func TestSuccessfulEnableAndDisableTemplateRepos(t *testing.T) {
 	testRepoURL := URLOfExistingRepo
 
 	t.Run("Successfully disable 1 template repo", func(t *testing.T) {
-		got, err := DisableTemplateRepos("local", []string{testRepoURL})
+		got, err := DisableTemplateRepos(cwTest.ConID, []string{testRepoURL})
 
 		assert.IsType(t, []utils.TemplateRepo{}, got)
 		assert.Nil(t, err)
@@ -358,7 +356,7 @@ func TestSuccessfulEnableAndDisableTemplateRepos(t *testing.T) {
 	})
 
 	t.Run("Successfully enable 1 template repo", func(t *testing.T) {
-		got, err := EnableTemplateRepos("local", []string{testRepoURL})
+		got, err := EnableTemplateRepos(cwTest.ConID, []string{testRepoURL})
 
 		assert.IsType(t, []utils.TemplateRepo{}, got)
 		assert.Nil(t, err)
@@ -383,14 +381,14 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 	}{
 		"enable 1 valid repo": {
 			in: []RepoOperation{
-				RepoOperation{
+				{
 					Operation: "enable",
 					URL:       URLOfExistingRepo,
 					Value:     "true",
 				},
 			},
 			want: []SubResponseFromBatchOperation{
-				SubResponseFromBatchOperation{
+				{
 					Status: 200,
 					RequestedOperation: RepoOperation{
 						Operation: "enable",
@@ -403,14 +401,14 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 		},
 		"enable 1 unknown repo": {
 			in: []RepoOperation{
-				RepoOperation{
+				{
 					Operation: "enable",
 					URL:       URLOfUnknownRepo,
 					Value:     "true",
 				},
 			},
 			want: []SubResponseFromBatchOperation{
-				SubResponseFromBatchOperation{
+				{
 					Status: 404,
 					RequestedOperation: RepoOperation{
 						Operation: "enable",
@@ -424,14 +422,14 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 		},
 		"disable 1 valid repo": {
 			in: []RepoOperation{
-				RepoOperation{
+				{
 					Operation: "enable",
 					URL:       URLOfExistingRepo,
 					Value:     "false",
 				},
 			},
 			want: []SubResponseFromBatchOperation{
-				SubResponseFromBatchOperation{
+				{
 					Status: 200,
 					RequestedOperation: RepoOperation{
 						Operation: "enable",
@@ -444,14 +442,14 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 		},
 		"disable 1 unknown repo": {
 			in: []RepoOperation{
-				RepoOperation{
+				{
 					Operation: "enable",
 					URL:       URLOfUnknownRepo,
 					Value:     "false",
 				},
 			},
 			want: []SubResponseFromBatchOperation{
-				SubResponseFromBatchOperation{
+				{
 					Status: 404,
 					RequestedOperation: RepoOperation{
 						Operation: "enable",
@@ -465,19 +463,19 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 		},
 		"enable/disable multiple repos": {
 			in: []RepoOperation{
-				RepoOperation{
+				{
 					Operation: "enable",
 					URL:       URLOfExistingRepo,
 					Value:     "true",
 				},
-				RepoOperation{
+				{
 					Operation: "enable",
 					URL:       URLOfUnknownRepo,
 					Value:     "false",
 				},
 			},
 			want: []SubResponseFromBatchOperation{
-				SubResponseFromBatchOperation{
+				{
 					Status: 200,
 					RequestedOperation: RepoOperation{
 						Operation: "enable",
@@ -485,7 +483,7 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 						Value:     "true",
 					},
 				},
-				SubResponseFromBatchOperation{
+				{
 					Status: 404,
 					RequestedOperation: RepoOperation{
 						Operation: "enable",
@@ -500,7 +498,7 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := BatchPatchTemplateRepos("local", test.in)
+			got, err := BatchPatchTemplateRepos(cwTest.ConID, test.in)
 			assert.Equal(t, test.want, got)
 			assert.Equal(t, test.wantedErr, err)
 		})
@@ -512,7 +510,7 @@ func TestBatchPatchTemplateRepos(t *testing.T) {
 func TestHTTPRequestWithRetryOnLock(t *testing.T) {
 	t.Run("Checks 423 is returned if the response StatusCode is always 423", func(t *testing.T) {
 		mockClient := &MockResponse{StatusCode: http.StatusLocked}
-		mockConnection := connections.Connection{ID: "local"}
+		mockConnection := connections.Connection{ID: cwTest.ConID}
 		mockReq, _ := http.NewRequest("", "", nil)
 
 		resp, httpSecError := HTTPRequestWithRetryOnLock(mockClient, mockReq, &mockConnection)
@@ -524,7 +522,7 @@ func TestHTTPRequestWithRetryOnLock(t *testing.T) {
 	})
 	t.Run("Checks that a non 423 StatusCode can be returned", func(t *testing.T) {
 		mockClient := &MockResponse{StatusCode: http.StatusInternalServerError}
-		mockConnection := connections.Connection{ID: "local"}
+		mockConnection := connections.Connection{ID: cwTest.ConID}
 		mockReq, _ := http.NewRequest("", "", nil)
 
 		resp, httpSecError := HTTPRequestWithRetryOnLock(mockClient, mockReq, &mockConnection)
@@ -535,7 +533,7 @@ func TestHTTPRequestWithRetryOnLock(t *testing.T) {
 		assert.Nil(t, httpSecError)
 	})
 	t.Run("Checks secError is returned by not using a mocked client (URL doesn't exist)", func(t *testing.T) {
-		mockConnection := connections.Connection{ID: "local"}
+		mockConnection := connections.Connection{ID: cwTest.ConID}
 		req, _ := http.NewRequest("GET", "nonexistanturl", nil)
 
 		resp, httpSecError := HTTPRequestWithRetryOnLock(http.DefaultClient, req, &mockConnection)

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -54,7 +54,7 @@ type (
 )
 
 // DownloadTemplate using the url/link provided
-func DownloadTemplate(destination, url string, gitCredentials utils.GitCredentials) (*Result, *ProjectError) {
+func DownloadTemplate(destination, url string, gitCredentials *utils.GitCredentials) (*Result, *ProjectError) {
 	projErr := checkProjectDirIsEmpty(destination)
 	if projErr != nil {
 		return nil, projErr

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -33,7 +33,7 @@ import (
 const testDir = "./testDir"
 
 func TestDownloadTemplate(t *testing.T) {
-	t.Run("insecure template repo", func(t *testing.T) {
+	t.Run("success case: download insecure template", func(t *testing.T) {
 		os.RemoveAll(testDir)
 		defer os.RemoveAll(testDir)
 
@@ -45,7 +45,7 @@ func TestDownloadTemplate(t *testing.T) {
 		assert.Equal(t, "success", out.Status)
 		assert.Nil(t, err)
 	})
-	t.Run("secure template repo (good username-password)", func(t *testing.T) {
+	t.Run("success case: download GHE template using good username-password", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
 		}
@@ -65,7 +65,26 @@ func TestDownloadTemplate(t *testing.T) {
 		assert.NotNil(t, out)
 		assert.Nil(t, err)
 	})
-	t.Run("secure template repo (bad credentials)", func(t *testing.T) {
+	t.Run("success case: download GHE template using good personalAccessToken", func(t *testing.T) {
+		if !test.UsingOwnGHECredentials {
+			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
+		}
+
+		os.RemoveAll(testDir)
+		defer os.RemoveAll(testDir)
+
+		dest := filepath.Join(testDir, "secureTemplateRepoGoodCredentials")
+		url := test.GHERepoURL
+		gitCredentials := &utils.GitCredentials{
+			PersonalAccessToken: test.GHEPersonalAccessToken,
+		}
+
+		out, err := DownloadTemplate(dest, url, gitCredentials)
+
+		assert.NotNil(t, out)
+		assert.Nil(t, err)
+	})
+	t.Run("fail case: download GHE template using bad password", func(t *testing.T) {
 		os.RemoveAll(testDir)
 		defer os.RemoveAll(testDir)
 
@@ -74,6 +93,22 @@ func TestDownloadTemplate(t *testing.T) {
 		gitCredentials := &utils.GitCredentials{
 			Username: test.GHEUsername,
 			Password: "badpassword",
+		}
+
+		out, err := DownloadTemplate(dest, url, gitCredentials)
+
+		assert.Nil(t, out)
+		assert.Equal(t, err.Desc, "unexpected status code: 401 Unauthorized")
+	})
+	t.Run("fail case: download GHE template using bad personalAccessToken)", func(t *testing.T) {
+		os.RemoveAll(testDir)
+		defer os.RemoveAll(testDir)
+
+		dest := filepath.Join(testDir, "secureTemplateRepoBadCredentials")
+		url := test.GHERepoURL
+		gitCredentials := &utils.GitCredentials{
+			Username: test.GHEUsername,
+			Password: "badpersonalaccesstoken",
 		}
 
 		out, err := DownloadTemplate(dest, url, gitCredentials)

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -39,9 +39,8 @@ func TestDownloadTemplate(t *testing.T) {
 
 		dest := filepath.Join(testDir, "insecureTemplateRepo")
 		url := test.PublicGHRepoURL
-		gitCredentials := utils.GitCredentials{}
 
-		out, err := DownloadTemplate(dest, url, gitCredentials)
+		out, err := DownloadTemplate(dest, url, nil)
 
 		assert.Equal(t, "success", out.Status)
 		assert.Nil(t, err)
@@ -56,7 +55,7 @@ func TestDownloadTemplate(t *testing.T) {
 
 		dest := filepath.Join(testDir, "secureTemplateRepoGoodCredentials")
 		url := test.GHERepoURL
-		gitCredentials := utils.GitCredentials{
+		gitCredentials := &utils.GitCredentials{
 			Username: test.GHEUsername,
 			Password: test.GHEPassword,
 		}
@@ -72,7 +71,7 @@ func TestDownloadTemplate(t *testing.T) {
 
 		dest := filepath.Join(testDir, "secureTemplateRepoBadCredentials")
 		url := test.GHERepoURL
-		gitCredentials := utils.GitCredentials{
+		gitCredentials := &utils.GitCredentials{
 			Username: test.GHEUsername,
 			Password: "badpassword",
 		}

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -45,7 +45,7 @@ func TestDownloadTemplate(t *testing.T) {
 		assert.Equal(t, "success", out.Status)
 		assert.Nil(t, err)
 	})
-	t.Run("secure template repo (good credentials)", func(t *testing.T) {
+	t.Run("secure template repo (good username-password)", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
 		}

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -1,0 +1,126 @@
+package templates
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/security"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+)
+
+// AddTemplateRepo adds the provided template repo to PFE and
+// stores provided gitCredentials to the keyring
+func AddTemplateRepo(conID, URL, description, name string, gitCredentials *utils.GitCredentials) ([]utils.TemplateRepo, error) {
+	if _, err := url.ParseRequestURI(URL); err != nil {
+		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
+	}
+
+	repos, addErr := apiroutes.AddTemplateRepoToPFE(conID, URL, description, name, gitCredentials)
+	if addErr != nil {
+		return nil, addErr
+	}
+
+	keyringErr := storeGitCredentialsInKeyring(URL, repos, conID, gitCredentials)
+	if keyringErr != nil {
+		return nil, keyringErr
+	}
+	return repos, nil
+}
+
+func storeGitCredentialsInKeyring(
+	URL string,
+	repos []utils.TemplateRepo,
+	conID string,
+	gitCredentials *utils.GitCredentials,
+) error {
+	var IDOfAddedRepo string
+	for _, repo := range repos {
+		if repo.ID != "" && repo.URL == URL {
+			IDOfAddedRepo = repo.ID
+		}
+	}
+	marshalledGitCredentials, marshallErr := json.Marshal(gitCredentials)
+	if marshallErr != nil {
+		return marshallErr
+	}
+	keyringErr := security.StoreSecretInKeyring(
+		conID,
+		"gitcredentials-"+IDOfAddedRepo,
+		string(marshalledGitCredentials),
+	)
+	if keyringErr != nil {
+		return keyringErr
+	}
+	return nil
+}
+
+// DeleteTemplateRepo deletes a template repo from PFE and
+// deletes any matching credentials from the keyring and
+// returns the new list of existing repos
+func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
+	if _, err := url.ParseRequestURI(URL); err != nil {
+		return nil, fmt.Errorf("Error: '%s' is not a valid URL", URL)
+	}
+	sourceID, findErr := findTemplateRepoSourceID(conID, URL)
+	if findErr != nil {
+		return nil, findErr
+	}
+	if sourceID != "" {
+		keyringErr := security.DeleteSecretFromKeyring(conID, "gitcredentials-"+sourceID)
+		if keyringErr != nil {
+			return nil, keyringErr
+		}
+	}
+	return apiroutes.DeleteTemplateRepoFromPFE(conID, URL)
+}
+
+// findTemplateSourceID matches a template URL to its SourceID if it has one
+func findTemplateSourceID(conID, templateURL string) (string, error) {
+	templates, err := apiroutes.GetTemplates(conID, "", false)
+	if err != nil {
+		return "", err
+	}
+	for _, template := range templates {
+		if template.SourceID != "" && template.URL == templateURL {
+			return template.SourceID, nil
+		}
+	}
+	return "", nil
+}
+
+// findTemplateRepoSourceID matches a template repo URL to its SourceID if it has one
+func findTemplateRepoSourceID(conID, repoURL string) (string, error) {
+	repos, err := apiroutes.GetTemplateRepos(conID)
+	if err != nil {
+		return "", err
+	}
+	for _, repo := range repos {
+		if repo.ID != "" && repo.URL == repoURL {
+			return repo.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// GetGitCredentialsFromKeychain gets GitHub credentials for a template from the keychain
+func GetGitCredentialsFromKeychain(conID, templateURL string) (utils.GitCredentials, error) {
+	gitCredentials := utils.GitCredentials{}
+	sourceID, findErr := findTemplateSourceID(conID, templateURL)
+	if findErr != nil {
+		return utils.GitCredentials{}, findErr
+	}
+	if sourceID != "" {
+		savedGitCredentials, err := security.GetSecretFromKeyring(conID, "gitcredentials-"+sourceID)
+		if err != nil {
+			return utils.GitCredentials{}, err
+		}
+
+		unmarshalErr := json.Unmarshal([]byte(savedGitCredentials), &gitCredentials)
+		if unmarshalErr != nil {
+			return utils.GitCredentials{}, err
+		}
+	}
+	return gitCredentials, nil
+}

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -105,22 +105,22 @@ func findTemplateRepoSourceID(conID, repoURL string) (string, error) {
 }
 
 // GetGitCredentialsFromKeychain gets GitHub credentials for a template from the keychain
-func GetGitCredentialsFromKeychain(conID, templateURL string) (utils.GitCredentials, error) {
-	gitCredentials := utils.GitCredentials{}
+func GetGitCredentialsFromKeychain(conID, templateURL string) (*utils.GitCredentials, error) {
 	sourceID, findErr := findTemplateSourceID(conID, templateURL)
 	if findErr != nil {
-		return utils.GitCredentials{}, findErr
+		return nil, findErr
 	}
-	if sourceID != "" {
-		savedGitCredentials, err := security.GetSecretFromKeyring(conID, "gitcredentials-"+sourceID)
-		if err != nil {
-			return utils.GitCredentials{}, err
-		}
-
-		unmarshalErr := json.Unmarshal([]byte(savedGitCredentials), &gitCredentials)
-		if unmarshalErr != nil {
-			return utils.GitCredentials{}, err
-		}
+	if sourceID == "" {
+		return nil, nil
+	}
+	savedGitCredentials, err := security.GetSecretFromKeyring(conID, "gitcredentials-"+sourceID)
+	if err != nil {
+		return nil, err
+	}
+	var gitCredentials *utils.GitCredentials
+	unmarshalErr := json.Unmarshal([]byte(savedGitCredentials), &gitCredentials)
+	if unmarshalErr != nil {
+		return nil, err
 	}
 	return gitCredentials, nil
 }

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -22,9 +22,11 @@ func AddTemplateRepo(conID, URL, description, name string, gitCredentials *utils
 		return nil, addErr
 	}
 
-	keyringErr := storeGitCredentialsInKeyring(URL, repos, conID, gitCredentials)
-	if keyringErr != nil {
-		return nil, keyringErr
+	if gitCredentials != nil {
+		keyringErr := storeGitCredentialsInKeyring(URL, repos, conID, gitCredentials)
+		if keyringErr != nil {
+			return nil, keyringErr
+		}
 	}
 	return repos, nil
 }
@@ -68,9 +70,13 @@ func DeleteTemplateRepo(conID, URL string) ([]utils.TemplateRepo, error) {
 		return nil, findErr
 	}
 	if sourceID != "" {
-		keyringErr := security.DeleteSecretFromKeyring(conID, "gitcredentials-"+sourceID)
-		if keyringErr != nil {
-			return nil, keyringErr
+		nameOfGitCredentialsSecret := "gitcredentials-" + sourceID
+		_, getKeyringErr := security.GetSecretFromKeyring(conID, nameOfGitCredentialsSecret)
+		if getKeyringErr == nil {
+			keyringErr := security.DeleteSecretFromKeyring(conID, nameOfGitCredentialsSecret)
+			if keyringErr != nil {
+				return nil, keyringErr
+			}
 		}
 	}
 	return apiroutes.DeleteTemplateRepoFromPFE(conID, URL)

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -115,7 +115,7 @@ func GetGitCredentialsFromKeychain(conID, templateURL string) (*utils.GitCredent
 	}
 	gitCredentialsString, keychainErr := security.GetSecretFromKeyring(conID, "gitcredentials-"+sourceID)
 	if keychainErr != nil {
-		return nil, keychainErr
+		return nil, nil
 	}
 	var gitCredentials *utils.GitCredentials
 	unmarshalErr := json.Unmarshal([]byte(gitCredentialsString), &gitCredentials)

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -113,14 +113,14 @@ func GetGitCredentialsFromKeychain(conID, templateURL string) (*utils.GitCredent
 	if sourceID == "" {
 		return nil, nil
 	}
-	savedGitCredentials, err := security.GetSecretFromKeyring(conID, "gitcredentials-"+sourceID)
-	if err != nil {
-		return nil, err
+	gitCredentialsString, keychainErr := security.GetSecretFromKeyring(conID, "gitcredentials-"+sourceID)
+	if keychainErr != nil {
+		return nil, keychainErr
 	}
 	var gitCredentials *utils.GitCredentials
-	unmarshalErr := json.Unmarshal([]byte(savedGitCredentials), &gitCredentials)
+	unmarshalErr := json.Unmarshal([]byte(gitCredentialsString), &gitCredentials)
 	if unmarshalErr != nil {
-		return nil, err
+		return nil, unmarshalErr
 	}
 	return gitCredentials, nil
 }

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -36,6 +36,13 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 				Password: cwTest.GHEPassword,
 			},
 		},
+		"GHE devfile URL with GHE personal access token": {
+			skip:  !cwTest.UsingOwnGHECredentials,
+			inURL: cwTest.GHEDevfileURL,
+			inGitCredentials: &utils.GitCredentials{
+				PersonalAccessToken: cwTest.GHEPersonalAccessToken,
+			},
+		},
 	}
 	for name, test := range tests {
 		if test.skip {

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -1,0 +1,110 @@
+package templates
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/eclipse/codewind-installer/pkg/apiroutes"
+	"github.com/eclipse/codewind-installer/pkg/project"
+	"github.com/eclipse/codewind-installer/pkg/security"
+	cwTest "github.com/eclipse/codewind-installer/pkg/test"
+	"github.com/eclipse/codewind-installer/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDir = "./testDir"
+
+func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
+	tests := map[string]struct {
+		skip             bool
+		inURL            string
+		inGitCredentials *utils.GitCredentials
+	}{
+		"public GH devfile URL": {
+			inURL: cwTest.PublicGHDevfileURL,
+		},
+		"GHE devfile URL with GHE basic credentials": {
+			skip:  !cwTest.UsingOwnGHECredentials,
+			inURL: cwTest.GHEDevfileURL,
+			inGitCredentials: &utils.GitCredentials{
+				Username: cwTest.GHEUsername,
+				Password: cwTest.GHEPassword,
+			},
+		},
+	}
+	for name, test := range tests {
+		if test.skip {
+			t.Skip()
+		}
+
+		t.Run(name, func(t *testing.T) {
+			var IDOfAddedRepo string
+
+			os.RemoveAll(testDir)
+			defer os.RemoveAll(testDir)
+
+			t.Run("Add template repo", func(t *testing.T) {
+				got, err := AddTemplateRepo(cwTest.ConID, test.inURL, "description", "name", test.inGitCredentials)
+
+				assert.IsType(t, []utils.TemplateRepo{}, got)
+				require.Nil(t, err)
+
+				if test.inGitCredentials != nil {
+					for _, repo := range got {
+						if repo.ID != "" && repo.URL == test.inURL {
+							IDOfAddedRepo = repo.ID
+						}
+					}
+					gitCredsString, keyringErr := security.GetSecretFromKeyring(cwTest.ConID, "gitcredentials-"+IDOfAddedRepo)
+					assert.Nil(t, keyringErr)
+
+					var gitCredentials *utils.GitCredentials
+					unmarshalErr := json.Unmarshal([]byte(gitCredsString), &gitCredentials)
+					assert.Nil(t, unmarshalErr)
+					assert.Equal(t, test.inGitCredentials, gitCredentials)
+				}
+			})
+
+			t.Run("Create project from template from added repo", func(t *testing.T) {
+				templates, err := apiroutes.GetTemplates(cwTest.ConID, "", false)
+				require.Nilf(t, err, "Error getting template repos: %s", err)
+
+				var URLOfAddedTemplate string
+				for _, template := range templates {
+					if template.SourceID == IDOfAddedRepo {
+						URLOfAddedTemplate = template.URL
+					}
+				}
+				gitCredentials, err := GetGitCredentialsFromKeychain(cwTest.ConID, URLOfAddedTemplate)
+				assert.Nil(t, err)
+				assert.NotNil(t, gitCredentials)
+
+				result, err := project.DownloadTemplate(testDir, URLOfAddedTemplate, gitCredentials)
+				assert.Nil(t, err)
+				if result != nil {
+					assert.Equal(t, result.Status, "success")
+				}
+			})
+
+			t.Run("Delete template repo", func(t *testing.T) {
+				got, err := DeleteTemplateRepo(cwTest.ConID, test.inURL)
+
+				assert.IsType(t, []utils.TemplateRepo{}, got)
+				assert.Nil(t, err)
+
+				if test.inGitCredentials != nil {
+					gitCredsString, err := security.GetSecretFromKeyring(cwTest.ConID, "gitcredentials-"+IDOfAddedRepo)
+					assert.Equal(t, "", gitCredsString)
+					require.NotNil(t, err)
+					assert.Equal(t, "sec_keyring_secret_not_found", err.Op)
+					assert.Contains(t, err.Desc, "not found in keyring")
+				}
+			})
+		})
+	}
+}

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -82,7 +82,7 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 				}
 				gitCredentials, err := GetGitCredentialsFromKeychain(cwTest.ConID, URLOfAddedTemplate)
 				assert.Nil(t, err)
-				assert.NotNil(t, gitCredentials)
+				assert.Equal(t, test.inGitCredentials, gitCredentials)
 
 				result, err := project.DownloadTemplate(testDir, URLOfAddedTemplate, gitCredentials)
 				assert.Nil(t, err)

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -61,13 +61,16 @@ func TestSuccessfulAddAndDeleteTemplateRepos(t *testing.T) {
 				assert.IsType(t, []utils.TemplateRepo{}, got)
 				require.Nil(t, templateErr)
 
-				if test.inGitCredentials != nil {
-					for _, repo := range got {
-						if repo.ID != "" && repo.URL == test.inURL {
-							IDOfAddedRepo = repo.ID
-						}
+				for _, repo := range got {
+					if repo.ID != "" && repo.URL == test.inURL {
+						IDOfAddedRepo = repo.ID
 					}
-					gitCredsString, keyringErr := security.GetSecretFromKeyring(cwTest.ConID, "gitcredentials-"+IDOfAddedRepo)
+				}
+
+				gitCredsString, keyringErr := security.GetSecretFromKeyring(cwTest.ConID, "gitcredentials-"+IDOfAddedRepo)
+				if test.inGitCredentials == nil {
+					assert.NotNil(t, keyringErr)
+				} else {
 					assert.Nil(t, keyringErr)
 
 					var gitCredentials *utils.GitCredentials

--- a/pkg/test/globals.go
+++ b/pkg/test/globals.go
@@ -15,6 +15,7 @@ package test
 const ConID = "local"
 
 // PublicGHRepoURL is a URL to a public GitHub repo (not requiring auth to access)
+// that PFE does not have on startup. It is linked to by the `PublicGHDevfileURL`
 const PublicGHRepoURL = "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
 
 // PublicGHDevfileURL is a URL to a devfiles/index.json in a public GitHub repo (not requiring auth to access)

--- a/pkg/test/globals.go
+++ b/pkg/test/globals.go
@@ -11,6 +11,9 @@
 
 package test
 
+// ConID is the default connection ID
+const ConID = "local"
+
 // PublicGHRepoURL is a URL to a public GitHub repo (not requiring auth to access)
 const PublicGHRepoURL = "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
 
@@ -21,7 +24,7 @@ const PublicGHDevfileURL = "https://raw.githubusercontent.com/kabanero-io/codewi
 const GHERepoURL = "https://github.ibm.com/DevCamp2018/git-basics"
 
 // GHEDevfileURL is a URL to a devfiles/index.json in a GitHub Enterprise repo
-const GHEDevfileURL = "https://raw.github.ibm.com/Richard-Waller/sampleGHETemplateRepo/415ece47958250175f182c095af7da6cfe40e58a/devfiles/index.json"
+const GHEDevfileURL = "https://raw.github.ibm.com/Richard-Waller/sampleGHETemplateRepo/2a0cb5e1accfc077e375f6582f7ee27015c4005b/devfiles/index.json"
 
 // GHEUsername is a username that passes the auth required to access a GHERepoURL
 const GHEUsername = "INSERT YOUR OWN: e.g. foo.bar@foobar.com"

--- a/pkg/test/globals.go
+++ b/pkg/test/globals.go
@@ -14,6 +14,10 @@ package test
 // ConID is the default connection ID
 const ConID = "local"
 
+// DefaultPublicGHRepoURL is a URL to a public GitHub repo (not requiring auth to access)
+// that PFE already has on startup
+const DefaultPublicGHRepoURL = "https://github.com/codewind-resources/nodeExpressTemplate"
+
 // PublicGHRepoURL is a URL to a public GitHub repo (not requiring auth to access)
 // that PFE does not have on startup. It is linked to by the `PublicGHDevfileURL`
 const PublicGHRepoURL = "https://github.com/microclimate-dev2ops/nodeExpressTemplate"

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
 )
 
 type (
@@ -160,6 +161,16 @@ func DownloadFromRepoURL(URL *url.URL, destination string, gitCredentials *GitCr
 func getGitHubClient(domain string, gitCredentials *GitCredentials) (*github.Client, error) {
 	if gitCredentials == nil {
 		return github.NewClient(nil), nil
+	}
+
+	if gitCredentials.PersonalAccessToken != "" {
+		ctx := context.Background()
+		tokenSource := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: gitCredentials.PersonalAccessToken},
+		)
+		tokenClient := oauth2.NewClient(ctx, tokenSource)
+		baseURL := "https://" + domain
+		return github.NewEnterpriseClient(baseURL, baseURL, tokenClient)
 	}
 
 	tp := github.BasicAuthTransport{

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -36,7 +36,7 @@ type (
 
 // DownloadFromURLThenExtract downloads files from a URL
 // to a destination, extracting them if necessary
-func DownloadFromURLThenExtract(inURL, destination string, gitCredentials GitCredentials) error {
+func DownloadFromURLThenExtract(inURL, destination string, gitCredentials *GitCredentials) error {
 	URL, err := url.ParseRequestURI(inURL)
 	if err != nil {
 		return err
@@ -53,12 +53,12 @@ func DownloadFromURLThenExtract(inURL, destination string, gitCredentials GitCre
 
 // DownloadFromTarGzURL downloads a tar.gz file from a URL
 // and extracts it to a destination
-func DownloadFromTarGzURL(URL *url.URL, destination string, gitCredentials GitCredentials) error {
+func DownloadFromTarGzURL(URL *url.URL, destination string, gitCredentials *GitCredentials) error {
 	time := time.Now().Format(time.RFC3339)
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
 	pathToTempFile := path.Join(os.TempDir(), "_"+time+"temp.tar.gz")
 
-	if gitCredentials != (GitCredentials{}) {
+	if gitCredentials != nil {
 		downloadURL, err := getURLToDownloadReleaseAsset(URL, gitCredentials)
 		if err != nil {
 			return err
@@ -66,7 +66,7 @@ func DownloadFromTarGzURL(URL *url.URL, destination string, gitCredentials GitCr
 		URL = downloadURL
 	}
 
-	err := DownloadFile(URL, pathToTempFile, gitCredentials)
+	err := DownloadFile(URL, pathToTempFile)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func DownloadFromTarGzURL(URL *url.URL, destination string, gitCredentials GitCr
 	return err
 }
 
-func getURLToDownloadReleaseAsset(URL *url.URL, gitCredentials GitCredentials) (*url.URL, error) {
+func getURLToDownloadReleaseAsset(URL *url.URL, gitCredentials *GitCredentials) (*url.URL, error) {
 	URLPathSlice := strings.Split(URL.Path, "/")
 
 	if !strings.Contains(URL.Host, "github") || len(URLPathSlice) < 6 {
@@ -135,7 +135,7 @@ func findAssetID(releases []*github.RepositoryRelease, releaseName string, URL *
 }
 
 // DownloadFromRepoURL downloads a repo from a URL to a destination
-func DownloadFromRepoURL(URL *url.URL, destination string, gitCredentials GitCredentials) error {
+func DownloadFromRepoURL(URL *url.URL, destination string, gitCredentials *GitCredentials) error {
 	URLPathSlice := strings.Split(URL.Path, "/")
 
 	if !strings.Contains(URL.Host, "github") || len(URLPathSlice) < 3 {
@@ -157,8 +157,8 @@ func DownloadFromRepoURL(URL *url.URL, destination string, gitCredentials GitCre
 	return DownloadAndExtractZip(zipURL, destination)
 }
 
-func getGitHubClient(domain string, gitCredentials GitCredentials) (*github.Client, error) {
-	if gitCredentials == (GitCredentials{}) {
+func getGitHubClient(domain string, gitCredentials *GitCredentials) (*github.Client, error) {
+	if gitCredentials == nil {
 		return github.NewClient(nil), nil
 	}
 
@@ -191,7 +191,7 @@ func DownloadAndExtractZip(zipURL *url.URL, destination string) error {
 	time = strings.Replace(time, ":", "-", -1) // ":" is illegal char in windows
 	pathToTempZipFile := path.Join(os.TempDir(), "_"+time+".zip")
 
-	err := DownloadFile(zipURL, pathToTempZipFile, GitCredentials{})
+	err := DownloadFile(zipURL, pathToTempZipFile)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func DownloadAndExtractZip(zipURL *url.URL, destination string) error {
 }
 
 // DownloadFile from URL to file destination
-func DownloadFile(URL *url.URL, destination string, gitCredentials GitCredentials) error {
+func DownloadFile(URL *url.URL, destination string) error {
 	resp, err := http.Get(URL.String())
 	if err != nil {
 		return err

--- a/pkg/utils/download_test.go
+++ b/pkg/utils/download_test.go
@@ -56,7 +56,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			wantedType:     nil,
 			wantedNumFiles: 17,
 		},
-		"success case: input good secure Git URL and credentials": {
+		"success case: input good GHE URL and username-password": {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            test.GHERepoURL,
 			inDestination:    filepath.Join(testDir, "git"),
@@ -84,7 +84,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			wantedType:     nil,
 			wantedNumFiles: 6,
 		},
-		"success case: input good private tar.gz URL and credentials": {
+		"success case: input good private tar.gz URL and username-password": {
 			skip:             !usingOwnPrivateGHCredentials,
 			inURL:            privateGHTarGzURL,
 			inDestination:    filepath.Join(testDir, "privateTarGz"),
@@ -92,10 +92,10 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			wantedType:       nil,
 			wantedNumFiles:   5,
 		},
-		"success case: input good GHE tar.gz URL and credentials": {
+		"success case: input good GHE tar.gz URL and username-password": {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            GHETarGzURL,
-			inDestination:    filepath.Join(testDir, "privateTarGz"),
+			inDestination:    filepath.Join(testDir, "GHETarGz"),
 			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       nil,
 			wantedNumFiles:   6,
@@ -307,7 +307,7 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 			wantedNumFiles:   0,
 		},
 		"fail case: input Git credentials with GHE URL that isn't to a release asset": {
-			inURL:            toURL("https://github.ibm.com/Richard-Waller/sampleGHERepo/foo"),
+			inURL:            toURL(test.GHERepoURL),
 			inDestination:    filepath.Join(testDir, "badURL"),
 			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       errors.New(""),
@@ -327,8 +327,14 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 			}
 
 			createdFiles, _ := ioutil.ReadDir(test.inDestination)
-			assert.Truef(t, len(createdFiles) == test.wantedNumFiles, "len(createdFiles) was %d but should have been %d. createdFiles: %s", len(createdFiles), test.wantedNumFiles, getFilenames(createdFiles))
-
+			assert.Truef(
+				t,
+				len(createdFiles) == test.wantedNumFiles,
+				"len(createdFiles) was %d but should have been %d. createdFiles: %s",
+				len(createdFiles),
+				test.wantedNumFiles,
+				getFilenames(createdFiles),
+			)
 		})
 		os.RemoveAll(testDir)
 		fmt.Println()

--- a/pkg/utils/download_test.go
+++ b/pkg/utils/download_test.go
@@ -64,7 +64,15 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			wantedType:       nil,
 			wantedNumFiles:   7,
 		},
-		"success case: input good private Git URL and credentials": {
+		"success case: input good GHE URL and personalAccessToken": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            test.GHERepoURL,
+			inDestination:    filepath.Join(testDir, "git"),
+			inGitCredentials: &GitCredentials{PersonalAccessToken: test.GHEPersonalAccessToken},
+			wantedType:       nil,
+			wantedNumFiles:   7,
+		},
+		"success case: input good private Git URL and username-password": {
 			skip:             !usingOwnPrivateGHCredentials,
 			inURL:            privateGHRepoURL,
 			inDestination:    filepath.Join(testDir, "git"),
@@ -97,6 +105,14 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			inURL:            GHETarGzURL,
 			inDestination:    filepath.Join(testDir, "GHETarGz"),
 			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			wantedType:       nil,
+			wantedNumFiles:   6,
+		},
+		"success case: input good GHE tar.gz URL and personalAccessToken": {
+			skip:             !test.UsingOwnGHECredentials,
+			inURL:            GHETarGzURL,
+			inDestination:    filepath.Join(testDir, "GHETarGz"),
+			inGitCredentials: &GitCredentials{PersonalAccessToken: test.GHEPersonalAccessToken},
 			wantedType:       nil,
 			wantedNumFiles:   6,
 		},

--- a/pkg/utils/download_test.go
+++ b/pkg/utils/download_test.go
@@ -45,7 +45,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 		skip             bool
 		inURL            string
 		inDestination    string
-		inGitCredentials GitCredentials
+		inGitCredentials *GitCredentials
 		wantedType       error
 		wantedErrMsg     string
 		wantedNumFiles   int
@@ -60,7 +60,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            test.GHERepoURL,
 			inDestination:    filepath.Join(testDir, "git"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       nil,
 			wantedNumFiles:   7,
 		},
@@ -68,7 +68,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !usingOwnPrivateGHCredentials,
 			inURL:            privateGHRepoURL,
 			inDestination:    filepath.Join(testDir, "git"),
-			inGitCredentials: GitCredentials{Username: privateGHUsername, Password: privateGHPassword},
+			inGitCredentials: &GitCredentials{Username: privateGHUsername, Password: privateGHPassword},
 			wantedType:       nil,
 			wantedNumFiles:   15,
 		},
@@ -88,7 +88,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !usingOwnPrivateGHCredentials,
 			inURL:            privateGHTarGzURL,
 			inDestination:    filepath.Join(testDir, "privateTarGz"),
-			inGitCredentials: GitCredentials{Username: privateGHUsername, Password: privateGHPassword},
+			inGitCredentials: &GitCredentials{Username: privateGHUsername, Password: privateGHPassword},
 			wantedType:       nil,
 			wantedNumFiles:   5,
 		},
@@ -96,7 +96,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            GHETarGzURL,
 			inDestination:    filepath.Join(testDir, "privateTarGz"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       nil,
 			wantedNumFiles:   6,
 		},
@@ -118,7 +118,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            test.GHERepoURL,
 			inDestination:    filepath.Join(testDir, "failCase"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: "bad password"},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: "bad password"},
 			wantedType:       errors.New(""),
 			wantedErrMsg:     "401 Unauthorized",
 			wantedNumFiles:   0,
@@ -127,7 +127,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            GHETarGzURLToNonExistentRepo,
 			inDestination:    filepath.Join(testDir, "failCase"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       errors.New(""),
 			wantedErrMsg:     "GitHub responded with status code 404",
 			wantedNumFiles:   0,
@@ -136,7 +136,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            GHETarGzURLToNonExistentRelease,
 			inDestination:    filepath.Join(testDir, "failCase"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       errors.New(""),
 			wantedErrMsg:     "Cannot find release ",
 			wantedNumFiles:   0,
@@ -145,7 +145,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			skip:             !test.UsingOwnGHECredentials,
 			inURL:            GHETarGzURLToNonExistentReleaseAsset,
 			inDestination:    filepath.Join(testDir, "failCase"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       errors.New(""),
 			wantedErrMsg:     "Cannot find matching assets for release ",
 			wantedNumFiles:   0,
@@ -184,7 +184,7 @@ func TestDownloadFromRepoURL(t *testing.T) {
 	tests := map[string]struct {
 		inURL            *url.URL
 		inDestination    string
-		inGitCredentials GitCredentials
+		inGitCredentials *GitCredentials
 		wantedType       error
 		wantedErrMsg     string
 		wantedNumFiles   int
@@ -262,8 +262,14 @@ func TestDownloadAndExtractZip(t *testing.T) {
 			assert.IsType(t, test.wantedType, got, "Got: %s", got)
 
 			createdFiles, _ := ioutil.ReadDir(test.inDestination)
-			assert.Truef(t, len(createdFiles) == test.wantedNumFiles, "len(createdFiles) was %d but should have been %d. createdFiles: %s", len(createdFiles), test.wantedNumFiles, getFilenames(createdFiles))
-
+			assert.Truef(
+				t,
+				len(createdFiles) == test.wantedNumFiles,
+				"len(createdFiles) was %d but should have been %d. createdFiles: %s",
+				len(createdFiles),
+				test.wantedNumFiles,
+				getFilenames(createdFiles),
+			)
 		})
 		os.RemoveAll(testDir)
 		fmt.Println()
@@ -274,7 +280,7 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 	tests := map[string]struct {
 		inURL            *url.URL
 		inDestination    string
-		inGitCredentials GitCredentials
+		inGitCredentials *GitCredentials
 		wantedType       error
 		wantedErrMsg     string
 		wantedNumFiles   int
@@ -295,7 +301,7 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 		"fail case: input Git credentials with URL that isn't GitHub": {
 			inURL:            toURL("https://www.google.com/"),
 			inDestination:    filepath.Join(testDir, "badURL"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       errors.New(""),
 			wantedErrMsg:     "URL must point to a GitHub repository release asset",
 			wantedNumFiles:   0,
@@ -303,7 +309,7 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 		"fail case: input Git credentials with GHE URL that isn't to a release asset": {
 			inURL:            toURL("https://github.ibm.com/Richard-Waller/sampleGHERepo/foo"),
 			inDestination:    filepath.Join(testDir, "badURL"),
-			inGitCredentials: GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
+			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: test.GHEPassword},
 			wantedType:       errors.New(""),
 			wantedErrMsg:     "URL must point to a GitHub repository release asset",
 			wantedNumFiles:   0,
@@ -332,7 +338,7 @@ func TestDownloadFromTarGzURL(t *testing.T) {
 func TestDownloadFile(t *testing.T) {
 	t.Run("fail case - response status code is not 200", func(t *testing.T) {
 		testURL := "https://github.com/nonexistentrepo"
-		err := DownloadFile(toURL(testURL), testDir, GitCredentials{})
+		err := DownloadFile(toURL(testURL), testDir)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "File download failed for "+testURL+", status code ")
 	})

--- a/pkg/utils/templates_test.go
+++ b/pkg/utils/templates_test.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractGitCredentials_Fail(t *testing.T) {
+	tests := map[string]struct {
+		inUsername            string
+		inPassword            string
+		inPersonalAccessToken string
+		wantErrMsg            string
+	}{
+		"multiple auth methods": {
+			inUsername:            "username",
+			inPassword:            "",
+			inPersonalAccessToken: "personalAccessToken",
+			wantErrMsg:            "received credentials for multiple authentication methods",
+		},
+		"username but no password": {
+			inUsername:            "username",
+			inPassword:            "",
+			inPersonalAccessToken: "",
+			wantErrMsg:            "received username but no password",
+		},
+		"password but no username": {
+			inUsername:            "",
+			inPassword:            "password",
+			inPersonalAccessToken: "",
+			wantErrMsg:            "received password but no username",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ExtractGitCredentials(test.inUsername, test.inPassword, test.inPersonalAccessToken)
+			assert.Nil(t, got)
+			assert.Equal(t, err.Error(), test.wantErrMsg)
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
For https://github.com/eclipse/codewind/issues/2647#issuecomment-630799796:

> As per the design above, we want cwctl to let the user provide credentials just once (when adding the secure template repo), and not need to re-enter the credentials when creating a project from one of those secure templates.

> I will make cwctl do this by storing the credentials in the keychain when the user calls cwctl templates repos add, and using those credentials when the user calls cwctl project create <templateURL>.

See updated README and tests for more details

**Note: this allows `cwctl project create` to use GHE personal access tokens, but will need a minor tweak when we want to use tokens to access non-GHE URLs.** Once we have an example a non-GHE URL from which we can download projects using access tokens, we can make this change (stop [using a GitHub Enterprise client](https://github.com/eclipse/codewind-installer/pull/482/files#diff-15027b369c05ec415272d89897a61147R173) in these cases)

## Which issue(s) does this PR fix ?
part of https://github.com/eclipse/codewind/issues/2647

## Does this PR require a documentation change ?
Included

## Any special notes for your reviewer ?
* Most/all of the tests I've added have to be skipped in Jenkins
* Tests use my GHE [template repo](https://github.ibm.com/Richard-Waller/sampleGHETemplateRepo/blob/master/devfiles/index.json). Would be good to move to a GHE repo we all control