### PR TITLE
use specific error for github authorization error

### DIFF
--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -189,11 +189,11 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		assert.Equal(t, "{\"status\":\"success\",\"projectPath\":\"./testDir\",\"result\":{\"language\":\"unknown\",\"projectType\":\"docker\"}}\n", string(out))
 	})
 	t.Run("fail case: create GHE project using good username but bad password"+
-		"\ncwctl project create --url <secureTemplateRepo> --path <testDir> --username <goodUsername> --password <badPassword>", func(t *testing.T) {
+		"\ncwctl --json project create --url <secureTemplateRepo> --path <testDir> --username <goodUsername> --password <badPassword>", func(t *testing.T) {
 		os.RemoveAll(testDir)
 		defer os.RemoveAll(testDir)
 
-		cmd := exec.Command(cwctl, "project", "create",
+		cmd := exec.Command(cwctl, "--json", "project", "create",
 			"--url="+test.GHERepoURL,
 			"--path="+testDir,
 			"--username="+test.GHEUsername,
@@ -201,6 +201,7 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		)
 		out, err := cmd.CombinedOutput()
 		assert.NotNil(t, err)
+		assert.Contains(t, string(out), "invalid_git_credentials")
 		assert.Contains(t, string(out), "401 Unauthorized")
 	})
 }
@@ -390,7 +391,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 	})
 	t.Run("fail case: add GHE template repo and create one of its projects using bad password, overriding good stored GHE creds"+
 		"\ncwctl templates repos add --url <GHEDevfile> --username --password"+
-		"\ncwctl project create --url <GHETemplateRepo> --username <goodUsername> --password <badPassword>"+
+		"\ncwctl --json project create --url <GHETemplateRepo> --username <goodUsername> --password <badPassword>"+
 		"\ncwctl templates repos remove --url", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
@@ -408,7 +409,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Contains(t, string(out), test.GHEDevfileURL)
 
-		createCmd := exec.Command(cwctl, "project", "create",
+		createCmd := exec.Command(cwctl, "--json", "project", "create",
 			"--url="+test.GHERepoURL,
 			"--path="+testDir,
 			"--username="+test.GHEUsername,
@@ -416,6 +417,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		)
 		createOut, createErr := createCmd.CombinedOutput()
 		assert.NotNil(t, createErr)
+		assert.Contains(t, string(createOut), "invalid_git_credentials")
 		assert.Contains(t, string(createOut), "401 Unauthorized")
 
 		removeCmd := exec.Command(cwctl, "templates", "repos", "remove",
@@ -427,7 +429,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 	})
 	t.Run("fail case: add GHE template repo and create one of its projects using bad personalAccessToken, overriding good stored GHE creds"+
 		"\ncwctl templates repos add --url <GHEDevfile> --personalAccessToken <goodToken>"+
-		"\ncwctl project create --url <GHETemplateRepo> --personalAccessToken <badToken>"+
+		"\ncwctl --json project create --url <GHETemplateRepo> --personalAccessToken <badToken>"+
 		"\ncwctl templates repos remove --url", func(t *testing.T) {
 		if !test.UsingOwnGHECredentials {
 			t.Skip("skipping this test because you haven't set GitHub credentials needed for this test")
@@ -444,13 +446,14 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Contains(t, string(out), test.GHEDevfileURL)
 
-		createCmd := exec.Command(cwctl, "project", "create",
+		createCmd := exec.Command(cwctl, "--json", "project", "create",
 			"--url="+test.GHERepoURL,
 			"--path="+testDir,
 			"--personalAccessToken=badtoken",
 		)
 		createOut, createErr := createCmd.CombinedOutput()
 		assert.NotNil(t, createErr)
+		assert.Contains(t, string(createOut), "invalid_git_credentials")
 		assert.Contains(t, string(createOut), "401 Unauthorized")
 
 		removeCmd := exec.Command(cwctl, "templates", "repos", "remove",

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -72,7 +72,12 @@ func DownloadTemplate(destination, url string, gitCredentials *utils.GitCredenti
 
 	err := utils.DownloadFromURLThenExtract(url, destination, gitCredentials)
 	if err != nil {
-		return nil, &ProjectError{errOpCreateProject, err, err.Error()}
+		errOp := errOpCreateProject
+		// if 401 error, use invalid credentials error code
+		if strings.Contains(err.Error(), "401 Unauthorized") {
+			errOp = errOpInvalidCredentials
+		}
+		return nil, &ProjectError{errOp, err, err.Error()}
 	}
 
 	err = utils.ReplaceInFiles(destination, "[PROJ_NAME_PLACEHOLDER]", projectName)

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -98,8 +98,8 @@ func TestDownloadTemplate(t *testing.T) {
 		out, err := DownloadTemplate(dest, url, gitCredentials)
 
 		assert.Nil(t, out)
-		assert.Equal(t, err.Op, errOpInvalidCredentials)
-		assert.Equal(t, err.Desc, "unexpected status code: 401 Unauthorized")
+		assert.Equal(t, errOpInvalidCredentials, err.Op)
+		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
 	})
 	t.Run("fail case: download GHE template using bad personalAccessToken)", func(t *testing.T) {
 		os.RemoveAll(testDir)
@@ -115,8 +115,8 @@ func TestDownloadTemplate(t *testing.T) {
 		out, err := DownloadTemplate(dest, url, gitCredentials)
 
 		assert.Nil(t, out)
-		assert.Equal(t, err.Op, errOpInvalidCredentials)
-		assert.Equal(t, err.Desc, "unexpected status code: 401 Unauthorized")
+		assert.Equal(t, errOpInvalidCredentials, err.Op)
+		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
 	})
 }
 

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -98,7 +98,8 @@ func TestDownloadTemplate(t *testing.T) {
 		out, err := DownloadTemplate(dest, url, gitCredentials)
 
 		assert.Nil(t, out)
-		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
+		assert.Equal(t, err.Op, errOpInvalidCredentials)
+		assert.Equal(t, err.Desc, "unexpected status code: 401 Unauthorized")
 	})
 	t.Run("fail case: download GHE template using bad personalAccessToken)", func(t *testing.T) {
 		os.RemoveAll(testDir)
@@ -114,7 +115,8 @@ func TestDownloadTemplate(t *testing.T) {
 		out, err := DownloadTemplate(dest, url, gitCredentials)
 
 		assert.Nil(t, out)
-		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
+		assert.Equal(t, err.Op, errOpInvalidCredentials)
+		assert.Equal(t, err.Desc, "unexpected status code: 401 Unauthorized")
 	})
 }
 

--- a/pkg/project/project_utils.go
+++ b/pkg/project/project_utils.go
@@ -46,6 +46,7 @@ const (
 	errOpSync            = "proj_sync"
 	errOpSyncRef         = "proj_sync_ref"
 	errOpWriteCwSettings = "proj_write_cw_settings"
+	errOpInvalidCredentials = "invalid_git_credentials"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Uses a specific error key (`invalid_git_credentials`) for whenever the Github API returns a `401 unauthorized` error, when creating a project.

Example: 

```
cwctl --json project create 
	-u https://github.ibm.com/James-Cockbain/git-basics 
	-p ~/documents/workspace/jam 
	--personalAccessToken no-token

{"error":"invalid_git_credentials","error_description":"unexpected status code: 401 Unauthorized"}
exit status 1
```
Modifies main tests to check for this error code in its existing bad password and access token tests.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3100

## Does this PR require a documentation change ?

No

## Any special notes for your reviewer ?

Modified tests require GHE credentials to be added in https://github.com/eclipse/codewind-installer/blob/master/pkg/test/globals.go.
