### PR TITLE
fix: project create from secure targz URLs

### DIFF
--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -79,7 +79,6 @@ func DownloadFromTarGzURL(URL *url.URL, destination string, gitCredentials *GitC
 func getURLToDownloadReleaseAsset(URL *url.URL, gitCredentials *GitCredentials) (*url.URL, error) {
 	URLPathSlice := strings.Split(URL.Path, "/")
 
-	var httpClient = &http.Client{}
 
 	if !strings.Contains(URL.Host, "github") || len(URLPathSlice) < 6 {
 		return nil, fmt.Errorf("URL must point to a GitHub repository release asset: %v", URL)
@@ -115,7 +114,7 @@ func getURLToDownloadReleaseAsset(URL *url.URL, gitCredentials *GitCredentials) 
 		owner,
 		repo,
 		assetID,
-		httpClient,
+		nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("Repositories.DownloadReleaseAsset returned error: %v", err)


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?
Fixes a bug introduced in https://github.com/eclipse/codewind-installer/pull/492. While migrating from `dep` to `mod`, we bumped our version of `go-github`, which [changed an API we use](https://github.com/google/go-github/issues/1378). In 492 we patched our use of the API, but in doing so accidentally broke project create - specifically downloading targz release assets from GHE.

The build didn't break because they don't run our GHE tests

This PR fixes the patch by ensuring we always return a `redirectURL`, which is what our current logic expects. We are set up to use our authorized GH client to download from the `redirectURL`.

## Which issue(s) does this PR fix ?
None, I found this bug

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
Interestingly, they changed the API partly because we contributed a similar feature to another one of their APIs: https://github.com/google/go-github/issues/1378#issuecomment-574921904 - 
![image](https://user-images.githubusercontent.com/18170169/84896065-3000ce00-b09b-11ea-831b-0521e0188d7e.png)
