### PR TITLE
Add local docker error to returned registry list on registry add.

### DIFF
--- a/pkg/apiroutes/registrysecrets.go
+++ b/pkg/apiroutes/registrysecrets.go
@@ -27,8 +27,9 @@ import (
 type (
 	// RegistryResponse : The registry information
 	RegistryResponse struct {
-		Address  string `json:"address"`
-		Username string `json:"username"`
+		Address          string `json:"address"`
+		Username         string `json:"username"`
+		LocalDockerError string `json:"localDockerError,omitempty"`
 	}
 
 	// RegistryParameters : The request structure to set the log level


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?

This PR adds a field to a registry entry returned in the registries list when a registry secret is added that contains any error message returned from the local docker login command run to log the user into that registry on their local machine. 
This allows us to determine if the local login to the registry failed even though the remote one succeeded. This is useful when working with a registry that isn't publically visible, for example the internal open shift registry, which the PFE container will be able to log into but the local machine won't.

Example output:
```
[hhellyer@Howards-MacBook-Pro:codewind-installer]$ ./cwctl rs add -a myregistry:9191 -u howard -p notapassword
[
	{
		"address": "localhost:9093",
		"username": "hhellyer"
	},
	{
		"address": "localhost:9092",
		"username": "me"
	},
	{
		"address": "myregistry:9191",
		"username": "howard",
		"localDockerError": "Docker login to myregistry:9191 as howard failed. Address, username or password is incorrect"
	}
]
```

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2961

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2961

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
