### PR TITLE
Project Link - output original error from PFE if available

### DIFF
--- a/pkg/project/link_test.go
+++ b/pkg/project/link_test.go
@@ -30,14 +30,15 @@ var errConflict = errors.New(textProjectLinkConflict)
 var errUnknownHTTPCode = errors.New(textUnknownResponseCode)
 
 var projectLinkCreateUpdateDeleteTests = []struct {
+	name       string
 	statusCode int
 	want       *ProjectError
 }{
-	{statusCode: http.StatusAccepted, want: nil},
-	{statusCode: http.StatusBadRequest, want: &ProjectError{errOpResponse, errInvalidRequest, errInvalidRequest.Error()}},
-	{statusCode: http.StatusNotFound, want: &ProjectError{errOpResponse, errUnknownNotFound, errUnknownNotFound.Error()}},
-	{statusCode: http.StatusConflict, want: &ProjectError{errOpResponse, errConflict, errConflict.Error()}},
-	{statusCode: http.StatusPermanentRedirect, want: &ProjectError{errOpResponse, errUnknownHTTPCode, errUnknownHTTPCode.Error()}},
+	{name: "Expect success - request should be accepted", statusCode: http.StatusAccepted, want: nil},
+	{name: "Expect failure - rejected with 400", statusCode: http.StatusBadRequest, want: &ProjectError{errOpResponse, errInvalidRequest, errInvalidRequest.Error()}},
+	{name: "Expect failure - rejected with 404", statusCode: http.StatusNotFound, want: &ProjectError{errOpResponse, errUnknownNotFound, errUnknownNotFound.Error()}},
+	{name: "Expect failure - rejected with 409", statusCode: http.StatusConflict, want: &ProjectError{errOpResponse, errConflict, errConflict.Error()}},
+	{name: "Expect failure - rejected with unknown http code", statusCode: http.StatusPermanentRedirect, want: &ProjectError{errOpResponse, errUnknownHTTPCode, errUnknownHTTPCode.Error()}},
 }
 
 func TestGetProjectLinks(t *testing.T) {
@@ -72,30 +73,36 @@ func TestGetProjectLinks(t *testing.T) {
 
 func TestCreateProjectLinks(t *testing.T) {
 	for _, tt := range projectLinkCreateUpdateDeleteTests {
-		emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
-		mockClient := &security.ClientMockAuthenticate{StatusCode: tt.statusCode, Body: emptyBody}
-		mockConnection := connections.Connection{ID: "local"}
-		got := CreateProjectLink(mockClient, &mockConnection, "dummyurl", "dummyProjectID", "dummyTargetProjectID", "dummyEnvName")
-		assert.Equal(t, tt.want, got)
+		t.Run(tt.name, func(t *testing.T) {
+			emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
+			mockClient := &security.ClientMockAuthenticate{StatusCode: tt.statusCode, Body: emptyBody}
+			mockConnection := connections.Connection{ID: "local"}
+			got := CreateProjectLink(mockClient, &mockConnection, "dummyurl", "dummyProjectID", "dummyTargetProjectID", "dummyEnvName")
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 
 func TestUpdateProjectLinks(t *testing.T) {
 	for _, tt := range projectLinkCreateUpdateDeleteTests {
-		emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
-		mockClient := &security.ClientMockAuthenticate{StatusCode: tt.statusCode, Body: emptyBody}
-		mockConnection := connections.Connection{ID: "local"}
-		got := UpdateProjectLink(mockClient, &mockConnection, "dummyurl", "dummyProjectID", "dummyEnvName", "dummyUpdatedEnvName")
-		assert.Equal(t, tt.want, got)
+		t.Run(tt.name, func(t *testing.T) {
+			emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
+			mockClient := &security.ClientMockAuthenticate{StatusCode: tt.statusCode, Body: emptyBody}
+			mockConnection := connections.Connection{ID: "local"}
+			got := UpdateProjectLink(mockClient, &mockConnection, "dummyurl", "dummyProjectID", "dummyEnvName", "dummyUpdatedEnvName")
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 
 func TestDeleteProjectLinks(t *testing.T) {
 	for _, tt := range projectLinkCreateUpdateDeleteTests {
-		emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
-		mockClient := &security.ClientMockAuthenticate{StatusCode: tt.statusCode, Body: emptyBody}
-		mockConnection := connections.Connection{ID: "local"}
-		got := DeleteProjectLink(mockClient, &mockConnection, "dummyurl", "dummyProjectID", "dummyEnvName")
-		assert.Equal(t, tt.want, got)
+		t.Run(tt.name, func(t *testing.T) {
+			emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
+			mockClient := &security.ClientMockAuthenticate{StatusCode: tt.statusCode, Body: emptyBody}
+			mockConnection := connections.Connection{ID: "local"}
+			got := DeleteProjectLink(mockClient, &mockConnection, "dummyurl", "dummyProjectID", "dummyEnvName")
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }

--- a/pkg/project/project_utils.go
+++ b/pkg/project/project_utils.go
@@ -26,46 +26,46 @@ type (
 )
 
 const (
-	errBadPath           = "proj_path" // Invalid path provided
-	errBadType           = "proj_type" // Invalid type provided
-	errOpBind            = "proj_bind"
-	errOpRequest         = "proj_request"
-	errOpResponse        = "proj_response" // Bad response to http
-	errOpFileParse       = "proj_parse"
-	errOpFileLoad        = "proj_load"
-	errOpFileWrite       = "proj_write"
-	errOpFileDelete      = "proj_delete"
-	errOpUnbind          = "proj_unbind"
-	errOpGetProject      = "proj_get"
-	errOpCreateProject   = "project create"
-	errOpConflict        = "proj_conflict"
-	errOpNotFound        = "proj_notfound"
-	errOpConNotFound     = "connection_notfound"
-	errOpInvalidID       = "proj_id_invalid"
-	errOpInvalidOptions  = "proj_options_invalid"
-	errOpSync            = "proj_sync"
-	errOpSyncRef         = "proj_sync_ref"
-	errOpWriteCwSettings = "proj_write_cw_settings"
+	errBadPath              = "proj_path" // Invalid path provided
+	errBadType              = "proj_type" // Invalid type provided
+	errOpBind               = "proj_bind"
+	errOpRequest            = "proj_request"
+	errOpResponse           = "proj_response" // Bad response to http
+	errOpFileParse          = "proj_parse"
+	errOpFileLoad           = "proj_load"
+	errOpFileWrite          = "proj_write"
+	errOpFileDelete         = "proj_delete"
+	errOpUnbind             = "proj_unbind"
+	errOpGetProject         = "proj_get"
+	errOpCreateProject      = "project create"
+	errOpConflict           = "proj_conflict"
+	errOpNotFound           = "proj_notfound"
+	errOpConNotFound        = "connection_notfound"
+	errOpInvalidID          = "proj_id_invalid"
+	errOpInvalidOptions     = "proj_options_invalid"
+	errOpSync               = "proj_sync"
+	errOpSyncRef            = "proj_sync_ref"
+	errOpWriteCwSettings    = "proj_write_cw_settings"
 	errOpInvalidCredentials = "invalid_git_credentials"
 )
 
 const (
-	textDupName                   = "project name is already in use"
-	textInvalidType               = "project type is invalid"
-	textInvalidProjectID          = "project ID is invalid"
-	textConnectionExists          = "project already added to this connection"
-	textConMissing                = "project connection not found"
-	textNoCodewind                = "unable to connect to Codewind server"
-	textAPINotFound               = "unable to find requested resource on Codewind server"
-	textNoProjects                = "unable to find any codewind projects"
-	textUpgradeError              = "error occurred upgrading projects"
-	textNoProjectPath             = "project path not given"
-	textProjectPathDoesNotExist   = "given project path does not exist"
-	textProjectPathNonEmpty       = "Non empty directory provided"
-	textUnknownResponseCode       = "unknown response code returned from Codewind server"
-	textProjectLinkTargetNotFound = "target project not found on Codewind server"
-	textProjectLinkConflict       = "project link env is already in use"
-	textInvalidRequest            = "request parameters are invalid"
+	textDupName                    = "project name is already in use"
+	textInvalidType                = "project type is invalid"
+	textInvalidProjectID           = "project ID is invalid"
+	textConnectionExists           = "project already added to this connection"
+	textConMissing                 = "project connection not found"
+	textNoCodewind                 = "unable to connect to Codewind server"
+	textAPINotFound                = "unable to find requested resource on Codewind server"
+	textNoProjects                 = "unable to find any codewind projects"
+	textUpgradeError               = "error occurred upgrading projects"
+	textNoProjectPath              = "project path not given"
+	textProjectPathDoesNotExist    = "given project path does not exist"
+	textProjectPathNonEmpty        = "Non empty directory provided"
+	textUnknownResponseCode        = "unknown response code returned from Codewind server"
+	textProjectLinkUnknownNotFound = "unknown 404 returned from Codewind server"
+	textProjectLinkConflict        = "project link env is already in use"
+	textInvalidRequest             = "request parameters are invalid"
 )
 
 // ProjectError : Error formatted in JSON containing an errorOp and a description from


### PR DESCRIPTION
**NOTE: Should follow the PFE PR for the same issue**

Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Changes the error handling for Project linking to output the original error from PFE when it is available + in a known format.
Refactor link tests to make them more manageable. 

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/3149

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
