### PR TITLE
Fixing diagnostics tests to work on Jenkins

### DIFF
--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -150,11 +150,11 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 
 		if file.FileInfo().IsDir() {
 			t.Log("file is dir")
-			os.MkdirAll(extractedFilePath, file.Mode())
+			os.MkdirAll(extractedFilePath, 0755)
 			zippedFile.Close()
 		} else {
 			t.Log("file is file")
-			dirErr := os.MkdirAll(filepath.Dir(extractedFilePath), file.Mode())
+			dirErr := os.MkdirAll(filepath.Dir(extractedFilePath), 0755)
 			if dirErr != nil {
 				zippedFile.Close()
 				return errors.New("unable to create directory " + filepath.Dir(extractedFilePath) + ": " + dirErr.Error())

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -141,6 +141,7 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 		zippedFile, err := file.Open()
 		if err != nil {
 			t.Log("Unable to open zipped file " + file.Name)
+			zipReader.Close()
 			return errors.New("Unable to open zipped file")
 		}
 
@@ -157,7 +158,11 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 			// For debug:
 			// fmt.Println("File extracted:", file.Name)
 			t.Log("file is file")
-			os.MkdirAll(filepath.Dir(extractedFilePath), file.Mode())
+			dirErr := os.MkdirAll(filepath.Dir(extractedFilePath), file.Mode())
+			if dirErr != nil {
+				zippedFile.Close()
+				return errors.New("unable to open file " + file.Name + ": " + err.Error())
+			}
 			outputFile, err := os.OpenFile(
 				extractedFilePath,
 				os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
@@ -165,7 +170,7 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 			)
 			if err != nil {
 				zippedFile.Close()
-				return errors.New("unable to open file " + file.Name)
+				return errors.New("unable to open file " + file.Name + ": " + err.Error())
 			}
 
 			io.Copy(outputFile, zippedFile)

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -459,7 +459,7 @@ func Test_createZipAndRemoveCollectedFiles(t *testing.T) {
 		assert.FileExists(t, expectedZipFilePath, "Unable to find "+expectedZipFileName)
 		// Jenkins test - what's in the zip file
 		t.Log("Contents of " + expectedZipFilePath)
-		read, _ := zip.OpenReader("test.zip")
+		read, _ := zip.OpenReader(expectedZipFilePath)
 		for _, file := range read.File {
 			t.Log(file.Name)
 		}

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -140,7 +140,7 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 
 		zippedFile, err := file.Open()
 		if err != nil {
-			t.Log("Unable to open zipped file " + file.Name))
+			t.Log("Unable to open zipped file " + file.Name)
 			return errors.New("Unable to open zipped file")
 		}
 

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -134,6 +134,7 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 		t.Log("Error - zipreader is empty")
 		return fmt.Errorf("file '%s' is empty", filePath)
 	}
+	defer zipReader.Close()
 
 	os.MkdirAll(destination, 0755)
 	for _, file := range zipReader.File {
@@ -141,7 +142,6 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 		zippedFile, err := file.Open()
 		if err != nil {
 			t.Log("Unable to open zipped file " + file.Name)
-			zipReader.Close()
 			return errors.New("Unable to open zipped file")
 		}
 
@@ -149,19 +149,15 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 		t.Log("extractedFilePath = " + extractedFilePath)
 
 		if file.FileInfo().IsDir() {
-			// For debug:
-			// fmt.Println("Directory Created:", extractedFilePath)
 			t.Log("file is dir")
 			os.MkdirAll(extractedFilePath, file.Mode())
 			zippedFile.Close()
 		} else {
-			// For debug:
-			// fmt.Println("File extracted:", file.Name)
 			t.Log("file is file")
 			dirErr := os.MkdirAll(filepath.Dir(extractedFilePath), file.Mode())
 			if dirErr != nil {
 				zippedFile.Close()
-				return errors.New("unable to open file " + file.Name + ": " + err.Error())
+				return errors.New("unable to create directory " + filepath.Dir(extractedFilePath) + ": " + dirErr.Error())
 			}
 			outputFile, err := os.OpenFile(
 				extractedFilePath,
@@ -178,7 +174,6 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 			zippedFile.Close()
 		}
 	}
-	zipReader.Close()
 	return nil
 }
 

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -128,7 +128,7 @@ func returnMockConnections() ([]connections.Connection, *connections.ConError) {
 
 //unzip file needed as utils.UnZip is not a straight unzipper of zips
 func unzipFile(t *testing.T, filePath, destination string) error {
-	t.Log("Unzipping "+filePath+" to "+destination)
+	t.Log("Unzipping " + filePath + " to " + destination)
 	zipReader, _ := zip.OpenReader(filePath)
 	if zipReader == nil {
 		t.Log("Error - zipreader is empty")
@@ -145,7 +145,7 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 		}
 
 		extractedFilePath := filepath.Join(destination, file.Name)
-		t.Log("extractedFilePath = "+extractedFilePath)
+		t.Log("extractedFilePath = " + extractedFilePath)
 
 		if file.FileInfo().IsDir() {
 			// For debug:
@@ -164,7 +164,7 @@ func unzipFile(t *testing.T, filePath, destination string) error {
 				file.Mode(),
 			)
 			if err != nil {
-			    zippedFile.Close()
+				zippedFile.Close()
 				return errors.New("unable to open file " + file.Name)
 			}
 
@@ -472,9 +472,9 @@ func Test_createZipAndRemoveCollectedFiles(t *testing.T) {
 		}
 		read.Close()
 		unzipErr := unzipFile(t, expectedZipFilePath, testDir)
-		if unzipErr != nil (
-			t.Error("Problems encountered unzipping "+expectedZipFilePath+": "+unzipErr.Error())
-		)
+		if unzipErr != nil {
+			t.Error("Problems encountered unzipping " + expectedZipFilePath + ": " + unzipErr.Error())
+		}
 		testDgAfterDir, _ := os.Open(testDir)
 		testfilenamesAfter, _ := testDgAfterDir.Readdirnames(-1)
 		testDgAfterDir.Close()

--- a/pkg/actions/diagnostics_test.go
+++ b/pkg/actions/diagnostics_test.go
@@ -439,9 +439,6 @@ func Test_gatherCodewindVersions(t *testing.T) {
 }
 
 func Test_createZipAndRemoveCollectedFiles(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping testing in short mode")
-	}
 	t.Run("createZipAndRemoveCollectedFiles - success", func(t *testing.T) {
 		diagnosticsDirName = testDir
 		testDgDir, _ := os.Open(testDir)
@@ -460,6 +457,13 @@ func Test_createZipAndRemoveCollectedFiles(t *testing.T) {
 		expectedZipFilePath := filepath.Join(diagnosticsDirName, expectedZipFileName)
 		createZipAndRemoveCollectedFiles()
 		assert.FileExists(t, expectedZipFilePath, "Unable to find "+expectedZipFileName)
+		// Jenkins test - what's in the zip file
+		t.Log("Contents of " + expectedZipFilePath)
+		read, _ := zip.OpenReader("test.zip")
+		for _, file := range read.File {
+			t.Log(file.Name)
+		}
+		read.Close()
 		unzipFile(expectedZipFilePath, testDir)
 		testDgAfterDir, _ := os.Open(testDir)
 		testfilenamesAfter, _ := testDgAfterDir.Readdirnames(-1)
@@ -828,9 +832,6 @@ func Test_DiagnosticsCollect(t *testing.T) {
 	oldGetAllConnections := getAllConnections
 	getAllConnections = returnMockConnections
 	t.Run("DiagnosticsCollect - collect all ", func(t *testing.T) {
-		if testing.Short() {
-			t.Skip("skipping testing in short mode")
-		}
 		diagnosticsDirName = testDir
 		app := cli.NewApp()
 		flagSet := flag.NewFlagSet("userFlags", flag.ContinueOnError)


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
This PR alters the diagnostic test suite so that tests that had to be skipped for Jenkins can be re-enabled. It achieves this by utilising file-wide variables to hold critical functions and structures, which the unit test file can then re-assign for mocking purposes.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3039
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3039
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No