### PR TITLE
test: fix assert.Equals assertions

### DIFF
--- a/pkg/apiroutes/pfe-ready_test.go
+++ b/pkg/apiroutes/pfe-ready_test.go
@@ -25,7 +25,7 @@ func Test_IsPFEReady(t *testing.T) {
 		if err != nil {
 			t.Fail()
 		}
-		assert.Equal(t, PFEReady, true)
+		assert.True(t, PFEReady)
 	})
 	t.Run("Asserts PFE not ready", func(t *testing.T) {
 		mockClientFalse := &MockResponse{StatusCode: http.StatusNotFound, Body: nil}
@@ -33,6 +33,6 @@ func Test_IsPFEReady(t *testing.T) {
 		if err != nil {
 			t.Fail()
 		}
-		assert.Equal(t, PFENotReady, false)
+		assert.False(t, PFENotReady)
 	})
 }

--- a/pkg/connections/connection_test.go
+++ b/pkg/connections/connection_test.go
@@ -82,7 +82,7 @@ func Test_GetAllConnections(t *testing.T) {
 			t.Fail()
 		}
 		assert.Len(t, result, 1)
-		assert.Equal(t, result[0].ID, "local")
+		assert.Equal(t, "local", result[0].ID)
 	})
 }
 

--- a/pkg/project/bind_test.go
+++ b/pkg/project/bind_test.go
@@ -65,7 +65,7 @@ func TestBindToPFE(t *testing.T) {
 			if projErr != nil {
 				t.Errorf("bindToPFE() returned the following error: %s", projErr.Desc)
 			}
-			assert.Equal(t, got, &test.bindResponse)
+			assert.Equal(t, &test.bindResponse, got)
 		})
 	}
 
@@ -119,5 +119,5 @@ func TestCompleteBind(t *testing.T) {
 	mockClient := &security.ClientMockAuthenticate{StatusCode: http.StatusOK, Body: nil}
 	mockConnection := connections.Connection{ID: "local"}
 	_, gotStatusCode := completeBind(mockClient, "testID", "dummyURL", &mockConnection)
-	assert.Equal(t, gotStatusCode, http.StatusOK)
+	assert.Equal(t, http.StatusOK, gotStatusCode)
 }

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -98,7 +98,7 @@ func TestDownloadTemplate(t *testing.T) {
 		out, err := DownloadTemplate(dest, url, gitCredentials)
 
 		assert.Nil(t, out)
-		assert.Equal(t, err.Desc, "unexpected status code: 401 Unauthorized")
+		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
 	})
 	t.Run("fail case: download GHE template using bad personalAccessToken)", func(t *testing.T) {
 		os.RemoveAll(testDir)
@@ -114,7 +114,7 @@ func TestDownloadTemplate(t *testing.T) {
 		out, err := DownloadTemplate(dest, url, gitCredentials)
 
 		assert.Nil(t, out)
-		assert.Equal(t, err.Desc, "unexpected status code: 401 Unauthorized")
+		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
 	})
 }
 
@@ -268,21 +268,21 @@ func TestWriteNewCwSettings(t *testing.T) {
 
 			cwSettings := readCwSettings(test.inProjectPath)
 
-			assert.Equal(t, cwSettings.ContextRoot, test.wantCwSettings.ContextRoot)
-			assert.Equal(t, cwSettings.InternalPort, test.wantCwSettings.InternalPort)
-			assert.Equal(t, cwSettings.HealthCheck, test.wantCwSettings.HealthCheck)
-			assert.Equal(t, cwSettings.IsHTTPS, test.wantCwSettings.IsHTTPS)
-			assert.Equal(t, cwSettings.StatusPingTimeout, test.wantCwSettings.StatusPingTimeout)
-			assert.Equal(t, cwSettings.IgnoredPaths, test.mockIgnoredPaths)
+			assert.Equal(t, test.wantCwSettings.ContextRoot, cwSettings.ContextRoot)
+			assert.Equal(t, test.wantCwSettings.InternalPort, cwSettings.InternalPort)
+			assert.Equal(t, test.wantCwSettings.HealthCheck, cwSettings.HealthCheck)
+			assert.Equal(t, test.wantCwSettings.IsHTTPS, cwSettings.IsHTTPS)
+			assert.Equal(t, test.wantCwSettings.StatusPingTimeout, cwSettings.StatusPingTimeout)
+			assert.Equal(t, test.mockIgnoredPaths, cwSettings.IgnoredPaths)
 
 			if test.wantCwSettings.InternalDebugPort != nil {
-				assert.Equal(t, cwSettings.InternalDebugPort, test.wantCwSettings.InternalDebugPort)
+				assert.Equal(t, test.wantCwSettings.InternalDebugPort, cwSettings.InternalDebugPort)
 			}
 			if test.wantCwSettings.MavenProfiles != nil {
-				assert.Equal(t, cwSettings.MavenProfiles, test.wantCwSettings.MavenProfiles)
+				assert.Equal(t, test.wantCwSettings.MavenProfiles, cwSettings.MavenProfiles)
 			}
 			if test.wantCwSettings.MavenProperties != nil {
-				assert.Equal(t, cwSettings.MavenProperties, test.wantCwSettings.MavenProperties)
+				assert.Equal(t, test.wantCwSettings.MavenProperties, cwSettings.MavenProperties)
 			}
 			os.Remove(test.inProjectPath)
 		})
@@ -312,7 +312,7 @@ func TestProjectPathExists(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := checkProjectPathExists(test.path)
-			assert.Equal(t, err, test.wantError)
+			assert.Equal(t, test.wantError, err)
 		})
 	}
 }
@@ -343,7 +343,7 @@ func TestCheckProjectDirIsEmpty(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := checkProjectDirIsEmpty(test.path)
-			assert.Equal(t, err, test.wantError)
+			assert.Equal(t, test.wantError, err)
 		})
 	}
 	os.RemoveAll(testFolder)

--- a/pkg/security/keychain_test.go
+++ b/pkg/security/keychain_test.go
@@ -71,7 +71,7 @@ func Test_Keychain_Secure(t *testing.T) {
 	t.Run("Test keyring returns an error when trying to delete a non-existent secret", func(t *testing.T) {
 		err := DeleteSecretFromKeyring(testConnection, testUsername)
 		assert.NotNil(t, err)
-		assert.Equal(t, err.Op, "sec_keyring_secret_not_found")
+		assert.Equal(t, "sec_keyring_secret_not_found", err.Op)
 		assert.Contains(t, err.Desc, "not found in keyring")
 	})
 

--- a/pkg/utils/download_test.go
+++ b/pkg/utils/download_test.go
@@ -387,7 +387,7 @@ func TestIsTarGzURL(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := IsTarGzURL(test.in)
-			assert.Equal(t, got, test.want)
+			assert.Equal(t, test.want, got)
 		})
 	}
 }

--- a/pkg/utils/filesystem_test.go
+++ b/pkg/utils/filesystem_test.go
@@ -61,7 +61,7 @@ func TestCreateTempFile(t *testing.T) {
 
 		_, err = os.Stat(testPath)
 		assert.Nil(t, err)
-		assert.Equal(t, PathExists(testPath), true)
+		assert.True(t, PathExists(testPath))
 
 		os.Remove(testPath)
 	})

--- a/pkg/utils/templates_test.go
+++ b/pkg/utils/templates_test.go
@@ -47,7 +47,7 @@ func TestExtractGitCredentials_Fail(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := ExtractGitCredentials(test.inUsername, test.inPassword, test.inPersonalAccessToken)
 			assert.Nil(t, got)
-			assert.Equal(t, err.Error(), test.wantErrMsg)
+			assert.Equal(t, test.wantErrMsg, err.Error())
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [x] Test

## What does this PR do ?
I noticed that with some of our `assert.Equals` statements we have got the `expected` and `actual` arguments the wrong way round. This makes test failure messages confusing, because they will tell us that the actual error is the one we're expecting

Ref:
![image](https://user-images.githubusercontent.com/18170169/83862183-7eb47c80-a719-11ea-8039-00f12a9aff5a.png)


## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
