### PR TITLE
[0.14.0] Retrieve default branch from github API.

### DIFF
--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -14,6 +14,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"testing"
@@ -202,7 +203,7 @@ func testCreateProjectFromTemplate(t *testing.T) {
 		out, err := cmd.CombinedOutput()
 		assert.NotNil(t, err)
 		assert.Contains(t, string(out), "invalid_git_credentials")
-		assert.Contains(t, string(out), "401 Unauthorized")
+		assert.Contains(t, string(out), http.StatusText(http.StatusUnauthorized))
 	})
 }
 
@@ -418,7 +419,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		createOut, createErr := createCmd.CombinedOutput()
 		assert.NotNil(t, createErr)
 		assert.Contains(t, string(createOut), "invalid_git_credentials")
-		assert.Contains(t, string(createOut), "401 Unauthorized")
+		assert.Contains(t, string(createOut), http.StatusText(http.StatusUnauthorized))
 
 		removeCmd := exec.Command(cwctl, "templates", "repos", "remove",
 			"--url="+test.GHEDevfileURL,
@@ -454,7 +455,7 @@ func testSuccessfulAddAndRemoveTemplateRepos(t *testing.T) {
 		createOut, createErr := createCmd.CombinedOutput()
 		assert.NotNil(t, createErr)
 		assert.Contains(t, string(createOut), "invalid_git_credentials")
-		assert.Contains(t, string(createOut), "401 Unauthorized")
+		assert.Contains(t, string(createOut), http.StatusText(http.StatusUnauthorized))
 
 		removeCmd := exec.Command(cwctl, "templates", "repos", "remove",
 			"--url="+test.GHEDevfileURL,

--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -74,7 +74,7 @@ func DownloadTemplate(destination, url string, gitCredentials *utils.GitCredenti
 	if err != nil {
 		errOp := errOpCreateProject
 		// if 401 error, use invalid credentials error code
-		if strings.Contains(err.Error(), "401 Unauthorized") {
+		if err.Error() == http.StatusText(http.StatusUnauthorized) {
 			errOp = errOpInvalidCredentials
 		}
 		return nil, &ProjectError{errOp, err, err.Error()}

--- a/pkg/project/create_test.go
+++ b/pkg/project/create_test.go
@@ -99,7 +99,7 @@ func TestDownloadTemplate(t *testing.T) {
 
 		assert.Nil(t, out)
 		assert.Equal(t, errOpInvalidCredentials, err.Op)
-		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
+		assert.Equal(t, http.StatusText(http.StatusUnauthorized), err.Desc)
 	})
 	t.Run("fail case: download GHE template using bad personalAccessToken)", func(t *testing.T) {
 		os.RemoveAll(testDir)
@@ -116,7 +116,7 @@ func TestDownloadTemplate(t *testing.T) {
 
 		assert.Nil(t, out)
 		assert.Equal(t, errOpInvalidCredentials, err.Op)
-		assert.Equal(t, "unexpected status code: 401 Unauthorized", err.Desc)
+		assert.Equal(t, http.StatusText(http.StatusUnauthorized), err.Desc)
 	})
 }
 

--- a/pkg/utils/download_test.go
+++ b/pkg/utils/download_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -136,7 +137,7 @@ func TestDownloadFromURLThenExtract(t *testing.T) {
 			inDestination:    filepath.Join(testDir, "failCase"),
 			inGitCredentials: &GitCredentials{Username: test.GHEUsername, Password: "bad password"},
 			wantedType:       errors.New(""),
-			wantedErrMsg:     "401 Unauthorized",
+			wantedErrMsg:     http.StatusText(http.StatusUnauthorized),
 			wantedNumFiles:   0,
 		},
 		"fail case: input good GHE tar.gz URL and credentials but no matching repo found": {


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Removes the assumption that a repositories default branch is `master` and replaces it with a query via the github API to find the default branch name. See: https://developer.github.com/v3/repos/#get-a-repository (We use the github API written in Go to access this.)

I've tested this by running:
`cwctl --insecure project create --conid KB9FJ0QO --p ~/work/codewind/codewind-workspace/odo-java --url https://codeload.github.com/spring-projects/spring-petclinic`
and it is now possible to create a Codewind project from that github repository.

## Which issue(s) does this PR fix ?
This resolves being unable to create a project from the ODO Java template. This was caused by the project renaming it's default branch from `master` to `main`.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3197

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?

This is a port of the same changes merged into master under https://github.com/eclipse/codewind-installer/pull/504