### PR TITLE
Remove hardcoded ignore list

### DIFF
--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -344,59 +344,13 @@ func retrieveRefPathsList(projectPath string) []refPath {
 }
 
 func ignoreFileOrDirectory(name string, isDir bool, cwSettingsIgnoredPathsList []string) bool {
-	// List of files that will not be sent to PFE
-	ignoredFiles := []string{
-		".DS_Store",
-		"*.swp",
-		"*.swx",
-		"Jenkinsfile",
-		".cfignore",
-		"localm2cache.zip",
-		"libertyrepocache.zip",
-		"run-dev",
-		"run-debug",
-		"manifest.yml",
-		"idt.js",
-		".bluemix",
-		".build-ubuntu",
-		".yo-rc.json",
-		"*.iml",
-		".project",
-		".classpath",
-		".options",
-	}
-
-	// List of directories that will not be sent to PFE
-	ignoredDirectories := []string{
-		".project",
-		"node_modules*",
-		".git*",
-		"load-test*",
-		".settings",
-		"Dockerfile-tools",
-		"target",
-		"mc-target",
-		".m2",
-		"debian",
-		".bluemix",
-		"terraform",
-		".build-ubuntu",
-		".idea",
-		".vscode",
-	}
-
-	ignoredList := ignoredFiles
-	if isDir {
-		ignoredList = ignoredDirectories
-	}
-
-	if len(cwSettingsIgnoredPathsList) > 0 {
-		ignoredList = append(ignoredList, cwSettingsIgnoredPathsList...)
-	}
-
 	isFileInIgnoredList := false
-	for _, fileName := range ignoredList {
+	for _, fileName := range cwSettingsIgnoredPathsList {
 		fileName = filepath.Clean(fileName)
+		// remove preceding slash from older versions of cw-settings
+		if strings.HasPrefix(fileName, "/") {
+			fileName = string([]rune(fileName)[1:])
+		}
 		matched, err := filepath.Match(fileName, name)
 		if err != nil {
 			return false

--- a/pkg/project/sync_test.go
+++ b/pkg/project/sync_test.go
@@ -76,17 +76,17 @@ func TestIgnoreFileOrDirectory(t *testing.T) {
 		shouldBeIgnored  bool
 		ignoredPathsList []string
 	}{
-		"success case: directory called node_modules should be ignored": {
+		"success case: directory called node_modules should be ignored as it is in .cw-settings": {
 			name:             "node_modules",
 			isDir:            true,
 			shouldBeIgnored:  true,
-			ignoredPathsList: []string{},
+			ignoredPathsList: []string{"node_modules*"},
 		},
-		"success case: directory called load-test-23498729 should be ignored": {
+		"success case: directory called load-test-23498729 should be ignored as it is in .cw-settings": {
 			name:             "load-test-23498729",
 			isDir:            true,
 			shouldBeIgnored:  true,
-			ignoredPathsList: []string{},
+			ignoredPathsList: []string{"load-test*"},
 		},
 		"success case: directory called not-a-load-test-23498729 should not be ignored": {
 			name:             "not-a-load-test-23498729",
@@ -100,17 +100,17 @@ func TestIgnoreFileOrDirectory(t *testing.T) {
 			shouldBeIgnored:  false,
 			ignoredPathsList: []string{},
 		},
-		"success case: file called .DS_Store should be ignored": {
+		"success case: file called .DS_Store should be ignored as it is in .cw-settings": {
 			name:             ".DS_Store",
 			isDir:            false,
 			shouldBeIgnored:  true,
-			ignoredPathsList: []string{},
+			ignoredPathsList: []string{".DS_Store"},
 		},
-		"success case: file called something.swp should be ignored": {
+		"success case: file called something.swp should be ignored as it is in .cw-settings": {
 			name:             "something.swp",
 			isDir:            false,
 			shouldBeIgnored:  true,
-			ignoredPathsList: []string{},
+			ignoredPathsList: []string{"*.swp"},
 		},
 		"success case: file called something.swpnot should not be ignored": {
 			name:             "something.swpnot",
@@ -136,17 +136,17 @@ func TestIgnoreFileOrDirectory(t *testing.T) {
 			shouldBeIgnored:  true,
 			ignoredPathsList: []string{"noddy_modules"},
 		},
-		"success case: file called file.iml should be ignored (IntelliJ metadata file, *.iml)": {
+		"success case: file called file.iml should be ignored (IntelliJ metadata file, *.iml) as it is in .cw-settings": {
 			name:             "file.iml",
 			isDir:            false,
 			shouldBeIgnored:  true,
-			ignoredPathsList: []string{},
+			ignoredPathsList: []string{"*.iml"},
 		},
 		"success case: path containing .idea should be ignored (IntelliJ metadata directory, .idea)": {
 			name:             ".idea",
 			isDir:            true,
 			shouldBeIgnored:  true,
-			ignoredPathsList: []string{},
+			ignoredPathsList: []string{".idea"},
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Removes the hard coded list of files to ignore when syncing projects. Ignore list is now only built from the files listed in cw-settings.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3138
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
None