### PR TITLE
TemplateRepo Auth pointer

### DIFF
--- a/pkg/utils/templates.go
+++ b/pkg/utils/templates.go
@@ -16,14 +16,14 @@ import "fmt"
 type (
 	// TemplateRepo represents a template repository.
 	TemplateRepo struct {
-		Description    string         `json:"description"`
-		URL            string         `json:"url"`
-		Name           string         `json:"name"`
-		ID             string         `json:"id"`
-		Enabled        bool           `json:"enabled"`
-		Protected      bool           `json:"protected"`
-		ProjectStyles  []string       `json:"projectStyles"`
-		Authentication Authentication `json:"authentication,omitempty"`
+		Description    string          `json:"description"`
+		URL            string          `json:"url"`
+		Name           string          `json:"name"`
+		ID             string          `json:"id"`
+		Enabled        bool            `json:"enabled"`
+		Protected      bool            `json:"protected"`
+		ProjectStyles  []string        `json:"projectStyles"`
+		Authentication *Authentication `json:"authentication,omitempty"`
 	}
 	// Authentication represents a template respository's authentication.
 	Authentication struct {


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Change the type of Authentication in the TemplateRepo object to be a pointer. This enables omitempty to properly hide the field when it is not returned from PFE

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3101
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
None