### PR TITLE
fix: fix project file mode on windows

### DIFF
--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -471,9 +472,13 @@ func syncFile(client utils.HTTPClient, projectID string, projectPath string, pat
 		return uploadResponse
 	}
 
+	mode := uint(fileStat.Mode().Perm())
+	if runtime.GOOS == "windows" {
+    mode = 775
+	}
 	fileUploadBody := FileUploadMsg{
 		IsDirectory:  fileStat.IsDir(),
-		Mode:         uint(fileStat.Mode().Perm()),
+		Mode:         mode,
 		RelativePath: relativePath,
 		Message:      "",
 	}

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -474,7 +474,7 @@ func syncFile(client utils.HTTPClient, projectID string, projectPath string, pat
 
 	mode := uint(fileStat.Mode().Perm())
 	if runtime.GOOS == "windows" {
-		mode = 509
+		mode = 0775
 	}
 	fileUploadBody := FileUploadMsg{
 		IsDirectory:  fileStat.IsDir(),

--- a/pkg/project/sync.go
+++ b/pkg/project/sync.go
@@ -474,7 +474,7 @@ func syncFile(client utils.HTTPClient, projectID string, projectPath string, pat
 
 	mode := uint(fileStat.Mode().Perm())
 	if runtime.GOOS == "windows" {
-    mode = 775
+		mode = 509
 	}
 	fileUploadBody := FileUploadMsg{
 		IsDirectory:  fileStat.IsDir(),


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
_fixes https://github.com/eclipse/codewind/issues/2713 by ensuring that project files on Windows are uploaded with the required permissions (775). Previously project files on Windows were uploaded with the wrong permissions, and we cannot detect the correct permissions accurately with Go on Windows https://github.com/eclipse/codewind/issues/2713#issuecomment-625263695

I tested that this works by verifying that setting the file mode in cwctl to be 509 indeed results in the file mode in PFE `codewind-workspace` to be 775 (octal representation of 509).

## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
