### PR TITLE
Add project name to project link list output

### DIFF
--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -291,9 +291,9 @@ func ProjectLinkList(c *cli.Context) {
 		} else {
 			w := new(tabwriter.Writer)
 			w.Init(os.Stdout, 0, 8, 2, '\t', 0)
-			fmt.Fprintln(w, "PROJECT NAME \tENVIRONMENT VARIABLE")
+			fmt.Fprintln(w, "TARGET PROJECT \tENVIRONMENT VARIABLE \t TARGET URL")
 			for _, project := range links {
-				fmt.Fprintln(w, project.ProjectName+"\t"+project.EnvName)
+				fmt.Fprintln(w, project.ProjectName+"\t"+project.EnvName+"\t"+project.ProjectURL)
 			}
 			fmt.Fprintln(w)
 			w.Flush()

--- a/pkg/actions/project.go
+++ b/pkg/actions/project.go
@@ -291,9 +291,9 @@ func ProjectLinkList(c *cli.Context) {
 		} else {
 			w := new(tabwriter.Writer)
 			w.Init(os.Stdout, 0, 8, 2, '\t', 0)
-			fmt.Fprintln(w, "ENVIRONMENT VARIABLE \tPROJECT ID")
+			fmt.Fprintln(w, "PROJECT NAME \tENVIRONMENT VARIABLE")
 			for _, project := range links {
-				fmt.Fprintln(w, project.EnvName+"\t"+project.ProjectID)
+				fmt.Fprintln(w, project.ProjectName+"\t"+project.EnvName)
 			}
 			fmt.Fprintln(w)
 			w.Flush()

--- a/pkg/project/link.go
+++ b/pkg/project/link.go
@@ -26,9 +26,10 @@ import (
 type (
 	// Link : The structure of a Link object returned from PFE
 	Link struct {
-		ProjectID  string `json:"projectID"`
-		EnvName    string `json:"envName"`
-		ProjectURL string `json:"projectURL"`
+		ProjectID   string `json:"projectID"`
+		ProjectName string `json:"projectName"`
+		EnvName     string `json:"envName"`
+		ProjectURL  string `json:"projectURL"`
 	}
 	// LinkParameters : The request structure to create a link
 	LinkParameters struct {

--- a/pkg/project/link_test.go
+++ b/pkg/project/link_test.go
@@ -33,8 +33,8 @@ func TestGetProjectLinks(t *testing.T) {
 	t.Run("Expect success - project links should be returned", func(t *testing.T) {
 		// construct mock response body and status code
 		links := []Link{
-			Link{ProjectID: "1234", ProjectURL: "URL1", EnvName: "ENV1"},
-			Link{ProjectID: "9999", ProjectURL: "URL2", EnvName: "ENV2"},
+			Link{ProjectID: "1234", ProjectName: "name1", ProjectURL: "URL1", EnvName: "ENV1"},
+			Link{ProjectID: "9999", ProjectName: "name2", ProjectURL: "URL2", EnvName: "ENV2"},
 		}
 		jsonResponse, _ := json.Marshal(links)
 		body := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds the project name into the response for `cwctl project link list --id`.
JSON output:
```
❯ cwctl --json project link list --id 7961a260-a4e1-11ea-8609-af62c8d34aa0
[{"projectID":"e07d2ef0-a0fa-11ea-8c83-95e049ef26c8","projectName":"webby","envName":"DA","projectURL":"cw-webby-e07d2ef0-a0fa-11ea-8c83-95e049ef26c8:9080"}]
```

Human readable output:
```
❯ cwctl project link list --id 7961a260-a4e1-11ea-8609-af62c8d34aa0
PROJECT NAME 	ENVIRONMENT VARIABLE
webby		DA
```

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
