### PR TITLE
Deliver Diagnostics tests

### DIFF
--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -502,7 +502,7 @@ func gatherCodewindVersions(connectionID string) {
 			"PFE VERSION: " + containerVersions.PFEVersion + errorString + "\n" +
 			"PERFORMANCE VERSION: " + containerVersions.PerformanceVersion + errorString + "\n")
 	if connectionID == "local" {
-		dockerClientVersion, dockerServerVersion := getDockerVersions()
+		dockerClientVersion, dockerServerVersion := getDockerVersions(getDockerClient)
 		versionsByteArray = append(versionsByteArray, []byte(
 			"DOCKER CLIENT VERSION: "+dockerClientVersion+"\n"+
 				"DOCKER SERVER VERSION: "+dockerServerVersion+"\n")...,
@@ -519,8 +519,8 @@ func gatherCodewindVersions(connectionID string) {
 	logDG("done\n")
 }
 
-func getDockerVersions() (clientVersion, serverVersion string) {
-	dockerClient, dockerErr := docker.NewDockerClient()
+func getDockerVersions(dockerNewClientFunc func() (docker.DockerClient, *docker.DockerError)) (clientVersion, serverVersion string) {
+	dockerClient, dockerErr := dockerNewClientFunc()
 	if dockerErr != nil {
 		warnDG("Problems getting docker client", dockerErr.Error())
 		return "Unable to determine version - " + dockerErr.Error(), "Unable to determine version - " + dockerErr.Error()

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -268,7 +268,7 @@ func dgLocalCommand(c *cli.Context) {
 	logDG("done\n")
 
 	if c.Bool("projects") {
-		collectCodewindProjectContainers()
+		collectCodewindProjectContainers(getDockerClient)
 	}
 
 	// Collect codewind versions
@@ -291,9 +291,9 @@ func collectCodewindContainers() {
 	}
 }
 
-func collectCodewindProjectContainers() {
+func collectCodewindProjectContainers(dockerNewClientFunc func() (docker.DockerClient, *docker.DockerError)) {
 	// Collect project container inspection & logs
-	dockerClient, dockerErr := docker.NewDockerClient()
+	dockerClient, dockerErr := dockerNewClientFunc()
 	if dockerErr != nil {
 		warnDG("Unable to get Docker client", dockerErr.Error())
 		return
@@ -624,7 +624,6 @@ func copyCodewindWorkspace(containerID string, dockerNewClientFunc func() (docke
 //writeJSONStructToFile - writes the given struct to file as JSON
 func writeJSONStructToFile(structure interface{}, targetFilePath string) error {
 	fileContents, _ := json.MarshalIndent(structure, "", " ")
-	logDG(string(fileContents))
 	err := ioutil.WriteFile(filepath.Join(diagnosticsDirName, targetFilePath), fileContents, 0644)
 	return err
 }

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -230,7 +230,7 @@ func confirmConnectionIDAndWorkspaceID(conid string) (string, string) {
 	return "", ""
 }
 
-func collectPodInfo(clientset *kubernetes.Clientset, podArray []corev1.Pod, workspaceDirName string) {
+func collectPodInfo(clientset kubernetes.Interface, podArray []corev1.Pod, workspaceDirName string) {
 	for _, pod := range podArray {
 		podName := pod.ObjectMeta.Name
 		logDG("Collecting information from pod " + podName + " ... ")

--- a/pkg/actions/diagnostics.go
+++ b/pkg/actions/diagnostics.go
@@ -65,6 +65,10 @@ type dgResultStruct struct {
 }
 
 // used so that unit testing can mock
+var exitFunction = func(code int) {
+	os.Exit(code)
+}
+
 type dgFunctions struct {
 	Local  func(bool)
 	Remote func(string, bool, kubernetes.Interface)
@@ -159,7 +163,7 @@ func DiagnosticsCollect(c *cli.Context) {
 		} else {
 			logDG("No diagnostics data was able to be collected - empty directory " + diagnosticsDirName + " has been deleted.")
 		}
-		os.Exit(1)
+		exitFunction(1)
 	}
 	if printAsJSON {
 		result := dgResultStruct{DgSuccess: true, DgOutputDir: diagnosticsDirName, DgWarningsEncountered: dgWarningArray}

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -12,14 +12,25 @@
 package actions
 
 import (
+	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
+
+const testDir = "./testDir/diagnostics"
+
+type testStruct struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
 
 func clearAllDiagnostics() {
 	app := cli.NewApp()
@@ -27,6 +38,10 @@ func clearAllDiagnostics() {
 	flagSet.Bool("clean", true, "")
 	context := cli.NewContext(app, flagSet, nil)
 	DiagnosticsCommand(context)
+}
+
+func getMockDockerClient() (docker.DockerClient, *docker.DockerError) {
+	return &docker.MockDockerClientWithCw{}, nil
 }
 
 // clearAllDiagnostics()
@@ -47,7 +62,7 @@ func clearAllDiagnostics() {
 // 	assert.DirExists(t, filepath.Join(homeDir, ".codewind", "diagnostics"))
 //  })
 
-func TestWarnDG(t *testing.T) {
+func Test_warnDG(t *testing.T) {
 	warning := "test_warn"
 	description := "test warning description"
 	expectedConsoleOutput := warning + ": " + description + "\n"
@@ -67,5 +82,150 @@ func TestWarnDG(t *testing.T) {
 		printAsJSON = true
 		warnDG(warning, description)
 		assert.Equal(t, expectedJSONOutput, dgWarningArray[0])
+	})
+}
+
+func Test_writeStreamToFile(t *testing.T) {
+	testString := "Testing writeStreamToFile"
+	testFileName := "twstf.txt"
+	os.MkdirAll(testDir, 0755)
+	diagnosticsDirName = testDir
+	t.Run("writeStreamToFile - success", func(t *testing.T) {
+		readcloser := ioutil.NopCloser(strings.NewReader(testString))
+		wSTFerr := writeStreamToFile(readcloser, testFileName)
+		if wSTFerr != nil {
+			t.Error("Error encountered - " + wSTFerr.Error())
+		}
+		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, testFileName))
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Equal(t, testString, string(contents))
+	})
+}
+
+func Test_writeJSONStructToFile(t *testing.T) {
+	testStructure := testStruct{Status: "OK", Message: "testing writeJSONStructToFile"}
+	testFileName := "twjstf.txt"
+	os.MkdirAll(testDir, 0755)
+	diagnosticsDirName = testDir
+	t.Run("writeJSONStructToFile - success", func(t *testing.T) {
+		wJSTFerr := writeJSONStructToFile(testStructure, testFileName)
+		if wJSTFerr != nil {
+			t.Error("Error encountered - " + wJSTFerr.Error())
+		}
+		file, fileErr := ioutil.ReadFile(filepath.Join(testDir, testFileName))
+		if fileErr != nil {
+			t.Error("Error encountered - " + fileErr.Error())
+		}
+		readStructure := testStruct{}
+		_ = json.Unmarshal([]byte(file), &readStructure)
+		assert.Equal(t, readStructure, testStructure)
+	})
+}
+
+func Test_copyCodewindWorkspace(t *testing.T) {
+	t.Run("copyCodewindWorkspace - empty containerID", func(t *testing.T) {
+		expectedErrorString := "Unable to find Codewind PFE container - could not get container ID"
+		cCWerr := copyCodewindWorkspace("", getMockDockerClient)
+		if cCWerr == nil {
+			t.Error("Did not receive expected error")
+		}
+		assert.Equal(t, expectedErrorString, cCWerr.Error())
+	})
+	t.Run("copyCodewindWorkspace - success", func(t *testing.T) {
+		diagnosticsLocalDirName = testDir
+		cCWerr := copyCodewindWorkspace("test", getMockDockerClient)
+		if cCWerr != nil {
+			t.Error("Error encountered - " + cCWerr.Error())
+		}
+		// file output from mock client is empty, so no files to test for
+	})
+}
+
+func Test_writeContainerLogToFile(t *testing.T) {
+	conName := "test"
+	t.Run("writeContainerLogToFile - empty containerID", func(t *testing.T) {
+		expectedErrorString := "Unable to find " + conName + " container - could not get container ID"
+		wCLTFerr := writeContainerLogToFile("", conName, getMockDockerClient)
+		if wCLTFerr == nil {
+			t.Error("Did not receive expected error")
+		}
+		assert.Equal(t, expectedErrorString, wCLTFerr.Error())
+	})
+	t.Run("writeContainerLogToFile - success", func(t *testing.T) {
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		wCLTFerr := writeContainerLogToFile("anything", conName, getMockDockerClient)
+		if wCLTFerr != nil {
+			t.Error("Error encountered - " + wCLTFerr.Error())
+		}
+		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, conName+".log"))
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Equal(t, "", string(contents))
+	})
+}
+
+func Test_writeContainerInspectToFile(t *testing.T) {
+	conName := "test"
+	t.Run("writeContainerInspectToFile - empty containerID", func(t *testing.T) {
+		expectedErrorString := "Unable to find " + conName + " container - could not get container ID"
+		wCITFerr := writeContainerInspectToFile("", conName, getMockDockerClient)
+		if wCITFerr == nil {
+			t.Error("Did not receive expected error")
+		}
+		assert.Equal(t, expectedErrorString, wCITFerr.Error())
+	})
+	t.Run("writeContainerInspectToFile - success", func(t *testing.T) {
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		wCITFerr := writeContainerLogToFile("anything", conName, getMockDockerClient)
+		if wCITFerr != nil {
+			t.Error("Error encountered - " + wCITFerr.Error())
+		}
+		// file output from mock client is empty, so no files to test for
+	})
+}
+
+func Test_getContainerID(t *testing.T) {
+	goodConName := "/codewind-pfe"
+	expectedGoodResult := "pfe"
+	t.Run("getContainerID - success", func(t *testing.T) {
+		containerID := getContainerID(goodConName, getMockDockerClient)
+		assert.Equal(t, expectedGoodResult, containerID)
+	})
+	//can't test for name not found without another client as mock client always returns a populated list
+}
+
+func Test_gatherCodewindVersions(t *testing.T) {
+	localConID := "local"
+	remoteConID := "remote"
+	t.Run("gatherCodewindVersions - local success", func(t *testing.T) {
+		diagnosticsLocalDirName = testDir
+		gatherCodewindVersions(localConID)
+		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, "codewind.versions"))
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Contains(t, string(contents), "CWCTL VERSION: ")
+		assert.Contains(t, string(contents), "PFE VERSION: ")
+		assert.Contains(t, string(contents), "PERFORMANCE VERSION: ")
+		assert.NotContains(t, string(contents), "GATEKEEPER VERSION: ")
+	})
+	t.Run("gatherCodewindVersions - remote success", func(t *testing.T) {
+		diagnosticsDirName = testDir
+		remoteDirName := codewindPrefix + remoteConID
+		os.MkdirAll(filepath.Join(testDir, remoteDirName), 0755)
+		gatherCodewindVersions(remoteConID)
+		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, codewindPrefix+remoteConID, "codewind.versions"))
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Contains(t, string(contents), "CWCTL VERSION: ")
+		assert.Contains(t, string(contents), "PFE VERSION: ")
+		assert.Contains(t, string(contents), "PERFORMANCE VERSION: ")
+		assert.Contains(t, string(contents), "GATEKEEPER VERSION: ")
 	})
 }

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -12,20 +12,29 @@
 package actions
 
 import (
+	"archive/zip"
 	"encoding/json"
+	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/eclipse/codewind-installer/pkg/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
 
-const testDir = "./testDir/diagnostics"
+const parentTestDir = "./testDir"
+
+var testDir = filepath.Join(parentTestDir, "diagnostics")
 
 type testStruct struct {
 	Status  string `json:"status"`
@@ -42,6 +51,60 @@ func clearAllDiagnostics() {
 
 func getMockDockerClient() (docker.DockerClient, *docker.DockerError) {
 	return &docker.MockDockerClientWithCw{}, nil
+}
+
+func getMockDockerErrorClient() (docker.DockerClient, *docker.DockerError) {
+	return &docker.MockDockerErrorClient{}, nil
+}
+
+var dockerClientError = docker.DockerError{Op: "Error", Err: errors.New("error"), Desc: "test error"}
+
+func getDockerClientError() (docker.DockerClient, *docker.DockerError) {
+	return nil, &dockerClientError
+}
+
+//unzip file needed as utils.UnZip is not a straight unzipper of zips
+func unzipFile(filePath, destination string) error {
+	zipReader, _ := zip.OpenReader(filePath)
+	if zipReader == nil {
+		return fmt.Errorf("file '%s' is empty", filePath)
+	}
+
+	os.MkdirAll(destination, 0755)
+	for _, file := range zipReader.File {
+
+		zippedFile, err := file.Open()
+		if err != nil {
+			return errors.New("Unable to open zipped file")
+		}
+
+		extractedFilePath := filepath.Join(destination, file.Name)
+
+		if file.FileInfo().IsDir() {
+			// For debug:
+			// fmt.Println("Directory Created:", extractedFilePath)
+			os.MkdirAll(extractedFilePath, file.Mode())
+			zippedFile.Close()
+		} else {
+			// For debug:
+			// fmt.Println("File extracted:", file.Name)
+			os.MkdirAll(filepath.Dir(extractedFilePath), file.Mode())
+			outputFile, err := os.OpenFile(
+				extractedFilePath,
+				os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+				file.Mode(),
+			)
+			if err != nil {
+				return errors.New("unable to open file " + file.Name)
+			}
+
+			io.Copy(outputFile, zippedFile)
+			zippedFile.Close()
+			outputFile.Close()
+		}
+	}
+	zipReader.Close()
+	return nil
 }
 
 // clearAllDiagnostics()
@@ -120,7 +183,7 @@ func Test_writeJSONStructToFile(t *testing.T) {
 		}
 		readStructure := testStruct{}
 		_ = json.Unmarshal([]byte(file), &readStructure)
-		assert.Equal(t, readStructure, testStructure)
+		assert.Equal(t, testStructure, readStructure)
 	})
 }
 
@@ -132,6 +195,23 @@ func Test_copyCodewindWorkspace(t *testing.T) {
 			t.Error("Did not receive expected error")
 		}
 		assert.Equal(t, expectedErrorString, cCWerr.Error())
+	})
+	t.Run("copyCodewindWorkspace - docker client error", func(t *testing.T) {
+		diagnosticsLocalDirName = testDir
+		cCWerr := copyCodewindWorkspace("test", getDockerClientError)
+		if cCWerr == nil {
+			t.Error("Expected error not encountered")
+		}
+		assert.Equal(t, &dockerClientError, cCWerr)
+	})
+	t.Run("copyCodewindWorkspace - error from docker client", func(t *testing.T) {
+		diagnosticsLocalDirName = testDir
+		expectedError := docker.DockerError{Op: docker.ErrOpContainerError, Err: docker.ErrCopyFromContainer, Desc: docker.ErrCopyFromContainer.Error()}
+		cCWerr := copyCodewindWorkspace("test", getMockDockerErrorClient)
+		if cCWerr == nil {
+			t.Error("Expected error not encountered")
+		}
+		assert.Equal(t, &expectedError, cCWerr)
 	})
 	t.Run("copyCodewindWorkspace - success", func(t *testing.T) {
 		diagnosticsLocalDirName = testDir
@@ -152,6 +232,25 @@ func Test_writeContainerLogToFile(t *testing.T) {
 			t.Error("Did not receive expected error")
 		}
 		assert.Equal(t, expectedErrorString, wCLTFerr.Error())
+	})
+	t.Run("writeContainerLogToFile - docker client error", func(t *testing.T) {
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		wCLTFerr := writeContainerLogToFile("anything", conName, getDockerClientError)
+		if wCLTFerr == nil {
+			t.Error("Expected error not encountered")
+		}
+		assert.Equal(t, &dockerClientError, wCLTFerr)
+	})
+	t.Run("writeContainerLogToFile - error from docker client", func(t *testing.T) {
+		expectedError := docker.DockerError{Op: docker.ErrOpContainerLogs, Err: docker.ErrContainerLogs, Desc: docker.ErrContainerLogs.Error()}
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		wCLTFerr := writeContainerLogToFile("anything", conName, getMockDockerErrorClient)
+		if wCLTFerr == nil {
+			t.Error("Expected error not encountered")
+		}
+		assert.Equal(t, &expectedError, wCLTFerr)
 	})
 	t.Run("writeContainerLogToFile - success", func(t *testing.T) {
 		os.MkdirAll(testDir, 0755)
@@ -178,20 +277,55 @@ func Test_writeContainerInspectToFile(t *testing.T) {
 		}
 		assert.Equal(t, expectedErrorString, wCITFerr.Error())
 	})
+	t.Run("writeContainerLogToFile - docker client error", func(t *testing.T) {
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		wCITFerr := writeContainerInspectToFile("anything", conName, getDockerClientError)
+		if wCITFerr == nil {
+			t.Error("Expected error not encountered")
+		}
+		assert.Equal(t, &dockerClientError, wCITFerr)
+	})
+	t.Run("writeContainerInspectToFile - error from docker client", func(t *testing.T) {
+		expectedError := docker.DockerError{Op: docker.ErrOpContainerInspect, Err: docker.ErrContainerInspect, Desc: docker.ErrContainerInspect.Error()}
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		wCITFerr := writeContainerInspectToFile("anything", conName, getMockDockerErrorClient)
+		if wCITFerr == nil {
+			t.Error("Expected error not encountered")
+		}
+		assert.Equal(t, &expectedError, wCITFerr)
+	})
 	t.Run("writeContainerInspectToFile - success", func(t *testing.T) {
 		os.MkdirAll(testDir, 0755)
 		diagnosticsDirName = testDir
-		wCITFerr := writeContainerLogToFile("anything", conName, getMockDockerClient)
+		wCITFerr := writeContainerInspectToFile("anything", conName, getMockDockerClient)
 		if wCITFerr != nil {
 			t.Error("Error encountered - " + wCITFerr.Error())
 		}
-		// file output from mock client is empty, so no files to test for
+		file, fileErr := ioutil.ReadFile(filepath.Join(testDir, conName+".inspect"))
+		if fileErr != nil {
+			t.Error("Error encountered - " + fileErr.Error())
+		}
+		readStructure := types.ContainerJSON{}
+		_ = json.Unmarshal([]byte(file), &readStructure)
+		// fakeclient returns a JSON object where the only thing it sets is AutoRemove
+		assert.Equal(t, true, readStructure.ContainerJSONBase.HostConfig.AutoRemove)
 	})
 }
 
 func Test_getContainerID(t *testing.T) {
 	goodConName := "/codewind-pfe"
 	expectedGoodResult := "pfe"
+	expectedBadResult := ""
+	t.Run("writeContainerLogToFile - docker client error", func(t *testing.T) {
+		containerID := getContainerID(goodConName, getDockerClientError)
+		assert.Equal(t, expectedBadResult, containerID)
+	})
+	t.Run("writeContainerInspectToFile - error from docker client", func(t *testing.T) {
+		containerID := getContainerID(goodConName, getMockDockerErrorClient)
+		assert.Equal(t, expectedBadResult, containerID)
+	})
 	t.Run("getContainerID - success", func(t *testing.T) {
 		containerID := getContainerID(goodConName, getMockDockerClient)
 		assert.Equal(t, expectedGoodResult, containerID)
@@ -227,5 +361,187 @@ func Test_gatherCodewindVersions(t *testing.T) {
 		assert.Contains(t, string(contents), "PFE VERSION: ")
 		assert.Contains(t, string(contents), "PERFORMANCE VERSION: ")
 		assert.Contains(t, string(contents), "GATEKEEPER VERSION: ")
+	})
+}
+
+func Test_createZipAndRemoveCollectedFiles(t *testing.T) {
+	t.Run("createZipAndRemoveCollectedFiles - success", func(t *testing.T) {
+		diagnosticsDirName = testDir
+		testDgDir, _ := os.Open(testDir)
+		testfilenames, _ := testDgDir.Readdirnames(-1)
+		testDgDir.Close()
+		nowTime = time.Now().Format("20060102150405")
+		expectedZipFileName := "diagnostics." + nowTime + ".zip"
+		expectedZipFilePath := filepath.Join(diagnosticsDirName, expectedZipFileName)
+		createZipAndRemoveCollectedFiles()
+		assert.FileExists(t, expectedZipFilePath, "Unable to find "+expectedZipFileName)
+		unzipFile(expectedZipFilePath, testDir)
+		testDgDir, _ = os.Open(testDir)
+		testfilenamesAfter, _ := testDgDir.Readdirnames(-1)
+		testDgDir.Close()
+		assert.ElementsMatch(t, append(testfilenames, expectedZipFileName), testfilenamesAfter)
+		os.Remove(expectedZipFilePath)
+	})
+}
+
+func Test_findIntellijDirectory(t *testing.T) {
+	t.Run("findIntellijDirectory - success", func(t *testing.T) {
+		expectedResult := "IntelliJTest"
+		testDirectoryPath := filepath.Join(testDir, expectedResult)
+		os.MkdirAll(testDirectoryPath, 0755)
+		result := findIntellijDirectory(testDir)
+		assert.Equal(t, expectedResult, result)
+		os.Remove(testDirectoryPath)
+	})
+}
+
+func Test_gatherCodewindIntellijLogs(t *testing.T) {
+	t.Run("gatherCodewindIntellijLogs - success with provided path", func(t *testing.T) {
+		testLogsPath := filepath.Join(testDir, "IntelliJTest")
+		testLogsDir := "logDir"
+		testLogsFile := "testFile.log"
+		expectedLogFileContents := "Log: Test"
+		expectedLogDirectory := "intellijLogs"
+		expectedLogOutputPath := filepath.Join(testDir, expectedLogDirectory, testLogsDir, testLogsFile)
+		testLogsFilePath := filepath.Join(testLogsPath, testLogsDir, testLogsFile)
+		os.MkdirAll(filepath.Dir(testLogsFilePath), 0755)
+		ioutil.WriteFile(testLogsFilePath, []byte(expectedLogFileContents), 0666)
+		diagnosticsDirName = testDir
+		gatherCodewindIntellijLogs(testLogsPath)
+		assert.FileExists(t, expectedLogOutputPath, "Unable to find expected log file "+expectedLogOutputPath)
+		contents, rfErr := ioutil.ReadFile(expectedLogOutputPath)
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Equal(t, expectedLogFileContents, string(contents))
+	})
+	t.Run("gatherCodewindIntellijLogs - success with default", func(t *testing.T) {
+		homeDir = testDir
+		testLogsIntelliDir := "IntelliJTest"
+		var testLogsPath string
+		switch runtime.GOOS {
+		case "darwin":
+			testLogsPath = filepath.Join(testDir, "Library", "Logs", "JetBrains", testLogsIntelliDir)
+		case "linux":
+			testLogsPath = filepath.Join(testDir, ".cache", "JetBrains", testLogsIntelliDir, "log")
+		case "windows":
+			testLogsPath = filepath.Join(testDir, "AppData", "Local", "JetBrains", testLogsIntelliDir, "log")
+		}
+		testLogsDir := "logDir"
+		testLogsFile := "testFile.log"
+		expectedLogFileContents := "Log: Default Test"
+		expectedLogDirectory := "intellijLogs"
+		expectedLogOutputPath := filepath.Join(testDir, expectedLogDirectory, testLogsDir, testLogsFile)
+		testLogsFilePath := filepath.Join(testLogsPath, testLogsDir, testLogsFile)
+		os.MkdirAll(filepath.Dir(testLogsFilePath), 0755)
+		ioutil.WriteFile(testLogsFilePath, []byte(expectedLogFileContents), 0666)
+		diagnosticsDirName = testDir
+		gatherCodewindIntellijLogs("")
+		assert.FileExists(t, expectedLogOutputPath, "Unable to find expected log file "+expectedLogOutputPath)
+		contents, rfErr := ioutil.ReadFile(expectedLogOutputPath)
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Equal(t, expectedLogFileContents, string(contents))
+	})
+}
+
+func Test_gatherCodewindVSCodeLogs(t *testing.T) {
+	t.Run("gatherCodewindVSCodeLogs - success with default", func(t *testing.T) {
+		homeDir = testDir
+		var testLogsPath string
+		switch runtime.GOOS {
+		case "darwin":
+			testLogsPath = filepath.Join(testDir, "Library", "Application Support", "Code", "logs")
+		case "linux":
+			testLogsPath = filepath.Join(testDir, ".config", "Code", "logs")
+		case "windows":
+			testLogsPath = filepath.Join(testDir, "AppData", "Roaming", "Code", "logs")
+		}
+		testLogsDir := "logDir"
+		testLogsFile := "testFile.log"
+		expectedLogFileContents := "Log: Default Test"
+		expectedLogDirectory := "vsCodeLogs"
+		expectedLogOutputPath := filepath.Join(testDir, expectedLogDirectory, "logs", testLogsDir, testLogsFile)
+		testLogsFilePath := filepath.Join(testLogsPath, testLogsDir, testLogsFile)
+		os.MkdirAll(filepath.Dir(testLogsFilePath), 0755)
+		ioutil.WriteFile(testLogsFilePath, []byte(expectedLogFileContents), 0666)
+		diagnosticsDirName = testDir
+		gatherCodewindVSCodeLogs()
+		assert.FileExists(t, expectedLogOutputPath, "Unable to find expected log file "+expectedLogOutputPath)
+		contents, rfErr := ioutil.ReadFile(expectedLogOutputPath)
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Equal(t, expectedLogFileContents, string(contents))
+	})
+}
+
+func Test_gatherCodewindEclipseLogs(t *testing.T) {
+	t.Run("gatherCodewindEclipseLogs - success with provided path", func(t *testing.T) {
+		testEclipsePath := filepath.Join(testDir, "EclipseTest")
+		testLogsPath := filepath.Join(testEclipsePath, ".metadata")
+		testLogsFile := "testFile.log"
+		expectedLogFileContents := "Log: Test"
+		expectedLogDirectory := "eclipseLogs"
+		expectedLogOutputPath := filepath.Join(testDir, expectedLogDirectory, testLogsFile)
+		testLogsFilePath := filepath.Join(testLogsPath, testLogsFile)
+		os.MkdirAll(filepath.Dir(testLogsFilePath), 0755)
+		ioutil.WriteFile(testLogsFilePath, []byte(expectedLogFileContents), 0666)
+		diagnosticsDirName = testDir
+		gatherCodewindEclipseLogs(testEclipsePath)
+		assert.FileExists(t, expectedLogOutputPath, "Unable to find expected log file "+expectedLogOutputPath)
+		contents, rfErr := ioutil.ReadFile(expectedLogOutputPath)
+		if rfErr != nil {
+			t.Error("Error encountered - " + rfErr.Error())
+		}
+		assert.Equal(t, expectedLogFileContents, string(contents))
+	})
+}
+
+func Test_collectCodewindProjectContainers(t *testing.T) {
+	printAsJSON = false
+	t.Run("collectCodewindProjectContainers - docker client error", func(t *testing.T) {
+		warning := "Unable to get Docker client"
+		description := dockerClientError.Error()
+		expectedConsoleOutput := warning + ": " + description + "\n"
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		originalStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		collectCodewindProjectContainers(getDockerClientError)
+		w.Close()
+		out, _ := ioutil.ReadAll(r)
+		os.Stdout = originalStdout
+		assert.Equal(t, expectedConsoleOutput, string(out))
+	})
+	t.Run("writeContainerLogToFile - error from docker client", func(t *testing.T) {
+		expectedError := docker.DockerError{Op: docker.ErrOpContainerList, Err: docker.ErrContainerList, Desc: docker.ErrContainerList.Error()}
+		expectedConsoleOutput := "Unable to get Docker container list: " + expectedError.Error() + "\n"
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		originalStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		collectCodewindProjectContainers(getMockDockerErrorClient)
+		w.Close()
+		out, _ := ioutil.ReadAll(r)
+		os.Stdout = originalStdout
+		assert.Equal(t, expectedConsoleOutput, string(out))
+
+	})
+	t.Run("collectCodewindProjectContainers - success but can't find containers", func(t *testing.T) {
+		expectedConsoleOutput := "Collecting information from container /cw-testProject ... Unable to find local\\projects\\cw-testProject container: could not get container ID\nUnable to find local\\projects\\cw-testProject container: could not get container ID\ndone\n"
+		os.MkdirAll(testDir, 0755)
+		diagnosticsDirName = testDir
+		originalStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		collectCodewindProjectContainers(getMockDockerClient)
+		w.Close()
+		out, _ := ioutil.ReadAll(r)
+		os.Stdout = originalStdout
+		assert.Equal(t, expectedConsoleOutput, string(out))
 	})
 }

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -631,7 +631,7 @@ func Test_dgLocalCommand(t *testing.T) {
 		yamlFileName := "docker-compose.yaml"
 		diagnosticsLocalDirName = filepath.Join(testDir, "local")
 		expectedYamlOutputPath := filepath.Join(diagnosticsLocalDirName, yamlFileName)
-		os.MkdirAll(testDir, 0755)
+		os.MkdirAll(diagnosticsLocalDirName, 0755)
 		codewindHome = testDir
 		ioutil.WriteFile(filepath.Join(codewindHome, yamlFileName), []byte(expectedYamlFileContent), 0666)
 		originalStdout := os.Stdout

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -13,7 +13,8 @@ package actions
 
 import (
 	"flag"
-	"path/filepath"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,14 +29,43 @@ func clearAllDiagnostics() {
 	DiagnosticsCommand(context)
 }
 
-func TestDiagnosticsCommand_NoArgs(t *testing.T) {
-	clearAllDiagnostics()
-	app := cli.NewApp()
-	flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)
-	flagSet.String("conid", "local", "")
-	context := cli.NewContext(app, flagSet, nil)
-	t.Run("success case - no arguments specified", func(t *testing.T) {
-		DiagnosticsCommand(context)
-		assert.DirExists(t, filepath.Join(homeDir, ".codewind", "diagnostics"))
+// clearAllDiagnostics()
+// app := cli.NewApp()
+// flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)
+// flagSet.String("conid", "local", "")
+// context := cli.NewContext(app, flagSet, nil)
+// t.Run("local success case - no arguments specified", func(t *testing.T) {
+// 	originalStdout := os.Stdout
+// 	r, w, _ := os.Pipe()
+// 	os.Stdout = w
+// 	DiagnosticsCommand(context)
+// 	w.Close()
+// 	out, _ := ioutil.ReadAll(r)
+// 	os.Stdout = originalStdout
+// 	fmt.Println("Spitting out output")
+// 	fmt.Println(string(out))
+// 	assert.DirExists(t, filepath.Join(homeDir, ".codewind", "diagnostics"))
+//  })
+
+func TestWarnDG(t *testing.T) {
+	warning := "test_warn"
+	description := "test warning description"
+	expectedConsoleOutput := warning + ": " + description + "\n"
+	expectedJSONOutput := dgWarning{WarningType: warning, WarningDesc: description}
+	t.Run("warnDG - console", func(t *testing.T) {
+		originalStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		warnDG(warning, description)
+		w.Close()
+		out, _ := ioutil.ReadAll(r)
+		os.Stdout = originalStdout
+		assert.Equal(t, expectedConsoleOutput, string(out))
+	})
+	t.Run("warnDG - json", func(t *testing.T) {
+		dgWarningArray = []dgWarning{}
+		printAsJSON = true
+		warnDG(warning, description)
+		assert.Equal(t, expectedJSONOutput, dgWarningArray[0])
 	})
 }

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -358,23 +358,24 @@ func Test_gatherCodewindVersions(t *testing.T) {
 	localConID := "local"
 	remoteConID := "remote"
 	t.Run("gatherCodewindVersions - local success", func(t *testing.T) {
-		diagnosticsLocalDirName = testDir
+		diagnosticsDirName = testDir
 		gatherCodewindVersions(localConID)
-		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, "codewind.versions"))
+		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, localConID, "codewind.versions"))
 		if rfErr != nil {
 			t.Error("Error encountered - " + rfErr.Error())
 		}
 		assert.Contains(t, string(contents), "CWCTL VERSION: ")
 		assert.Contains(t, string(contents), "PFE VERSION: ")
 		assert.Contains(t, string(contents), "PERFORMANCE VERSION: ")
+		assert.Contains(t, string(contents), "DOCKER CLIENT VERSION: ")
+		assert.Contains(t, string(contents), "DOCKER SERVER VERSION: ")
 		assert.NotContains(t, string(contents), "GATEKEEPER VERSION: ")
 	})
 	t.Run("gatherCodewindVersions - remote success", func(t *testing.T) {
 		diagnosticsDirName = testDir
-		remoteDirName := codewindPrefix + remoteConID
-		os.MkdirAll(filepath.Join(testDir, remoteDirName), 0755)
+		os.MkdirAll(filepath.Join(testDir, remoteConID), 0755)
 		gatherCodewindVersions(remoteConID)
-		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, codewindPrefix+remoteConID, "codewind.versions"))
+		contents, rfErr := ioutil.ReadFile(filepath.Join(testDir, remoteConID, "codewind.versions"))
 		if rfErr != nil {
 			t.Error("Error encountered - " + rfErr.Error())
 		}
@@ -382,6 +383,8 @@ func Test_gatherCodewindVersions(t *testing.T) {
 		assert.Contains(t, string(contents), "PFE VERSION: ")
 		assert.Contains(t, string(contents), "PERFORMANCE VERSION: ")
 		assert.Contains(t, string(contents), "GATEKEEPER VERSION: ")
+		assert.NotContains(t, string(contents), "DOCKER CLIENT VERSION: ")
+		assert.NotContains(t, string(contents), "DOCKER SERVER VERSION: ")
 	})
 }
 

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package actions
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+)
+
+func clearAllDiagnostics() {
+	app := cli.NewApp()
+	flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)
+	flagSet.Bool("clean", true, "")
+	context := cli.NewContext(app, flagSet, nil)
+	DiagnosticsCommand(context)
+}
+
+func TestDiagnosticsCommand_NoArgs(t *testing.T) {
+	clearAllDiagnostics()
+	app := cli.NewApp()
+	flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)
+	flagSet.String("conid", "local", "")
+	context := cli.NewContext(app, flagSet, nil)
+	t.Run("success case - no arguments specified", func(t *testing.T) {
+		DiagnosticsCommand(context)
+		assert.DirExists(t, filepath.Join(homeDir, ".codewind", "diagnostics"))
+	})
+}

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -415,6 +415,9 @@ func Test_gatherCodewindVersions(t *testing.T) {
 }
 
 func Test_createZipAndRemoveCollectedFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
 	t.Run("createZipAndRemoveCollectedFiles - success", func(t *testing.T) {
 		diagnosticsDirName = testDir
 		testDgDir, _ := os.Open(testDir)
@@ -685,6 +688,9 @@ func Test_collectPodInfo(t *testing.T) {
 }
 
 func Test_confirmConnectionIDAndWorkspaceID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
 	t.Run("confirmConnectionIDAndWorkspaceID - connection not found", func(t *testing.T) {
 		expectedConsoleOutput := "connection_not_found: Unable to associate  with existing connection\n"
 		originalStdout := os.Stdout
@@ -755,6 +761,9 @@ func Test_getDockerVersions(t *testing.T) {
 }
 
 func Test_dgRemoteCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
 	// this runs collectPodInfo, which panics - so success is collecting the panic
 	printAsJSON = false
 	t.Run("dgRemoteCommand - codewind pod panic", func(t *testing.T) {
@@ -770,7 +779,7 @@ func Test_dgRemoteCommand(t *testing.T) {
 		}()
 		dgRemoteCommand("local", true, mockClientset)
 	})
-	t.Run("dgRemoteCommand - codewind pod panic", func(t *testing.T) {
+	t.Run("dgRemoteCommand - project pod panic", func(t *testing.T) {
 		mockClientset = fake.NewSimpleClientset(mockProjectPod, mockDeployment)
 		diagnosticsDirName = testDir
 		defer func() {
@@ -799,6 +808,9 @@ func Test_DiagnosticsCollect(t *testing.T) {
 		},
 	}
 	t.Run("DiagnosticsCollect - collect all ", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping testing in short mode")
+		}
 		diagnosticsDirName = testDir
 		app := cli.NewApp()
 		flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -44,14 +44,6 @@ type testStruct struct {
 	Message string `json:"message"`
 }
 
-// func clearAllDiagnostics() {
-// 	app := cli.NewApp()
-// 	flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)
-// 	flagSet.Bool("clean", true, "")
-// 	context := cli.NewContext(app, flagSet, nil)
-// 	DiagnosticsCommand(context)
-// }
-
 // mock docker clients
 
 func getMockDockerClient() (docker.DockerClient, *docker.DockerError) {
@@ -177,24 +169,6 @@ func isEmptyDir(name string) bool {
 	}
 	return false
 }
-
-// clearAllDiagnostics()
-// app := cli.NewApp()
-// flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)
-// flagSet.String("conid", "local", "")
-// context := cli.NewContext(app, flagSet, nil)
-// t.Run("local success case - no arguments specified", func(t *testing.T) {
-// 	originalStdout := os.Stdout
-// 	r, w, _ := os.Pipe()
-// 	os.Stdout = w
-// 	DiagnosticsCommand(context)
-// 	w.Close()
-// 	out, _ := ioutil.ReadAll(r)
-// 	os.Stdout = originalStdout
-// 	fmt.Println("Spitting out output")
-// 	fmt.Println(string(out))
-// 	assert.DirExists(t, filepath.Join(homeDir, ".codewind", "diagnostics"))
-//  })
 
 func Test_warnDG(t *testing.T) {
 	warning := "test_warn"

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -395,6 +395,7 @@ func Test_gatherCodewindVersions(t *testing.T) {
 		assert.Contains(t, string(contents), "DOCKER CLIENT VERSION: ")
 		assert.Contains(t, string(contents), "DOCKER SERVER VERSION: ")
 		assert.NotContains(t, string(contents), "GATEKEEPER VERSION: ")
+		os.RemoveAll(filepath.Join(testDir, localConID))
 	})
 	t.Run("gatherCodewindVersions - remote success", func(t *testing.T) {
 		diagnosticsDirName = testDir

--- a/pkg/actions/version.go
+++ b/pkg/actions/version.go
@@ -122,7 +122,7 @@ func GetAllConnectionVersions() {
 // RemoteListAll prints information for all remote installations in the given namespace
 func RemoteListAll(c *cli.Context) {
 	namespace := c.String("namespace")
-	remoteInstalls, err := remote.GetExistingDeployments(namespace)
+	remoteInstalls, err := remote.GetExistingDeployments(namespace, nil)
 	if err != nil {
 		HandleRemInstError(err)
 		os.Exit(1)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -460,7 +460,7 @@ func GetContainerListWithOptions(dockerClient DockerClient, options types.Contai
 
 	containers, err := dockerClient.ContainerList(ctx, options)
 	if err != nil {
-		return nil, &DockerError{errOpContainerList, err, err.Error()}
+		return nil, &DockerError{ErrOpContainerList, err, err.Error()}
 	}
 	return containers, nil
 }
@@ -508,7 +508,7 @@ func getContainerAutoRemovePolicy(dockerClient DockerClient, containerID string)
 
 	containerInfo, err := dockerClient.ContainerInspect(ctx, containerID)
 	if err != nil {
-		return false, &DockerError{errOpContainerInspect, err, err.Error()}
+		return false, &DockerError{ErrOpContainerInspect, err, err.Error()}
 	}
 
 	return containerInfo.HostConfig.AutoRemove, nil
@@ -715,7 +715,7 @@ func InspectContainer(dockerClient DockerClient, containerID string) (types.Cont
 
 	containerInfo, err := dockerClient.ContainerInspect(ctx, containerID)
 	if err != nil {
-		return types.ContainerJSON{nil, nil, nil, nil}, &DockerError{errOpContainerInspect, err, err.Error()}
+		return types.ContainerJSON{nil, nil, nil, nil}, &DockerError{ErrOpContainerInspect, err, err.Error()}
 	}
 	return containerInfo, nil
 }
@@ -726,7 +726,7 @@ func GetContainerLogs(dockerClient DockerClient, containerID string) (io.ReadClo
 
 	containerLogStream, err := dockerClient.ContainerLogs(ctx, containerID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
 	if err != nil {
-		return nil, &DockerError{errOpContainerLogs, err, err.Error()}
+		return nil, &DockerError{ErrOpContainerLogs, err, err.Error()}
 	}
 
 	return containerLogStream, nil
@@ -738,7 +738,7 @@ func GetFilesFromContainer(dockerClient DockerClient, containerID, path string) 
 
 	fileTarStream, _, err := dockerClient.CopyFromContainer(ctx, containerID, path)
 	if err != nil {
-		return nil, &DockerError{errOpContainerError, err, err.Error()}
+		return nil, &DockerError{ErrOpContainerError, err, err.Error()}
 	}
 
 	return fileTarStream, nil

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -750,7 +750,7 @@ func GetServerVersion(dockerClient DockerClient) (types.Version, *DockerError) {
 
 	version, err := dockerClient.ServerVersion(ctx)
 	if err != nil {
-		return version, &DockerError{errDockerVersion, err, err.Error()}
+		return version, &DockerError{ErrDockerVersion, err, err.Error()}
 	}
 
 	return version, nil

--- a/pkg/docker/docker_error.go
+++ b/pkg/docker/docker_error.go
@@ -21,11 +21,14 @@ type DockerError struct {
 }
 
 const (
-	errOpValidate                = "DOCKER_VALIDATE"
-	errOpClientCreate            = "CLIENT_CREATE_ERROR"
-	errOpContainerInspect        = "CONTAINER_INSPECT_ERROR"
-	errOpContainerLogs           = "CONTAINER_LOGS_ERROR"
-	errOpContainerError          = "CONTAINER_ERROR"
+	errOpValidate     = "DOCKER_VALIDATE"
+	errOpClientCreate = "CLIENT_CREATE_ERROR"
+	// ErrOpContainerInspect exported for test purposes
+	ErrOpContainerInspect = "CONTAINER_INSPECT_ERROR"
+	// ErrOpContainerLogs exported for test purposes
+	ErrOpContainerLogs = "CONTAINER_LOGS_ERROR"
+	// ErrOpContainerError exported for test purposes
+	ErrOpContainerError          = "CONTAINER_ERROR"
 	errOpStopContainer           = "CONTAINER_STOP_ERROR"
 	errOpDockerComposeFileCreate = "DOCKER_COMPOSE_FILE_CREATE_ERROR"
 	errOpDockerComposeStart      = "DOCKER_COMPOSE_START_ERROR"
@@ -36,10 +39,11 @@ const (
 	errOpImageTag                = "IMAGE_TAG_ERROR"
 	errOpImageRemove             = "IMAGE_REMOVE_ERROR"
 	errOpImageDigest             = "IMAGE_DIGEST_ERROR"
-	errOpContainerList           = "CONTAINER_LIST_ERROR"
-	errOpImageList               = "IMAGE_LIST_ERROR"
-	errDockerCredential          = "DOCKER_CREDENTIAL_ERROR"
-	errDockerVersion             = "DOCKER_VERSION_ERROR"
+	// ErrOpContainerList exported for test purposes
+	ErrOpContainerList  = "CONTAINER_LIST_ERROR"
+	errOpImageList      = "IMAGE_LIST_ERROR"
+	errDockerCredential = "DOCKER_CREDENTIAL_ERROR"
+	errDockerVersion    = "DOCKER_VERSION_ERROR"
 )
 
 const (

--- a/pkg/docker/docker_error.go
+++ b/pkg/docker/docker_error.go
@@ -43,7 +43,8 @@ const (
 	ErrOpContainerList  = "CONTAINER_LIST_ERROR"
 	errOpImageList      = "IMAGE_LIST_ERROR"
 	errDockerCredential = "DOCKER_CREDENTIAL_ERROR"
-	errDockerVersion    = "DOCKER_VERSION_ERROR"
+	// ErrDockerVersion exported for test purposes
+	ErrDockerVersion = "DOCKER_VERSION_ERROR"
 )
 
 const (

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -221,7 +221,7 @@ func TestGetAutoRemovePolicy(t *testing.T) {
 	t.Run("returns DockerError when docker ImageList errors", func(t *testing.T) {
 		client := &MockDockerErrorClient{}
 		_, err := getContainerAutoRemovePolicy(client, "pfe")
-		wantErr := &DockerError{ErrOpContainerInspect, errContainerInspect, errContainerInspect.Error()}
+		wantErr := &DockerError{ErrOpContainerInspect, ErrContainerInspect, ErrContainerInspect.Error()}
 		assert.Equal(t, wantErr, err)
 	})
 }
@@ -240,7 +240,7 @@ func TestStopContainer(t *testing.T) {
 	t.Run("returns DockerError when docker ContainerStop errors", func(t *testing.T) {
 		client := &MockDockerErrorClient{}
 		err := StopContainer(client, types.Container{})
-		containerInspectErr := &DockerError{ErrOpContainerInspect, errContainerInspect, errContainerInspect.Error()}
+		containerInspectErr := &DockerError{ErrOpContainerInspect, ErrContainerInspect, ErrContainerInspect.Error()}
 		wantErr := &DockerError{errOpStopContainer, containerInspectErr, containerInspectErr.Desc}
 		assert.Equal(t, wantErr, err)
 	})

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -26,7 +26,7 @@ func TestPullImage(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ImagePull errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		err := PullImage(client, "dummyImage", true)
 		wantErr := &DockerError{errOpImagePull, errImagePull, errImagePull.Error()}
 		assert.Equal(t, wantErr, err)
@@ -43,7 +43,7 @@ func TestGetImageList(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ImageList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, err := GetImageList(client)
 		wantErr := &DockerError{errOpImageList, errImageList, errImageList.Error()}
 		assert.Equal(t, wantErr, err)
@@ -60,9 +60,9 @@ func TestGetContainerList(t *testing.T) {
 	})
 
 	t.Run("returns error when docker ContainerList returns error", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, err := GetContainerList(client)
-		wantErr := &DockerError{errOpContainerList, errContainerList, errContainerList.Error()}
+		wantErr := &DockerError{ErrOpContainerList, ErrContainerList, ErrContainerList.Error()}
 		assert.Equal(t, wantErr, err)
 	})
 }
@@ -85,7 +85,7 @@ func TestCheckImageStatus(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ImageList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, err := CheckImageStatus(client)
 		wantErr := &DockerError{errOpImageList, errImageList, errImageList.Error()}
 		assert.Equal(t, wantErr, err)
@@ -126,10 +126,10 @@ func TestCheckContainerStatus(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ContainerList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 
 		_, err := CheckContainerStatus(client, LocalCWContainerNames)
-		wantErr := &DockerError{errOpContainerList, errContainerList, errContainerList.Error()}
+		wantErr := &DockerError{ErrOpContainerList, ErrContainerList, ErrContainerList.Error()}
 		assert.Equal(t, wantErr, err)
 	})
 }
@@ -144,7 +144,7 @@ func TestGetImageTags(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ImageList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, err := GetImageTags(client)
 		wantErr := &DockerError{errOpImageList, errImageList, errImageList.Error()}
 		assert.Equal(t, wantErr, err)
@@ -161,9 +161,9 @@ func TestGetContainerTags(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ContainerList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, err := GetContainerTags(client)
-		wantErr := &DockerError{errOpContainerList, errContainerList, errContainerList.Error()}
+		wantErr := &DockerError{ErrOpContainerList, ErrContainerList, ErrContainerList.Error()}
 		assert.Equal(t, err, wantErr)
 	})
 }
@@ -188,9 +188,9 @@ func TestGetPFEHostAndPort(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ContainerList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, _, err := GetPFEHostAndPort(client)
-		wantErr := &DockerError{errOpContainerList, errContainerList, errContainerList.Error()}
+		wantErr := &DockerError{ErrOpContainerList, ErrContainerList, ErrContainerList.Error()}
 		assert.Equal(t, wantErr, err)
 	})
 }
@@ -203,7 +203,7 @@ func TestValidateImageDigest(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ImageList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, err := ValidateImageDigest(client, "test:0.0.9")
 		wantErr := &DockerError{errOpImageList, errImageList, errImageList.Error()}
 		assert.Equal(t, wantErr, err)
@@ -219,9 +219,9 @@ func TestGetAutoRemovePolicy(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ImageList errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		_, err := getContainerAutoRemovePolicy(client, "pfe")
-		wantErr := &DockerError{errOpContainerInspect, errContainerInspect, errContainerInspect.Error()}
+		wantErr := &DockerError{ErrOpContainerInspect, errContainerInspect, errContainerInspect.Error()}
 		assert.Equal(t, wantErr, err)
 	})
 }
@@ -238,9 +238,9 @@ func TestStopContainer(t *testing.T) {
 	})
 
 	t.Run("returns DockerError when docker ContainerStop errors", func(t *testing.T) {
-		client := &mockDockerErrorClient{}
+		client := &MockDockerErrorClient{}
 		err := StopContainer(client, types.Container{})
-		containerInspectErr := &DockerError{errOpContainerInspect, errContainerInspect, errContainerInspect.Error()}
+		containerInspectErr := &DockerError{ErrOpContainerInspect, errContainerInspect, errContainerInspect.Error()}
 		wantErr := &DockerError{errOpStopContainer, containerInspectErr, containerInspectErr.Desc}
 		assert.Equal(t, wantErr, err)
 	})

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestPullImage(t *testing.T) {
 	t.Run("does not error when docker ImagePull succeeds", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 		err := PullImage(client, "dummyImage", true)
 		assert.Nil(t, err)
 	})
@@ -35,7 +35,7 @@ func TestPullImage(t *testing.T) {
 
 func TestGetImageList(t *testing.T) {
 	t.Run("gets the image list that is returned by the docker client", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		imageList, err := GetImageList(client)
 		assert.Nil(t, err)
@@ -52,7 +52,7 @@ func TestGetImageList(t *testing.T) {
 
 func TestGetContainerList(t *testing.T) {
 	t.Run("gets the container list that is returned by the docker client", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		containerList, err := GetContainerList(client)
 		assert.Nil(t, err)
@@ -69,7 +69,7 @@ func TestGetContainerList(t *testing.T) {
 
 func TestCheckImageStatus(t *testing.T) {
 	t.Run("returns true when correct images are returned by the docker client", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		imageStatus, err := CheckImageStatus(client)
 		assert.Nil(t, err)
@@ -94,7 +94,7 @@ func TestCheckImageStatus(t *testing.T) {
 
 func TestCheckContainerStatus(t *testing.T) {
 	t.Run("returns true when correct containers are returned by the docker client", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		containerStatus, err := CheckContainerStatus(client, LocalCWContainerNames)
 		assert.Nil(t, err)
@@ -102,7 +102,7 @@ func TestCheckContainerStatus(t *testing.T) {
 	})
 
 	t.Run("returns true when checking for only PFE", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		containerStatus, err := CheckContainerStatus(client, []string{PfeContainerName})
 		assert.Nil(t, err)
@@ -136,7 +136,7 @@ func TestCheckContainerStatus(t *testing.T) {
 
 func TestGetImageTags(t *testing.T) {
 	t.Run("returns the image tags set in the ImageList mock", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		imageTags, err := GetImageTags(client)
 		assert.Nil(t, err)
@@ -153,7 +153,7 @@ func TestGetImageTags(t *testing.T) {
 
 func TestGetContainerTags(t *testing.T) {
 	t.Run("returns the container tags set in the ContainerList mock", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		imageTags, err := GetContainerTags(client)
 		assert.Nil(t, err)
@@ -170,7 +170,7 @@ func TestGetContainerTags(t *testing.T) {
 
 func TestGetPFEHostAndPort(t *testing.T) {
 	t.Run("returns the PFE host and port set in the ContainerList mock", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 
 		host, port, err := GetPFEHostAndPort(client)
 		assert.Nil(t, err)
@@ -197,7 +197,7 @@ func TestGetPFEHostAndPort(t *testing.T) {
 
 func TestValidateImageDigest(t *testing.T) {
 	t.Run("no error returned when image digests match those from dockerhub", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 		_, err := ValidateImageDigest(client, "test:0.0.9")
 		assert.Nil(t, err)
 	})
@@ -212,7 +212,7 @@ func TestValidateImageDigest(t *testing.T) {
 
 func TestGetAutoRemovePolicy(t *testing.T) {
 	t.Run("no error returned when image digests match those from dockerhub", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 		autoremovePolicy, err := getContainerAutoRemovePolicy(client, "pfe")
 		assert.Nil(t, err)
 		assert.True(t, autoremovePolicy)
@@ -228,7 +228,7 @@ func TestGetAutoRemovePolicy(t *testing.T) {
 
 func TestStopContainer(t *testing.T) {
 	t.Run("no error returned when container is stopped", func(t *testing.T) {
-		client := &mockDockerClientWithCw{}
+		client := &MockDockerClientWithCw{}
 		err := StopContainer(client, types.Container{
 			Names: []string{"/codewind-pfe"},
 			ID:    "pfe",

--- a/pkg/docker/fakeclient.go
+++ b/pkg/docker/fakeclient.go
@@ -47,6 +47,9 @@ var mockContainerListWithCwContainers = []types.Container{
 	types.Container{
 		Names: []string{"/codewind-performance"},
 		Image: "eclipse/codewind-performance:0.0.9"},
+	types.Container{
+		Names: []string{"/cw-testProject"},
+		Image: "eclipse/codewind-performance:0.0.9"},
 }
 
 var mockContainerListWithOnlyPFEContainer = []types.Container{
@@ -299,69 +302,93 @@ func (m *mockDockerClientWithoutCw) ServerVersion(ctx context.Context) (types.Ve
 	return types.Version{Platform: struct{ Name string }{""}, Components: []types.ComponentVersion{}, Version: "", APIVersion: "", MinAPIVersion: "", GitCommit: "", GoVersion: "", Os: "", Arch: "", KernelVersion: "", Experimental: true, BuildTime: ""}, nil
 }
 
-// This mock client will return errors for each call to a docker function
-type mockDockerErrorClient struct {
+//MockDockerErrorClient - This mock client will return errors for each call to a docker function
+type MockDockerErrorClient struct {
 }
 
 var errImagePull = errors.New("error pulling image")
 var errImageList = errors.New("error listing images")
-var errContainerList = errors.New("error listing containers")
+
+//ErrContainerInspect - exported for testing purposes
+var ErrContainerList = errors.New("error listing containers")
 var errContainerStop = errors.New("error stopping container")
 var errContainerRemove = errors.New("error removing container")
-var errContainerInspect = errors.New("error inspecting container")
+
+//ErrContainerInspect - exported for testing purposes
+var ErrContainerInspect = errors.New("error inspecting container")
 var errDistributionInspect = errors.New("error inspecting distribution")
 
-func (m *mockDockerErrorClient) ImageList(ctx context.Context, imageListOptions types.ImageListOptions) ([]types.ImageSummary, error) {
+//ErrContainerLogs - exported for testing purposes
+var ErrContainerLogs = errors.New("error getting container logs")
+
+//ErrCopyFromContainer - exported for testing purposes
+var ErrCopyFromContainer = errors.New("error copying files from container")
+var errServerVersion = errors.New("error getting server version")
+
+//ImageList - returns an error
+func (m *MockDockerErrorClient) ImageList(ctx context.Context, imageListOptions types.ImageListOptions) ([]types.ImageSummary, error) {
 	return nil, errImageList
 }
 
-func (m *mockDockerErrorClient) ImagePull(ctx context.Context, image string, imagePullOptions types.ImagePullOptions) (io.ReadCloser, error) {
+//ImagePull - returns an error
+func (m *MockDockerErrorClient) ImagePull(ctx context.Context, image string, imagePullOptions types.ImagePullOptions) (io.ReadCloser, error) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
 	return r, errImagePull
 }
 
-func (m *mockDockerErrorClient) ContainerList(ctx context.Context, containerListOptions types.ContainerListOptions) ([]types.Container, error) {
-	return []types.Container{}, errContainerList
+//ContainerList - returns an error
+func (m *MockDockerErrorClient) ContainerList(ctx context.Context, containerListOptions types.ContainerListOptions) ([]types.Container, error) {
+	return []types.Container{}, ErrContainerList
 }
 
-func (m *mockDockerErrorClient) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
+//ContainerStop - returns an error
+func (m *MockDockerErrorClient) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
 	return errContainerStop
 }
 
-func (m *mockDockerErrorClient) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
+//ContainerRemove - returns an error
+func (m *MockDockerErrorClient) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
 	return errContainerRemove
 }
 
-func (m *mockDockerErrorClient) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
-	return types.ContainerJSON{}, errContainerInspect
+//ContainerInspect - returns an error
+func (m *MockDockerErrorClient) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	return types.ContainerJSON{}, ErrContainerInspect
 }
 
-func (m *mockDockerErrorClient) DaemonHost() string {
+//DaemonHost - returns an empty string
+func (m *MockDockerErrorClient) DaemonHost() string {
 	return ""
 }
 
-func (m *mockDockerErrorClient) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
+//DistributionInspect - returns an error
+func (m *MockDockerErrorClient) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
 	return registry.DistributionInspect{}, errDistributionInspect
 }
 
-func (m *mockDockerErrorClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+//RegistryLogin - returns an error
+func (m *MockDockerErrorClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	return registry.AuthenticateOKBody{}, nil
 }
 
-func (m *mockDockerErrorClient) ClientVersion() string {
+//ClientVersion - returns an empty string
+func (m *MockDockerErrorClient) ClientVersion() string {
 	return ""
 }
 
-func (m *mockDockerErrorClient) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+//ContainerLogs - returns an error
+func (m *MockDockerErrorClient) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
-	return r, nil
+	return r, ErrContainerLogs
 }
 
-func (m *mockDockerErrorClient) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
+//CopyFromContainer - returns an error
+func (m *MockDockerErrorClient) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
-	return r, types.ContainerPathStat{Name: "", Size: 0, Mode: 0, Mtime: time.Now(), LinkTarget: ""}, nil
+	return r, types.ContainerPathStat{Name: "", Size: 0, Mode: 0, Mtime: time.Now(), LinkTarget: ""}, ErrCopyFromContainer
 }
 
-func (m *mockDockerErrorClient) ServerVersion(ctx context.Context) (types.Version, error) {
-	return types.Version{Platform: struct{ Name string }{""}, Components: []types.ComponentVersion{}, Version: "", APIVersion: "", MinAPIVersion: "", GitCommit: "", GoVersion: "", Os: "", Arch: "", KernelVersion: "", Experimental: true, BuildTime: ""}, nil
+//ServerVersion - returns an error
+func (m *MockDockerErrorClient) ServerVersion(ctx context.Context) (types.Version, error) {
+	return types.Version{Platform: struct{ Name string }{""}, Components: []types.ComponentVersion{}, Version: "", APIVersion: "", MinAPIVersion: "", GitCommit: "", GoVersion: "", Os: "", Arch: "", KernelVersion: "", Experimental: true, BuildTime: ""}, errServerVersion
 }

--- a/pkg/docker/fakeclient.go
+++ b/pkg/docker/fakeclient.go
@@ -79,50 +79,60 @@ var mockContainerListWithoutCwContainers = []types.Container{
 	},
 }
 
-// This mock client will return container and images lists, with Codewind items included
-type mockDockerClientWithCw struct {
+//MockDockerClientWithCw - This mock client will return container and images lists, with Codewind items included
+type MockDockerClientWithCw struct {
 }
 
-func (m *mockDockerClientWithCw) ImagePull(ctx context.Context, image string, imagePullOptions types.ImagePullOptions) (io.ReadCloser, error) {
+//ImagePull - returns empty ReadCloser
+func (m *MockDockerClientWithCw) ImagePull(ctx context.Context, image string, imagePullOptions types.ImagePullOptions) (io.ReadCloser, error) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
 	return r, nil
 }
 
-func (m *mockDockerClientWithCw) ImageList(ctx context.Context, imageListOptions types.ImageListOptions) ([]types.ImageSummary, error) {
+//ImageList - reutrns some mock images
+func (m *MockDockerClientWithCw) ImageList(ctx context.Context, imageListOptions types.ImageListOptions) ([]types.ImageSummary, error) {
 	return mockImageSummaryWithCwImages, nil
 }
 
-func (m *mockDockerClientWithCw) ContainerList(ctx context.Context, containerListOptions types.ContainerListOptions) ([]types.Container, error) {
+//ContainerList - returns some mock containers
+func (m *MockDockerClientWithCw) ContainerList(ctx context.Context, containerListOptions types.ContainerListOptions) ([]types.Container, error) {
 	return mockContainerListWithCwContainers, nil
 }
 
-func (m *mockDockerClientWithCw) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
+//ContainerStop - returns no errors
+func (m *MockDockerClientWithCw) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
 	return nil
 }
 
-func (m *mockDockerClientWithCw) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
+//ContainerRemove - returns no errors
+func (m *MockDockerClientWithCw) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
 	return nil
 }
 
-func (m *mockDockerClientWithCw) ClientVersion() string {
+//ClientVersion - returns empty string
+func (m *MockDockerClientWithCw) ClientVersion() string {
 	return ""
 }
 
-func (m *mockDockerClientWithCw) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+//ContainerLogs - returns empty ReadCloser
+func (m *MockDockerClientWithCw) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
 	return r, nil
 }
 
-func (m *mockDockerClientWithCw) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
+//CopyFromContainer - returns empty ReadCloser, empty ContainerPathStat
+func (m *MockDockerClientWithCw) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
 	return r, types.ContainerPathStat{Name: "", Size: 0, Mode: 0, Mtime: time.Now(), LinkTarget: ""}, nil
 }
 
-func (m *mockDockerClientWithCw) ServerVersion(ctx context.Context) (types.Version, error) {
+//ServerVersion - returns empty Version struct
+func (m *MockDockerClientWithCw) ServerVersion(ctx context.Context) (types.Version, error) {
 	return types.Version{Platform: struct{ Name string }{""}, Components: []types.ComponentVersion{}, Version: "", APIVersion: "", MinAPIVersion: "", GitCommit: "", GoVersion: "", Os: "", Arch: "", KernelVersion: "", Experimental: true, BuildTime: ""}, nil
 }
 
-func (m *mockDockerClientWithCw) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+//ContainerInspect - returns basic ContainerJSON
+func (m *MockDockerClientWithCw) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
 	return types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{
 			HostConfig: &container.HostConfig{
@@ -132,11 +142,13 @@ func (m *mockDockerClientWithCw) ContainerInspect(ctx context.Context, container
 	}, nil
 }
 
-func (m *mockDockerClientWithCw) DaemonHost() string {
+//DaemonHost - returns empty string
+func (m *MockDockerClientWithCw) DaemonHost() string {
 	return ""
 }
 
-func (m *mockDockerClientWithCw) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
+//DistributionInspect - returns a basic DistributionInspect
+func (m *MockDockerClientWithCw) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error) {
 	return registry.DistributionInspect{
 		Descriptor: v1.Descriptor{
 			Digest: "sha256:7173b809",
@@ -144,7 +156,8 @@ func (m *mockDockerClientWithCw) DistributionInspect(ctx context.Context, image,
 	}, nil
 }
 
-func (m *mockDockerClientWithCw) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+//RegistryLogin - returns basic AuthenticateOKBody
+func (m *MockDockerClientWithCw) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	return registry.AuthenticateOKBody{}, nil
 }
 

--- a/pkg/docker/fakeclient.go
+++ b/pkg/docker/fakeclient.go
@@ -309,7 +309,7 @@ type MockDockerErrorClient struct {
 var errImagePull = errors.New("error pulling image")
 var errImageList = errors.New("error listing images")
 
-//ErrContainerInspect - exported for testing purposes
+//ErrContainerList - exported for testing purposes
 var ErrContainerList = errors.New("error listing containers")
 var errContainerStop = errors.New("error stopping container")
 var errContainerRemove = errors.New("error removing container")
@@ -323,7 +323,9 @@ var ErrContainerLogs = errors.New("error getting container logs")
 
 //ErrCopyFromContainer - exported for testing purposes
 var ErrCopyFromContainer = errors.New("error copying files from container")
-var errServerVersion = errors.New("error getting server version")
+
+//ErrServerVersion - exported for testing purposes
+var ErrServerVersion = errors.New("error getting server version")
 
 //ImageList - returns an error
 func (m *MockDockerErrorClient) ImageList(ctx context.Context, imageListOptions types.ImageListOptions) ([]types.ImageSummary, error) {
@@ -390,5 +392,5 @@ func (m *MockDockerErrorClient) CopyFromContainer(ctx context.Context, container
 
 //ServerVersion - returns an error
 func (m *MockDockerErrorClient) ServerVersion(ctx context.Context) (types.Version, error) {
-	return types.Version{Platform: struct{ Name string }{""}, Components: []types.ComponentVersion{}, Version: "", APIVersion: "", MinAPIVersion: "", GitCommit: "", GoVersion: "", Os: "", Arch: "", KernelVersion: "", Experimental: true, BuildTime: ""}, errServerVersion
+	return types.Version{Platform: struct{ Name string }{""}, Components: []types.ComponentVersion{}, Version: "", APIVersion: "", MinAPIVersion: "", GitCommit: "", GoVersion: "", Os: "", Arch: "", KernelVersion: "", Experimental: true, BuildTime: ""}, ErrServerVersion
 }

--- a/pkg/remote/deploy_get.go
+++ b/pkg/remote/deploy_get.go
@@ -35,18 +35,21 @@ type K8sAPI struct {
 }
 
 // GetExistingDeployments returns information about the remote installations of codewind, across all namespaces by default
-func GetExistingDeployments(namespace string) ([]ExistingDeployment, *RemInstError) {
-	config, err := GetKubeConfig()
-
-	if err != nil {
-		logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
-		return nil, &RemInstError{errOpNotFound, err, err.Error()}
-	}
-
+func GetExistingDeployments(namespace string, clientset kubernetes.Interface) ([]ExistingDeployment, *RemInstError) {
 	client := K8sAPI{}
-	client.clientset, err = kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, &RemInstError{errOpNotFound, err, err.Error()}
+	if clientset == nil {
+		config, err := GetKubeConfig()
+		if err != nil {
+			logr.Infof("Unable to retrieve Kubernetes Config %v\n", err)
+			return nil, &RemInstError{errOpNotFound, err, err.Error()}
+		}
+
+		client.clientset, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, &RemInstError{errOpNotFound, err, err.Error()}
+		}
+	} else {
+		client.clientset = clientset
 	}
 
 	deployments, RemInstErr := client.findDeployments(namespace)

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -60,7 +60,7 @@ func UnZip(filePath, destination string) error {
 		errors.CheckErr(err, 402, "")
 		defer zippedFile.Close()
 
-		fileNameArr := strings.Split(file.Name, string(os.PathSeparator))
+		fileNameArr := strings.Split(file.Name, "/")
 		extractedFilePath = destination
 
 		for i := 1; i < len(fileNameArr); i++ {

--- a/pkg/utils/filesystem.go
+++ b/pkg/utils/filesystem.go
@@ -60,7 +60,7 @@ func UnZip(filePath, destination string) error {
 		errors.CheckErr(err, 402, "")
 		defer zippedFile.Close()
 
-		fileNameArr := strings.Split(file.Name, "/")
+		fileNameArr := strings.Split(file.Name, string(os.PathSeparator))
 		extractedFilePath = destination
 
 		for i := 1; i < len(fileNameArr); i++ {


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
This PR creates unit tests for `diagnostics.go` using the golang testing package. It also alters some docker and version resources to allow sharing of test docker clients, and to allow the `Kubernetes.fake` client to be passed through some of the structure of CWCTL functions in order to test the diagnostic functions that use Kube Client. Test coverage at time of delivery is 84.4%.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2927
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2927

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
To run the tests, navigate to the package (pkg/actions) and run `go test`. To see coverage, run `go test -v -coverprofile cpout` followed by `go tool cover -html=cpout`.